### PR TITLE
Fix async flakiness in pageChangesSample test

### DIFF
--- a/pager/src/androidTest/java/com/google/accompanist/pager/TestUtils.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/TestUtils.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.test.performGesture
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.test.swipeWithVelocity
 import androidx.compose.ui.unit.LayoutDirection
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlin.math.absoluteValue
 import kotlin.math.hypot
 import kotlin.math.roundToLong
@@ -91,3 +94,15 @@ fun randomColor() = Color(
     green = Random.nextFloat(),
     blue = Random.nextFloat(),
 )
+
+/**
+ * Copied from Turbine:
+ * https://github.com/cashapp/turbine/blob/trunk/src/jvmTest/kotlin/app/cash/turbine/jvmTestUtil.kt
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun suspendTest(body: suspend TestCoroutineScope.() -> Unit) {
+    // We don't use runBlockingTest because it always advances time unconditionally.
+    val scope = TestCoroutineScope()
+    scope.launch { scope.body() }
+    scope.cleanupTestCoroutines()
+}


### PR DESCRIPTION
Due to async coroutines which sometimes wouldn't complete before the test finished. Fixed by using `TestCoroutineScope` and `suspendTest()` from Turbine.