### PR TITLE
Expose progress of animated insets

### DIFF
--- a/insets/api/insets.api
+++ b/insets/api/insets.api
@@ -1,7 +1,7 @@
 public final class com/google/accompanist/insets/ComposeInsets {
 	public static final fun ProvideWindowInsets (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ProvideWindowInsets (ZZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun coerceEachDimensionAtLeast (Lcom/google/accompanist/insets/Insets;Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
+	public static final fun coerceEachDimensionAtLeast (Lcom/google/accompanist/insets/InsetsType;Lcom/google/accompanist/insets/InsetsType;)Lcom/google/accompanist/insets/Insets;
 	public static final fun getLocalWindowInsets ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun imePadding (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
 	public static final fun navigationBarsHeight-3ABfNKs (Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;
@@ -16,8 +16,8 @@ public final class com/google/accompanist/insets/ComposeInsets {
 	public static final fun statusBarsPadding (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
 	public static final fun systemBarsPadding (Landroidx/compose/ui/Modifier;Z)Landroidx/compose/ui/Modifier;
 	public static synthetic fun systemBarsPadding$default (Landroidx/compose/ui/Modifier;ZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
-	public static final fun toPaddingValues-nbWgWpA (Lcom/google/accompanist/insets/Insets;ZZZZFFLandroidx/compose/runtime/Composer;II)Landroidx/compose/foundation/layout/PaddingValues;
-	public static final fun toPaddingValues-s2pLCVw (Lcom/google/accompanist/insets/Insets;ZZZZFFFFLandroidx/compose/runtime/Composer;II)Landroidx/compose/foundation/layout/PaddingValues;
+	public static final fun toPaddingValues-nbWgWpA (Lcom/google/accompanist/insets/InsetsType;ZZZZFFLandroidx/compose/runtime/Composer;II)Landroidx/compose/foundation/layout/PaddingValues;
+	public static final fun toPaddingValues-s2pLCVw (Lcom/google/accompanist/insets/InsetsType;ZZZZFFFFLandroidx/compose/runtime/Composer;II)Landroidx/compose/foundation/layout/PaddingValues;
 }
 
 public abstract interface annotation class com/google/accompanist/insets/ExperimentalAnimatedInsets : java/lang/annotation/Annotation {
@@ -43,17 +43,37 @@ public final class com/google/accompanist/insets/ImeNestedScrollConnectionKt {
 	public static final fun rememberImeNestedScrollConnection (ZZLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/input/nestedscroll/NestedScrollConnection;
 }
 
-public final class com/google/accompanist/insets/Insets {
+public abstract interface class com/google/accompanist/insets/Insets {
+	public abstract fun copy (IIII)Lcom/google/accompanist/insets/Insets;
+	public abstract fun getBottom ()I
+	public abstract fun getLeft ()I
+	public abstract fun getRight ()I
+	public abstract fun getTop ()I
+	public abstract fun minus (Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
+	public abstract fun plus (Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
+}
+
+public final class com/google/accompanist/insets/Insets$DefaultImpls {
+	public static fun copy (Lcom/google/accompanist/insets/Insets;IIII)Lcom/google/accompanist/insets/Insets;
+	public static synthetic fun copy$default (Lcom/google/accompanist/insets/Insets;IIIIILjava/lang/Object;)Lcom/google/accompanist/insets/Insets;
+	public static fun minus (Lcom/google/accompanist/insets/Insets;Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
+	public static fun plus (Lcom/google/accompanist/insets/Insets;Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
+}
+
+public final class com/google/accompanist/insets/InsetsType : com/google/accompanist/insets/Insets {
 	public fun <init> ()V
-	public final fun copy (IIIIZ)Lcom/google/accompanist/insets/Insets;
-	public static synthetic fun copy$default (Lcom/google/accompanist/insets/Insets;IIIIZILjava/lang/Object;)Lcom/google/accompanist/insets/Insets;
-	public final fun getBottom ()I
-	public final fun getLeft ()I
-	public final fun getRight ()I
-	public final fun getTop ()I
+	public fun copy (IIII)Lcom/google/accompanist/insets/Insets;
+	public final fun getAnimatedInsets ()Lcom/google/accompanist/insets/Insets;
+	public final fun getAnimationFraction ()F
+	public final fun getAnimationInProgress ()Z
+	public fun getBottom ()I
+	public final fun getLayoutInsets ()Lcom/google/accompanist/insets/Insets;
+	public fun getLeft ()I
+	public fun getRight ()I
+	public fun getTop ()I
 	public final fun isVisible ()Z
-	public final fun minus (Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
-	public final fun plus (Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
+	public fun minus (Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
+	public fun plus (Lcom/google/accompanist/insets/Insets;)Lcom/google/accompanist/insets/Insets;
 }
 
 public final class com/google/accompanist/insets/VerticalSide : java/lang/Enum {
@@ -76,10 +96,10 @@ public final class com/google/accompanist/insets/ViewWindowInsetObserver {
 
 public final class com/google/accompanist/insets/WindowInsets {
 	public fun <init> ()V
-	public final fun getIme ()Lcom/google/accompanist/insets/Insets;
-	public final fun getNavigationBars ()Lcom/google/accompanist/insets/Insets;
-	public final fun getStatusBars ()Lcom/google/accompanist/insets/Insets;
-	public final fun getSystemBars ()Lcom/google/accompanist/insets/Insets;
-	public final fun getSystemGestures ()Lcom/google/accompanist/insets/Insets;
+	public final fun getIme ()Lcom/google/accompanist/insets/InsetsType;
+	public final fun getNavigationBars ()Lcom/google/accompanist/insets/InsetsType;
+	public final fun getStatusBars ()Lcom/google/accompanist/insets/InsetsType;
+	public final fun getSystemBars ()Lcom/google/accompanist/insets/InsetsType;
+	public final fun getSystemGestures ()Lcom/google/accompanist/insets/InsetsType;
 }
 

--- a/insets/src/androidTest/java/com/google/accompanist/insets/InsetsAssertions.kt
+++ b/insets/src/androidTest/java/com/google/accompanist/insets/InsetsAssertions.kt
@@ -18,7 +18,7 @@ package com.google.accompanist.insets
 
 import android.graphics.Rect
 import androidx.core.view.WindowInsetsCompat
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 
 internal fun WindowInsets.assertEqualTo(insets: androidx.core.view.WindowInsetsCompat) {
     systemBars.assertEqualTo(
@@ -42,10 +42,10 @@ internal fun WindowInsets.assertEqualTo(insets: androidx.core.view.WindowInsetsC
     )
 }
 
-internal fun Insets.assertEqualTo(insets: androidx.core.graphics.Insets, visible: Boolean) {
+internal fun InsetsType.assertEqualTo(insets: androidx.core.graphics.Insets, visible: Boolean) {
     // This might look a bit weird, why are we using a Rect? Well, it makes the assertion
     // error message much easier to read, by containing all of the dimensions.
-    Truth.assertThat(Rect(left, top, right, bottom))
+    assertThat(Rect(left, top, right, bottom))
         .isEqualTo(Rect(insets.left, insets.top, insets.right, insets.bottom))
-    Truth.assertThat(this.isVisible).isEqualTo(visible)
+    assertThat(isVisible).isEqualTo(visible)
 }

--- a/insets/src/main/java/com/google/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/com/google/accompanist/insets/Insets.kt
@@ -71,7 +71,7 @@ class WindowInsets {
 }
 
 /**
- * Represents the values for a type of insets, and stored information about the layout insets,
+ * Represents the values for a type of insets, and stores information about the layout insets,
  * animating insets, and visibility of the insets.
  *
  * [InsetsType] instances are commonly stored in a [WindowInsets] instance.

--- a/insets/src/main/java/com/google/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/com/google/accompanist/insets/Insets.kt
@@ -79,7 +79,7 @@ class WindowInsets {
 @Stable
 @Suppress("MemberVisibilityCanBePrivate")
 class InsetsType : Insets {
-    private var ongoingAnimations by mutableStateOf(0)
+    private var ongoingAnimationsCount by mutableStateOf(0)
     internal val _layoutInsets = MutableInsets()
     internal val _animatedInsets = MutableInsets()
 
@@ -138,7 +138,7 @@ class InsetsType : Insets {
      * Whether this insets type is being animated at this moment.
      */
     val animationInProgress: Boolean
-        get() = ongoingAnimations > 0
+        get() = ongoingAnimationsCount > 0
 
     /**
      * The progress of any ongoing animations, in the range of 0 to 1.
@@ -149,13 +149,13 @@ class InsetsType : Insets {
         internal set
 
     internal fun onAnimationStart() {
-        ongoingAnimations++
+        ongoingAnimationsCount++
     }
 
     internal fun onAnimationEnd() {
-        ongoingAnimations--
+        ongoingAnimationsCount--
 
-        if (ongoingAnimations == 0) {
+        if (ongoingAnimationsCount == 0) {
             // If there are no on-going animations, clear out the animated insets
             _animatedInsets.reset()
             animationFraction = 0f

--- a/insets/src/main/java/com/google/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/com/google/accompanist/insets/Insets.kt
@@ -95,7 +95,7 @@ class InsetsType : Insets {
 
     /**
      * The animated insets for this [InsetsType]. These are the insets which are updated from
-     * any on-going animations. If there are no animations in progress, the return [Insets] will
+     * any on-going animations. If there are no animations in progress, the returned [Insets] will
      * be empty.
      *
      * You should not normally need to use this directly, and instead use [left], [top],

--- a/insets/src/main/java/com/google/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/com/google/accompanist/insets/Insets.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:Suppress("NOTHING_TO_INLINE", "unused")
+@file:Suppress("NOTHING_TO_INLINE", "unused", "PropertyName")
 
 @file:JvmName("ComposeInsets")
 @file:JvmMultifileClass
@@ -23,6 +23,8 @@ package com.google.accompanist.insets
 
 import android.view.View
 import android.view.WindowInsetsAnimation
+import androidx.annotation.FloatRange
+import androidx.annotation.IntRange
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -45,54 +47,86 @@ class WindowInsets {
     /**
      * Inset values which match [WindowInsetsCompat.Type.systemBars]
      */
-    val systemBars = Insets()
+    val systemBars: InsetsType = InsetsType()
 
     /**
      * Inset values which match [WindowInsetsCompat.Type.systemGestures]
      */
-    val systemGestures = Insets()
+    val systemGestures: InsetsType = InsetsType()
 
     /**
      * Inset values which match [WindowInsetsCompat.Type.navigationBars]
      */
-    val navigationBars = Insets()
+    val navigationBars: InsetsType = InsetsType()
 
     /**
      * Inset values which match [WindowInsetsCompat.Type.statusBars]
      */
-    val statusBars = Insets()
+    val statusBars: InsetsType = InsetsType()
 
     /**
      * Inset values which match [WindowInsetsCompat.Type.ime]
      */
-    val ime = Insets()
+    val ime: InsetsType = InsetsType()
 }
 
+/**
+ * Represents the values for a type of insets, and stored information about the layout insets,
+ * animating insets, and visibility of the insets.
+ *
+ * [InsetsType] instances are commonly stored in a [WindowInsets] instance.
+ */
 @Stable
-class Insets {
-    /**
-     * The left dimension of these insets in pixels.
-     */
-    var left by mutableStateOf(0)
-        internal set
+@Suppress("MemberVisibilityCanBePrivate")
+class InsetsType : Insets {
+    private var ongoingAnimations by mutableStateOf(0)
+    internal val _layoutInsets = MutableInsets()
+    internal val _animatedInsets = MutableInsets()
 
     /**
-     * The top dimension of these insets in pixels.
+     * The layout insets for this [InsetsType]. These are the insets which are defined from the
+     * current window layout.
+     *
+     * You should not normally need to use this directly, and instead use [left], [top],
+     * [right], and [bottom] to return the correct value for the current state.
      */
-    var top by mutableStateOf(0)
-        internal set
+    val layoutInsets: Insets
+        get() = _layoutInsets
 
     /**
-     * The right dimension of these insets in pixels.
+     * The animated insets for this [InsetsType]. These are the insets which are updated from
+     * any on-going animations. If there are no animations in progress, the return [Insets] will
+     * be empty.
+     *
+     * You should not normally need to use this directly, and instead use [left], [top],
+     * [right], and [bottom] to return the correct value for the current state.
      */
-    var right by mutableStateOf(0)
-        internal set
+    val animatedInsets: Insets
+        get() = _animatedInsets
 
     /**
-     * The bottom dimension of these insets in pixels.
+     * The left dimension of the insets in pixels.
      */
-    var bottom by mutableStateOf(0)
-        internal set
+    override val left: Int
+        get() = (if (animationInProgress) animatedInsets else layoutInsets).left
+
+    /**
+     * The top dimension of the insets in pixels.
+     */
+    override val top: Int
+        get() = (if (animationInProgress) animatedInsets else layoutInsets).top
+
+    /**
+     * The right dimension of the insets in pixels.
+     */
+    override val right: Int
+        get() = (if (animationInProgress) animatedInsets else layoutInsets).right
+
+    /**
+     * The bottom dimension of the insets in pixels.
+     */
+    override val bottom: Int
+        get() = (if (animationInProgress) animatedInsets else layoutInsets).bottom
 
     /**
      * Whether the insets are currently visible.
@@ -100,36 +134,107 @@ class Insets {
     var isVisible by mutableStateOf(true)
         internal set
 
-    internal var ongoingAnimations by mutableStateOf(0)
+    /**
+     * Whether this insets type is being animated at this moment.
+     */
+    val animationInProgress: Boolean
+        get() = ongoingAnimations > 0
+
+    /**
+     * The progress of any ongoing animations, in the range of 0 to 1.
+     * If there is no animation in progress, this will return 0.
+     */
+    @get:FloatRange(from = 0.0, to = 1.0)
+    var animationFraction by mutableStateOf(0f)
+        internal set
+
+    internal fun onAnimationStart() {
+        ongoingAnimations++
+    }
+
+    internal fun onAnimationEnd() {
+        ongoingAnimations--
+
+        if (ongoingAnimations == 0) {
+            // If there are no on-going animations, clear out the animated insets
+            _animatedInsets.reset()
+            animationFraction = 0f
+        }
+    }
+}
+
+@Stable
+interface Insets {
+    /**
+     * The left dimension of these insets in pixels.
+     */
+    @get:IntRange(from = 0)
+    val left: Int
+
+    /**
+     * The top dimension of these insets in pixels.
+     */
+    @get:IntRange(from = 0)
+    val top: Int
+
+    /**
+     * The right dimension of these insets in pixels.
+     */
+    @get:IntRange(from = 0)
+    val right: Int
+
+    /**
+     * The bottom dimension of these insets in pixels.
+     */
+    @get:IntRange(from = 0)
+    val bottom: Int
 
     fun copy(
         left: Int = this.left,
         top: Int = this.top,
         right: Int = this.right,
         bottom: Int = this.bottom,
-        isVisible: Boolean = this.isVisible,
-    ): Insets = Insets().apply {
-        this.left = left
-        this.top = top
-        this.right = right
-        this.bottom = bottom
-        this.isVisible = isVisible
-        this.ongoingAnimations = ongoingAnimations
-    }
+    ): Insets = MutableInsets(left, top, right, bottom)
 
     operator fun minus(other: Insets): Insets = copy(
-        left = this@Insets.left - other.left,
-        top = this@Insets.top - other.top,
-        right = this@Insets.right - other.right,
-        bottom = this@Insets.bottom - other.bottom,
+        left = this.left - other.left,
+        top = this.top - other.top,
+        right = this.right - other.right,
+        bottom = this.bottom - other.bottom,
     )
 
     operator fun plus(other: Insets): Insets = copy(
-        left = this@Insets.left + other.left,
-        top = this@Insets.top + other.top,
-        right = this@Insets.right + other.right,
-        bottom = this@Insets.bottom + other.bottom,
+        left = this.left + other.left,
+        top = this.top + other.top,
+        right = this.right + other.right,
+        bottom = this.bottom + other.bottom,
     )
+}
+
+internal class MutableInsets(
+    left: Int = 0,
+    top: Int = 0,
+    right: Int = 0,
+    bottom: Int = 0,
+) : Insets {
+    override var left by mutableStateOf(left)
+        internal set
+
+    override var top by mutableStateOf(top)
+        internal set
+
+    override var right by mutableStateOf(right)
+        internal set
+
+    override var bottom by mutableStateOf(bottom)
+        internal set
+
+    fun reset() {
+        left = 0
+        top = 0
+        right = 0
+        bottom = 0
+    }
 }
 
 val LocalWindowInsets = staticCompositionLocalOf<WindowInsets> {
@@ -239,41 +344,27 @@ class ViewWindowInsetObserver(private val view: View) {
         }
 
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, wic ->
-            // Go through each inset type and update it from the WindowInsetsCompat.
-            //
-            // If the inset type is currently being animated we ignore this pass. This is
-            // because WindowInsetsAnimation is built with the view system in mind, such that
-            // it forces consumers to be laid out in the final state, then immediately transform
-            // itself to look like the start state (because we shouldn't use layout
-            // animations in views). For more information, see:
-            // https://medium.com/androiddevelopers/animating-your-keyboard-reacting-to-inset-animations-839be3d4c31b
-            //
-            // Compose (hopefully) doesn't need that, so we can just apply the animated insets
-            // directly to the layout.
+            // Go through each inset type and update its layoutInsets from the
+            // WindowInsetsCompat values
             windowInsets.statusBars.run {
-                if (ongoingAnimations == 0) {
-                    updateFrom(wic, WindowInsetsCompat.Type.statusBars())
-                }
+                _layoutInsets.updateFrom(wic.getInsets(WindowInsetsCompat.Type.statusBars()))
+                isVisible = wic.isVisible(WindowInsetsCompat.Type.statusBars())
             }
             windowInsets.navigationBars.run {
-                if (ongoingAnimations == 0) {
-                    updateFrom(wic, WindowInsetsCompat.Type.navigationBars())
-                }
+                _layoutInsets.updateFrom(wic.getInsets(WindowInsetsCompat.Type.navigationBars()))
+                isVisible = wic.isVisible(WindowInsetsCompat.Type.navigationBars())
             }
             windowInsets.systemBars.run {
-                if (ongoingAnimations == 0) {
-                    updateFrom(wic, WindowInsetsCompat.Type.systemBars())
-                }
+                _layoutInsets.updateFrom(wic.getInsets(WindowInsetsCompat.Type.systemBars()))
+                isVisible = wic.isVisible(WindowInsetsCompat.Type.systemBars())
             }
             windowInsets.systemGestures.run {
-                if (ongoingAnimations == 0) {
-                    updateFrom(wic, WindowInsetsCompat.Type.systemGestures())
-                }
+                _layoutInsets.updateFrom(wic.getInsets(WindowInsetsCompat.Type.systemGestures()))
+                isVisible = wic.isVisible(WindowInsetsCompat.Type.systemGestures())
             }
             windowInsets.ime.run {
-                if (ongoingAnimations == 0) {
-                    updateFrom(wic, WindowInsetsCompat.Type.ime())
-                }
+                _layoutInsets.updateFrom(wic.getInsets(WindowInsetsCompat.Type.ime()))
+                isVisible = wic.isVisible(WindowInsetsCompat.Type.ime())
             }
 
             if (consumeWindowInsets) WindowInsetsCompat.CONSUMED else wic
@@ -414,19 +505,19 @@ private class InnerWindowInsetsAnimationCallback(
     override fun onPrepare(animation: WindowInsetsAnimationCompat) {
         // Go through each type and flag that an animation has started
         if (animation.typeMask and WindowInsetsCompat.Type.ime() != 0) {
-            windowInsets.ime.ongoingAnimations++
+            windowInsets.ime.onAnimationStart()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.statusBars() != 0) {
-            windowInsets.statusBars.ongoingAnimations++
+            windowInsets.statusBars.onAnimationStart()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.navigationBars() != 0) {
-            windowInsets.navigationBars.ongoingAnimations++
+            windowInsets.navigationBars.onAnimationStart()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.systemBars() != 0) {
-            windowInsets.systemBars.ongoingAnimations++
+            windowInsets.systemBars.onAnimationStart()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.systemGestures() != 0) {
-            windowInsets.systemGestures.ongoingAnimations++
+            windowInsets.systemGestures.onAnimationStart()
         }
     }
 
@@ -434,73 +525,78 @@ private class InnerWindowInsetsAnimationCallback(
         platformInsets: WindowInsetsCompat,
         runningAnimations: List<WindowInsetsAnimationCompat>
     ): WindowInsetsCompat {
-        val runningTypes = runningAnimations.fold(0) { acc, animation ->
-            acc or animation.typeMask
-        }
-        if (runningTypes and WindowInsetsCompat.Type.ime() != 0) {
-            windowInsets.ime.updateFrom(
-                windowInsets = platformInsets,
-                type = WindowInsetsCompat.Type.ime()
-            )
-        }
-        if (runningTypes and WindowInsetsCompat.Type.statusBars() != 0) {
-            windowInsets.statusBars.updateFrom(
-                windowInsets = platformInsets,
-                type = WindowInsetsCompat.Type.statusBars()
-            )
-        }
-        if (runningTypes and WindowInsetsCompat.Type.navigationBars() != 0) {
-            windowInsets.navigationBars.updateFrom(
-                windowInsets = platformInsets,
-                type = WindowInsetsCompat.Type.navigationBars()
-            )
-        }
-        if (runningTypes and WindowInsetsCompat.Type.systemBars() != 0) {
-            windowInsets.systemBars.updateFrom(
-                windowInsets = platformInsets,
-                type = WindowInsetsCompat.Type.systemBars()
-            )
-        }
-        if (runningTypes and WindowInsetsCompat.Type.systemGestures() != 0) {
-            windowInsets.systemGestures.updateFrom(
-                windowInsets = platformInsets,
-                type = WindowInsetsCompat.Type.systemGestures()
-            )
-        }
+        // Update each inset type with the given parameters
+        windowInsets.ime.updateAnimation(
+            platformInsets = platformInsets,
+            runningAnimations = runningAnimations,
+            type = WindowInsetsCompat.Type.ime()
+        )
+        windowInsets.statusBars.updateAnimation(
+            platformInsets = platformInsets,
+            runningAnimations = runningAnimations,
+            type = WindowInsetsCompat.Type.statusBars()
+        )
+        windowInsets.navigationBars.updateAnimation(
+            platformInsets = platformInsets,
+            runningAnimations = runningAnimations,
+            type = WindowInsetsCompat.Type.navigationBars()
+        )
+        windowInsets.systemBars.updateAnimation(
+            platformInsets = platformInsets,
+            runningAnimations = runningAnimations,
+            type = WindowInsetsCompat.Type.systemBars()
+        )
+        windowInsets.systemBars.updateAnimation(
+            platformInsets = platformInsets,
+            runningAnimations = runningAnimations,
+            type = WindowInsetsCompat.Type.systemGestures()
+        )
         return platformInsets
+    }
+
+    private inline fun InsetsType.updateAnimation(
+        platformInsets: WindowInsetsCompat,
+        runningAnimations: List<WindowInsetsAnimationCompat>,
+        type: Int,
+    ) {
+        // If there are animations of the given type...
+        if (runningAnimations.any { it.typeMask or type != 0 }) {
+            // Update our animated inset values
+            _animatedInsets.updateFrom(platformInsets.getInsets(type))
+            // And update the animation fraction. We use the maximum animation progress of any
+            // ongoing animations for this type.
+            animationFraction = runningAnimations.maxOf { it.fraction }
+        }
     }
 
     override fun onEnd(animation: WindowInsetsAnimationCompat) {
         // Go through each type and flag that an animation has ended
         if (animation.typeMask and WindowInsetsCompat.Type.ime() != 0) {
-            windowInsets.ime.ongoingAnimations--
+            windowInsets.ime.onAnimationEnd()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.statusBars() != 0) {
-            windowInsets.statusBars.ongoingAnimations--
+            windowInsets.statusBars.onAnimationEnd()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.navigationBars() != 0) {
-            windowInsets.navigationBars.ongoingAnimations--
+            windowInsets.navigationBars.onAnimationEnd()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.systemBars() != 0) {
-            windowInsets.systemBars.ongoingAnimations--
+            windowInsets.systemBars.onAnimationEnd()
         }
         if (animation.typeMask and WindowInsetsCompat.Type.systemGestures() != 0) {
-            windowInsets.systemGestures.ongoingAnimations--
+            windowInsets.systemGestures.onAnimationEnd()
         }
     }
 }
 
 /**
- * Updates our mutable state backed [Insets] from an Android system insets.
+ * Updates our mutable state backed [InsetsType] from an Android system insets.
  */
-private fun Insets.updateFrom(windowInsets: WindowInsetsCompat, type: Int) {
-    val insets = windowInsets.getInsets(type)
+private fun MutableInsets.updateFrom(insets: androidx.core.graphics.Insets) {
     left = insets.left
     top = insets.top
     right = insets.right
     bottom = insets.bottom
-
-    isVisible = windowInsets.isVisible(type)
 }
 
 /**
@@ -511,14 +607,14 @@ private fun Insets.updateFrom(windowInsets: WindowInsetsCompat, type: Int) {
  * dimension value in [minimumValue], otherwise a copy of this with each dimension coerced with the
  * corresponding dimension value in [minimumValue].
  */
-fun Insets.coerceEachDimensionAtLeast(minimumValue: Insets): Insets {
+fun InsetsType.coerceEachDimensionAtLeast(minimumValue: InsetsType): Insets {
     // Fast path, no need to copy if: this >= minimumValue
     if (left >= minimumValue.left && top >= minimumValue.top &&
         right >= minimumValue.right && bottom >= minimumValue.bottom
     ) {
         return this
     }
-    return copy(
+    return MutableInsets(
         left = left.coerceAtLeast(minimumValue.left),
         top = top.coerceAtLeast(minimumValue.top),
         right = right.coerceAtLeast(minimumValue.right),

--- a/insets/src/main/java/com/google/accompanist/insets/Padding.kt
+++ b/insets/src/main/java/com/google/accompanist/insets/Padding.kt
@@ -48,7 +48,7 @@ fun Modifier.systemBarsPadding(
     enabled: Boolean = true
 ): Modifier = composed {
     InsetsPaddingModifier(
-        insets = LocalWindowInsets.current.systemBars,
+        insetsType = LocalWindowInsets.current.systemBars,
         applyLeft = enabled,
         applyTop = enabled,
         applyRight = enabled,
@@ -62,7 +62,7 @@ fun Modifier.systemBarsPadding(
  */
 fun Modifier.statusBarsPadding(): Modifier = composed {
     InsetsPaddingModifier(
-        insets = LocalWindowInsets.current.statusBars,
+        insetsType = LocalWindowInsets.current.statusBars,
         applyTop = true
     )
 }
@@ -85,7 +85,7 @@ fun Modifier.navigationBarsPadding(
     right: Boolean = true
 ): Modifier = composed {
     InsetsPaddingModifier(
-        insets = LocalWindowInsets.current.navigationBars,
+        insetsType = LocalWindowInsets.current.navigationBars,
         applyLeft = left,
         applyRight = right,
         applyBottom = bottom
@@ -102,7 +102,7 @@ fun Modifier.navigationBarsPadding(
  */
 fun Modifier.imePadding(): Modifier = composed {
     InsetsPaddingModifier(
-        insets = LocalWindowInsets.current.ime,
+        insetsType = LocalWindowInsets.current.ime,
         applyLeft = true,
         applyRight = true,
         applyBottom = true,
@@ -116,8 +116,8 @@ fun Modifier.imePadding(): Modifier = composed {
  */
 fun Modifier.navigationBarsWithImePadding(): Modifier = composed {
     InsetsPaddingModifier(
-        insets = LocalWindowInsets.current.ime,
-        minimumInsets = LocalWindowInsets.current.navigationBars,
+        insetsType = LocalWindowInsets.current.ime,
+        minimumInsetsType = LocalWindowInsets.current.navigationBars,
         applyLeft = true,
         applyRight = true,
         applyBottom = true,
@@ -125,8 +125,8 @@ fun Modifier.navigationBarsWithImePadding(): Modifier = composed {
 }
 
 private data class InsetsPaddingModifier(
-    private val insets: Insets,
-    private val minimumInsets: Insets? = null,
+    private val insetsType: InsetsType,
+    private val minimumInsetsType: InsetsType? = null,
     private val applyLeft: Boolean = false,
     private val applyTop: Boolean = false,
     private val applyRight: Boolean = false,
@@ -136,10 +136,10 @@ private data class InsetsPaddingModifier(
         measurable: Measurable,
         constraints: Constraints
     ): MeasureResult {
-        val transformedInsets = if (minimumInsets != null) {
+        val transformedInsets = if (minimumInsetsType != null) {
             // If we have a minimum insets, coerce each dimensions
-            insets.coerceEachDimensionAtLeast(minimumInsets)
-        } else insets
+            insetsType.coerceEachDimensionAtLeast(minimumInsetsType)
+        } else insetsType
 
         val left = if (applyLeft) transformedInsets.left else 0
         val top = if (applyTop) transformedInsets.top else 0
@@ -171,7 +171,7 @@ private data class InsetsPaddingModifier(
  * @param additionalVertical Value to add to the top and bottom dimensions.
  */
 @Composable
-inline fun Insets.toPaddingValues(
+inline fun InsetsType.toPaddingValues(
     start: Boolean = true,
     top: Boolean = true,
     end: Boolean = true,
@@ -202,7 +202,7 @@ inline fun Insets.toPaddingValues(
  * @param additionalBottom Value to add to the bottom dimension.
  */
 @Composable
-fun Insets.toPaddingValues(
+fun InsetsType.toPaddingValues(
     start: Boolean = true,
     top: Boolean = true,
     end: Boolean = true,

--- a/insets/src/main/java/com/google/accompanist/insets/Size.kt
+++ b/insets/src/main/java/com/google/accompanist/insets/Size.kt
@@ -64,7 +64,7 @@ fun Modifier.statusBarsHeight(
     additional: Dp = 0.dp
 ): Modifier = composed {
     InsetsSizeModifier(
-        insets = LocalWindowInsets.current.statusBars,
+        insetsType = LocalWindowInsets.current.statusBars,
         heightSide = VerticalSide.Top,
         additionalHeight = additional
     )
@@ -99,7 +99,7 @@ fun Modifier.navigationBarsHeight(
     additional: Dp = 0.dp
 ): Modifier = composed {
     InsetsSizeModifier(
-        insets = LocalWindowInsets.current.navigationBars,
+        insetsType = LocalWindowInsets.current.navigationBars,
         heightSide = VerticalSide.Bottom,
         additionalHeight = additional
     )
@@ -140,7 +140,7 @@ fun Modifier.navigationBarsWidth(
     additional: Dp = 0.dp
 ): Modifier = composed {
     InsetsSizeModifier(
-        insets = LocalWindowInsets.current.navigationBars,
+        insetsType = LocalWindowInsets.current.navigationBars,
         widthSide = side,
         additionalWidth = additional
     )
@@ -154,7 +154,7 @@ fun Modifier.navigationBarsWidth(
  * issue tracker.
  */
 private data class InsetsSizeModifier(
-    private val insets: Insets,
+    private val insetsType: InsetsType,
     private val widthSide: HorizontalSide? = null,
     private val additionalWidth: Dp = 0.dp,
     private val heightSide: VerticalSide? = null,
@@ -166,23 +166,23 @@ private data class InsetsSizeModifier(
             val additionalHeightPx = additionalHeight.roundToPx()
             return Constraints(
                 minWidth = additionalWidthPx + when (widthSide) {
-                    HorizontalSide.Left -> insets.left
-                    HorizontalSide.Right -> insets.right
+                    HorizontalSide.Left -> insetsType.left
+                    HorizontalSide.Right -> insetsType.right
                     null -> 0
                 },
                 minHeight = additionalHeightPx + when (heightSide) {
-                    VerticalSide.Top -> insets.top
-                    VerticalSide.Bottom -> insets.bottom
+                    VerticalSide.Top -> insetsType.top
+                    VerticalSide.Bottom -> insetsType.bottom
                     null -> 0
                 },
                 maxWidth = when (widthSide) {
-                    HorizontalSide.Left -> insets.left + additionalWidthPx
-                    HorizontalSide.Right -> insets.right + additionalWidthPx
+                    HorizontalSide.Left -> insetsType.left + additionalWidthPx
+                    HorizontalSide.Right -> insetsType.right + additionalWidthPx
                     null -> Constraints.Infinity
                 },
                 maxHeight = when (heightSide) {
-                    VerticalSide.Top -> insets.top + additionalHeightPx
-                    VerticalSide.Bottom -> insets.bottom + additionalHeightPx
+                    VerticalSide.Top -> insetsType.top + additionalHeightPx
+                    VerticalSide.Bottom -> insetsType.bottom + additionalHeightPx
                     null -> Constraints.Infinity
                 }
             )


### PR DESCRIPTION
This PRs refactors the `Insets` class so it now stores:

- Layout insets
- Animated insets
- Animated progress fraction

The types of properties have changed slightly (so technically API breaking), but the actual typical usage is exactly the same: `LocalWindowInsets.statusBars.top`.

Fixes #227 