### PR TITLE
[Pager] Use passed in width for active indicator

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
@@ -93,7 +93,7 @@ fun HorizontalPagerIndicator(
                         y = 0
                     )
                 }
-                .size(width = indicatorHeight, height = indicatorHeight)
+                .size(width = indicatorWidth, height = indicatorHeight)
                 .background(
                     color = activeColor,
                     shape = indicatorShape,
@@ -159,7 +159,7 @@ fun VerticalPagerIndicator(
                         y = ((spacing + indicatorHeight) * scrollPosition).roundToPx(),
                     )
                 }
-                .size(width = indicatorHeight, height = indicatorHeight)
+                .size(width = indicatorWidth, height = indicatorHeight)
                 .background(
                     color = activeColor,
                     shape = indicatorShape,


### PR DESCRIPTION
I've been using the paging indicator library and noticed that the width was being used for the page indicator containers, but not the active indicator.

I updated it to use the passed in width for the active indicator, instead of the height.