### PR TITLE
[Pager] Update currentPage to act as the selected page

### DIFF
--- a/docs/pager.md
+++ b/docs/pager.md
@@ -131,15 +131,11 @@ HorizontalPager(state = pagerState) { page ->
 
 ## Reacting to page changes
 
-From reading above, you might be thinking that reading [`PagerState.currentPage`][currentpage-api] is a good way to know when the selected page changes. Unfortunately `currentPage` does not tell you the currently selected page, but instead tells you which page is (mostly) displayed on screen.
-
-To know when the selected page changes, you can use the [`pageChanges`](../api/pager/pager/com.google.accompanist.pager/page-changes.html) flow:
+The [`PagerState.currentPage`][currentpage-api] property is updated whenever the selected page changes. You can use the `snapshowFlow` function to observe changes in a flow:
 
 ``` kotlin
-import com.google.accompanist.pager.pageChanges
-
 LaunchedEffect(pagerState) {
-    pagerState.pageChanges.collect { page ->
+    snapshotFlow { pagerState.currentPage }.collect { page ->
         // Selected page has changed...
     }
 }
@@ -160,11 +156,9 @@ We also publish a sibling library called `pager-indicators` which provides some 
 The [HorizontalPagerWithIndicatorSample](https://github.com/google/accompanist/blob/main/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerWithIndicatorSample.kt) and [VerticalPagerWithIndicatorSample](https://github.com/google/accompanist/blob/snapshot/sample/src/main/java/com/google/accompanist/sample/pager/VerticalPagerWithIndicatorSample.kt) show you how to use these.
 
 
-## Integration with Tabs
+### Integration with Tabs
 
-A common use-case for [`HorizontalPager`][api-horizpager] is to be used in conjunction with a [`TabRow`](https://developer.android.com/reference/kotlin/androidx/compose/material/package-summary#tabrow).
-
-The [HorizontalPagerTabsSample](https://github.com/google/accompanist/blob/main/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerTabsSample.kt) demonstrates how this can be done:
+A common use-case for [`HorizontalPager`][api-horizpager] is to be used in conjunction with a [`TabRow`](https://developer.android.com/reference/kotlin/androidx/compose/material/package-summary#tabrow) or [`ScrollableTabRow`](https://developer.android.com/reference/kotlin/androidx/compose/material/package-summary#scrollabletabrow).
 
 <figure>
     <video width="300" controls loop>
@@ -174,7 +168,36 @@ The [HorizontalPagerTabsSample](https://github.com/google/accompanist/blob/main/
     <figcaption>HorizontalPager + TabRow</figcaption>
 </figure>
 
-### 
+
+Provided in the `pager-indicators` library is a modifier which can be used on a tab indicator like so:
+
+``` kotlin
+val pagerState = rememberPagerState(pageCount = pages.size)
+
+TabRow(
+    // Our selected tab is our current page
+    selectedTabIndex = pagerState.currentPage,
+    // Override the indicator, using the provided pagerTabIndicatorOffset modifier
+    indicator = { tabPositions ->
+        TabRowDefaults.Indicator(
+            Modifier.pagerTabIndicatorOffset(pagerState, tabPositions)
+        )
+    }
+) {
+    // Add tabs for all of our pages
+    pages.forEachIndexed { index, title ->
+        Tab(
+            text = { Text(title) },
+            selected = pagerState.currentPage == index,
+            onClick = { /* TODO */ },
+        )
+    }
+}
+
+HorizontalPager(state = pagerState) { page ->
+    // TODO: page content
+}
+```
 
 ---
 

--- a/pager-indicators/api/pager-indicators.api
+++ b/pager-indicators/api/pager-indicators.api
@@ -3,3 +3,7 @@ public final class com/google/accompanist/pager/PagerIndicatorKt {
 	public static final fun VerticalPagerIndicator-RfBtt3o (Lcom/google/accompanist/pager/PagerState;Landroidx/compose/ui/Modifier;JJFFFLandroidx/compose/ui/graphics/Shape;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class com/google/accompanist/pager/PagerTabKt {
+	public static final fun pagerTabIndicatorOffset (Landroidx/compose/ui/Modifier;Lcom/google/accompanist/pager/PagerState;Ljava/util/List;)Landroidx/compose/ui/Modifier;
+}
+

--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.pager
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.ScrollableTabRow
+import androidx.compose.material.TabPosition
+import androidx.compose.material.TabRow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.lerp
+import kotlin.math.absoluteValue
+import kotlin.math.max
+
+/**
+ * This indicator syncs up a [TabRow] or [ScrollableTabRow] tab indicator with a
+ * [HorizontalPager] or [VerticalPager]. See the sample for a full demonstration.
+ *
+ * @sample com.google.accompanist.sample.pager.PagerWithTabs
+ */
+@ExperimentalPagerApi
+fun Modifier.pagerTabIndicatorOffset(
+    pagerState: PagerState,
+    tabPositions: List<TabPosition>,
+): Modifier = composed {
+    val targetIndicatorOffset: Dp
+    val indicatorWidth: Dp
+
+    val currentTab = tabPositions[pagerState.currentPage]
+    val targetPage = pagerState.targetPage
+    val targetTab = targetPage?.let { tabPositions.getOrNull(it) }
+
+    if (targetTab != null) {
+        // The distance between the target and current page. If the pager is animating over many
+        // items this could be > 1
+        val targetDistance = (targetPage - pagerState.currentPage).absoluteValue
+        // Our normalized fraction over the target distance
+        val fraction = (pagerState.currentPageOffset / max(targetDistance, 1)).absoluteValue
+
+        targetIndicatorOffset = lerp(currentTab.left, targetTab.left, fraction)
+        indicatorWidth = lerp(currentTab.width, targetTab.width, fraction).absoluteValue
+    } else {
+        // Otherwise we just use the current tab/page
+        targetIndicatorOffset = currentTab.left
+        indicatorWidth = currentTab.width
+    }
+
+    fillMaxWidth()
+        .wrapContentSize(Alignment.BottomStart)
+        .offset(x = targetIndicatorOffset)
+        .width(indicatorWidth)
+}
+
+private inline val Dp.absoluteValue: Dp
+    get() = value.absoluteValue.dp

--- a/pager/api/pager.api
+++ b/pager/api/pager.api
@@ -33,6 +33,7 @@ public final class com/google/accompanist/pager/PagerState : androidx/compose/fo
 	public final fun getCurrentPage ()I
 	public final fun getCurrentPageOffset ()F
 	public final fun getPageCount ()I
+	public final fun getTargetPage ()Ljava/lang/Integer;
 	public fun isScrollInProgress ()Z
 	public fun scroll (Landroidx/compose/foundation/MutatePriority;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun scrollToPage (IFLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/pager/src/androidTest/java/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/PagerTest.kt
@@ -137,9 +137,10 @@ abstract class PagerTest {
         assertPagerLayout(currentPage = 0)
     }
 
+    @Suppress("DEPRECATION") // pageChanges
     @OptIn(FlowPreview::class)
     @Test
-    fun pageChangesSample() = suspendTest {
+    fun pageChanges() = suspendTest {
         val pagerState = setPagerContent(pageCount = 10)
 
         // Collect the pageChanges flow into a Channel, allowing us to poll values

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -249,7 +249,7 @@ internal fun Pager(
     val coroutineScope = rememberCoroutineScope()
     val semanticsAxisRange = remember(state, reverseDirection) {
         ScrollAxisRange(
-            value = { state.currentPage + state.currentPageOffset },
+            value = { state.currentLayoutPage + state.currentLayoutPageOffset },
             maxValue = { state.lastPageIndex.toFloat() },
         )
     }
@@ -284,14 +284,15 @@ internal fun Pager(
             .then(scrollable)
             .clipToBounds(),
         content = {
-            val firstPage = (state.currentPage - offscreenLimit).coerceAtLeast(0)
-            val lastPage = (state.currentPage + offscreenLimit).coerceAtMost(state.lastPageIndex)
+            val firstPage = (state.currentLayoutPage - offscreenLimit).coerceAtLeast(0)
+            val lastPage = (state.currentLayoutPage + offscreenLimit).coerceAtMost(state.lastPageIndex)
 
             if (DebugLog) {
                 Log.d(
                     LogTag,
                     "Content: firstPage:$firstPage, " +
-                        "current:${state.currentPage}, " +
+                        "layoutPage:${state.currentLayoutPage}, " +
+                        "currentPage:${state.currentPage}, " +
                         "lastPage:$lastPage"
                 )
             }
@@ -328,8 +329,8 @@ internal fun Pager(
         val pagerHeight = placeables.maxOf { it.height }.coerceAtLeast(constraints.minHeight)
 
         layout(width = pagerWidth, height = pagerHeight) {
-            val currentPage = state.currentPage
-            val offset = state.currentPageOffset
+            val layoutPage = state.currentLayoutPage
+            val offset = state.currentLayoutPageOffset
             val itemSpacingPx = itemSpacing.roundToPx()
 
             placeables.forEachIndexed { index, placeable ->
@@ -347,16 +348,16 @@ internal fun Pager(
 
                 var yItemOffset = 0
                 var xItemOffset = 0
-                val offsetForPage = page - currentPage - offset
+                val offsetForPage = page - layoutPage - offset
 
                 if (isVertical) {
-                    if (currentPage == page) {
-                        state.pageSize = placeable.height
+                    if (layoutPage == page) {
+                        state.currentLayoutPageSize = placeable.height
                     }
                     yItemOffset = (offsetForPage * (placeable.height + itemSpacingPx)).roundToInt()
                 } else {
-                    if (currentPage == page) {
-                        state.pageSize = placeable.width
+                    if (layoutPage == page) {
+                        state.currentLayoutPageSize = placeable.width
                     }
                     xItemOffset = (offsetForPage * (placeable.width + itemSpacingPx)).roundToInt()
                 }
@@ -395,11 +396,8 @@ private class PagerScopeImpl(
     private val boxScope: BoxScope,
     private val state: PagerState,
 ) : PagerScope, BoxScope by boxScope {
-    override val currentPage: Int
-        get() = state.currentPage
-
-    override val currentPageOffset: Float
-        get() = state.currentPageOffset
+    override val currentPage: Int get() = state.currentPage
+    override val currentPageOffset: Float get() = state.currentPageOffset
 }
 
 /**

--- a/sample/src/main/java/com/google/accompanist/sample/pager/DocsSamples.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/DocsSamples.kt
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
+@file:Suppress("UNUSED_ANONYMOUS_PARAMETER")
+
 package com.google.accompanist.sample.pager
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.ExperimentalPagerApi
@@ -30,7 +36,7 @@ import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.HorizontalPagerIndicator
 import com.google.accompanist.pager.VerticalPager
 import com.google.accompanist.pager.VerticalPagerIndicator
-import com.google.accompanist.pager.pageChanges
+import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.google.accompanist.pager.rememberPagerState
 import kotlinx.coroutines.flow.collect
 
@@ -117,14 +123,43 @@ fun PageChangesSample() {
     val pagerState = rememberPagerState(pageCount = 10)
 
     LaunchedEffect(pagerState) {
-        // Collect from the PageState's pageChanges flow, which emits when the
-        // current page has changed
-        pagerState.pageChanges.collect { page ->
+        // Collect from the a snapshotFlow reading the currentPage
+        snapshotFlow { pagerState.currentPage }.collect { page ->
             AnalyticsService.sendPageSelectedEvent(page)
         }
     }
 
     VerticalPager(state = pagerState) { page ->
         Text(text = "Page: $page")
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+fun PagerWithTabs(pages: List<String>) {
+    val pagerState = rememberPagerState(pageCount = pages.size)
+
+    TabRow(
+        // Our selected tab is our current page
+        selectedTabIndex = pagerState.currentPage,
+        // Override the indicator, using the provided pagerTabIndicatorOffset modifier
+        indicator = { tabPositions ->
+            TabRowDefaults.Indicator(
+                Modifier.pagerTabIndicatorOffset(pagerState, tabPositions)
+            )
+        }
+    ) {
+        // Add tabs for all of our pages
+        pages.forEachIndexed { index, title ->
+            Tab(
+                text = { Text(title) },
+                selected = pagerState.currentPage == index,
+                onClick = { /* TODO */ },
+            )
+        }
+    }
+
+    HorizontalPager(state = pagerState) { page ->
+        // TODO: page content
     }
 }

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerTabsSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerTabsSample.kt
@@ -23,17 +23,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Surface
 import androidx.compose.material.Tab
-import androidx.compose.material.TabPosition
 import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
@@ -42,14 +38,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.lerp
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
-import com.google.accompanist.pager.PagerState
+import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.google.accompanist.pager.rememberPagerState
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
@@ -117,7 +110,9 @@ private fun Sample() {
 
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.weight(1f).fillMaxWidth()
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
             ) { page ->
                 // Our content for each page
                 Box(modifier = Modifier.fillMaxSize()) {
@@ -134,34 +129,4 @@ private fun Sample() {
             }
         }
     }
-}
-
-/**
- * This indicator syncs up the tab indicator with the [HorizontalPager] position.
- * We may add this in the library at some point.
- */
-@OptIn(ExperimentalPagerApi::class)
-fun Modifier.pagerTabIndicatorOffset(
-    pagerState: PagerState,
-    tabPositions: List<TabPosition>,
-): Modifier = composed {
-    val targetIndicatorOffset: Dp
-    val indicatorWidth: Dp
-
-    val currentTab = tabPositions[pagerState.currentPage]
-    val nextTab = tabPositions.getOrNull(pagerState.currentPage + 1)
-    if (nextTab != null) {
-        // If we have a next tab, lerp between the size and offset
-        targetIndicatorOffset = lerp(currentTab.left, nextTab.left, pagerState.currentPageOffset)
-        indicatorWidth = lerp(currentTab.width, nextTab.width, pagerState.currentPageOffset)
-    } else {
-        // Otherwise we just use the current tab/page
-        targetIndicatorOffset = currentTab.left
-        indicatorWidth = currentTab.width
-    }
-
-    fillMaxWidth()
-        .wrapContentSize(Alignment.BottomStart)
-        .offset(x = targetIndicatorOffset)
-        .width(indicatorWidth)
 }


### PR DESCRIPTION
Reading the selected page is a common use for pagers, especially when used with things like Tabs. This PR clarifies what currentPage and currentPageOffset to mean the 'selected page', and thus only get updated after a scroll has completed.

This allows us to tidy up the Tab offset modifier and make it a provided function in the library.

Internally, we've now separated the 'selected page' from the internal 'layout page' (and offset), which allows us to set the selected page only once a scroll has finished.

Fixes #280