### PR TITLE
Pager parameter to disable scrolling by hand

### DIFF
--- a/pager/api/pager.api
+++ b/pager/api/pager.api
@@ -2,8 +2,8 @@ public abstract interface annotation class com/google/accompanist/pager/Experime
 }
 
 public final class com/google/accompanist/pager/Pager {
-	public static final fun HorizontalPager (Lcom/google/accompanist/pager/PagerState;Landroidx/compose/ui/Modifier;ZILandroidx/compose/foundation/gestures/FlingBehavior;Landroidx/compose/ui/Alignment$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
-	public static final fun VerticalPager (Lcom/google/accompanist/pager/PagerState;Landroidx/compose/ui/Modifier;ZILandroidx/compose/foundation/gestures/FlingBehavior;Landroidx/compose/ui/Alignment$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun HorizontalPager (Lcom/google/accompanist/pager/PagerState;Landroidx/compose/ui/Modifier;ZZILandroidx/compose/foundation/gestures/FlingBehavior;Landroidx/compose/ui/Alignment$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VerticalPager (Lcom/google/accompanist/pager/PagerState;Landroidx/compose/ui/Modifier;ZZILandroidx/compose/foundation/gestures/FlingBehavior;Landroidx/compose/ui/Alignment$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 	public static final fun calculateCurrentOffsetForPage (Lcom/google/accompanist/pager/PagerScope;I)F
 }
 

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -138,6 +138,7 @@ fun HorizontalPager(
     state: PagerState,
     modifier: Modifier = Modifier,
     reverseLayout: Boolean = false,
+    isDraggable: Boolean = true,
     @IntRange(from = 1) offscreenLimit: Int = 1,
     flingBehavior: FlingBehavior = PagerDefaults.defaultPagerFlingConfig(state),
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
@@ -149,6 +150,7 @@ fun HorizontalPager(
         modifier = modifier,
         isVertical = false,
         reverseLayout = reverseLayout,
+        isDraggable = isDraggable,
         offscreenLimit = offscreenLimit,
         flingBehavior = flingBehavior,
         verticalAlignment = verticalAlignment,
@@ -184,6 +186,7 @@ fun VerticalPager(
     state: PagerState,
     modifier: Modifier = Modifier,
     reverseLayout: Boolean = false,
+    isDraggable: Boolean = true,
     @IntRange(from = 1) offscreenLimit: Int = 1,
     flingBehavior: FlingBehavior = PagerDefaults.defaultPagerFlingConfig(state),
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
@@ -195,6 +198,7 @@ fun VerticalPager(
         modifier = modifier,
         isVertical = true,
         reverseLayout = reverseLayout,
+        isDraggable = isDraggable,
         offscreenLimit = offscreenLimit,
         verticalAlignment = verticalAlignment,
         horizontalAlignment = horizontalAlignment,
@@ -209,6 +213,7 @@ internal fun Pager(
     state: PagerState,
     modifier: Modifier,
     reverseLayout: Boolean,
+    isDraggable: Boolean,
     isVertical: Boolean,
     verticalAlignment: Alignment.Vertical,
     horizontalAlignment: Alignment.Horizontal,
@@ -245,12 +250,16 @@ internal fun Pager(
         selectableGroup()
     }
 
-    val scrollable = Modifier.scrollable(
-        orientation = if (isVertical) Orientation.Vertical else Orientation.Horizontal,
-        flingBehavior = flingBehavior,
-        reverseDirection = reverseDirection,
-        state = state,
-    )
+    val scrollable = if(isDraggable) { 
+        Modifier.scrollable(
+            orientation = if (isVertical) Orientation.Vertical else Orientation.Horizontal,
+            flingBehavior = flingBehavior,
+            reverseDirection = reverseDirection,
+            state = state,
+        ) 
+    } else { 
+        Modifier 
+    }
 
     Layout(
         modifier = modifier

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -138,7 +138,7 @@ fun HorizontalPager(
     state: PagerState,
     modifier: Modifier = Modifier,
     reverseLayout: Boolean = false,
-    isDraggable: Boolean = true,
+    dragEnabled: Boolean = true,
     @IntRange(from = 1) offscreenLimit: Int = 1,
     flingBehavior: FlingBehavior = PagerDefaults.defaultPagerFlingConfig(state),
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
@@ -150,7 +150,7 @@ fun HorizontalPager(
         modifier = modifier,
         isVertical = false,
         reverseLayout = reverseLayout,
-        isDraggable = isDraggable,
+        dragEnabled = dragEnabled,
         offscreenLimit = offscreenLimit,
         flingBehavior = flingBehavior,
         verticalAlignment = verticalAlignment,
@@ -186,7 +186,7 @@ fun VerticalPager(
     state: PagerState,
     modifier: Modifier = Modifier,
     reverseLayout: Boolean = false,
-    isDraggable: Boolean = true,
+    dragEnabled: Boolean = true,
     @IntRange(from = 1) offscreenLimit: Int = 1,
     flingBehavior: FlingBehavior = PagerDefaults.defaultPagerFlingConfig(state),
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
@@ -198,7 +198,7 @@ fun VerticalPager(
         modifier = modifier,
         isVertical = true,
         reverseLayout = reverseLayout,
-        isDraggable = isDraggable,
+        dragEnabled = dragEnabled,
         offscreenLimit = offscreenLimit,
         verticalAlignment = verticalAlignment,
         horizontalAlignment = horizontalAlignment,
@@ -213,7 +213,7 @@ internal fun Pager(
     state: PagerState,
     modifier: Modifier,
     reverseLayout: Boolean,
-    isDraggable: Boolean,
+    dragEnabled: Boolean,
     isVertical: Boolean,
     verticalAlignment: Alignment.Vertical,
     horizontalAlignment: Alignment.Horizontal,
@@ -250,16 +250,13 @@ internal fun Pager(
         selectableGroup()
     }
 
-    val scrollable = if(isDraggable) { 
-        Modifier.scrollable(
-            orientation = if (isVertical) Orientation.Vertical else Orientation.Horizontal,
-            flingBehavior = flingBehavior,
-            reverseDirection = reverseDirection,
-            state = state,
-        ) 
-    } else { 
-        Modifier 
-    }
+    val scrollable = Modifier.scrollable(
+        orientation = if (isVertical) Orientation.Vertical else Orientation.Horizontal,
+        flingBehavior = flingBehavior,
+        reverseDirection = reverseDirection,
+        state = state,
+        enabled = dragEnabled,
+    )
 
     Layout(
         modifier = modifier

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -126,6 +126,8 @@ object PagerDefaults {
  * @param reverseLayout reverse the direction of scrolling and layout, when `true` items will be
  * composed from the end to the start and [PagerState.currentPage] == 0 will mean
  * the first item is located at the end.
+ * @param dragEnabled toggle manual scrolling, when `false` the user can not drag the view to a
+ * different page
  * @param offscreenLimit the number of pages that should be retained on either side of the
  * current page. This value is required to be `1` or greater.
  * @param flingBehavior logic describing fling behavior.
@@ -174,6 +176,8 @@ fun HorizontalPager(
  * @param reverseLayout reverse the direction of scrolling and layout, when `true` items will be
  * composed from the bottom to the top and [PagerState.currentPage] == 0 will mean
  * the first item is located at the bottom.
+ * @param dragEnabled toggle manual scrolling, when `false` the user can not drag the view to a
+ * different page
  * @param offscreenLimit the number of pages that should be retained on either side of the
  * current page. This value is required to be `1` or greater.
  * @param flingBehavior logic describing fling behavior.


### PR DESCRIPTION
This commit adds a parameter to the Pager composable to disable scrolling by hand. If disabled, PagerState.animateScrollToPage() can be used to programmatically switch to a different page.