### PR TITLE
[Pager] Handle infinite constraints

### DIFF
--- a/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerInfiniteHeightTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerInfiniteHeightTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.pager
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsAtLeast
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@OptIn(ExperimentalPagerApi::class) // Pager is currently experimental
+@LargeTest
+@RunWith(JUnit4::class)
+class HorizontalPagerInfiniteHeightTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun horizontalPagerInScrollableColumn() {
+        rule.setContent {
+            Column(Modifier.verticalScroll(rememberScrollState())) {
+                HorizontalPager(
+                    state = rememberPagerState(pageCount = 10),
+                    modifier = Modifier
+                        // fillMaxHeight() with verticalScroll() parents means that pager will
+                        // receive infinite max height constraints which doesn't make much sense
+                        // for pagers....
+                        .fillMaxHeight()
+                        .fillMaxWidth()
+                        .testTag(TestTag)
+                ) {
+                    Box(Modifier.fillMaxWidth().height(200.dp))
+                }
+            }
+        }
+
+        val rootBounds = rule.onRoot().getUnclippedBoundsInRoot()
+
+        // Assert that HorizontalPager handled the infinite max height constraint
+        // by wrapping it's content instead.
+        rule.onNodeWithTag(TestTag)
+            .assertWidthIsEqualTo(rootBounds.width)
+            // Since the pager's content uses 200.dp height
+            .assertHeightIsAtLeast(200.dp)
+    }
+
+    companion object {
+        const val TestTag = "Pager"
+    }
+}

--- a/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerInfiniteHeightTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerInfiniteHeightTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.pager
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.width
+import androidx.test.filters.LargeTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@OptIn(ExperimentalPagerApi::class) // Pager is currently experimental
+@LargeTest
+@RunWith(JUnit4::class)
+class VerticalPagerInfiniteHeightTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun verticalPagerInScrollableRow() {
+        rule.setContent {
+            Row(Modifier.horizontalScroll(rememberScrollState())) {
+                VerticalPager(
+                    state = rememberPagerState(pageCount = 10),
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        // fillMaxWidth() with horizontalScroll() parents means that pager will
+                        // receive infinite max width constraints which doesn't make much sense
+                        // for pagers....
+                        .fillMaxWidth()
+                        .testTag(TestTag)
+                ) {
+                    Box(Modifier.fillMaxHeight().width(200.dp))
+                }
+            }
+        }
+
+        val rootBounds = rule.onRoot().getUnclippedBoundsInRoot()
+
+        // Assert that VerticalPager handled the infinite max width constraint
+        // by wrapping it's content instead.
+        rule.onNodeWithTag(TestTag)
+            // Since the pager's content uses 200.dp width
+            .assertWidthIsEqualTo(200.dp)
+            .assertHeightIsEqualTo(rootBounds.height)
+    }
+
+    companion object {
+        const val TestTag = "Pager"
+    }
+}

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerBasicSample.kt
@@ -93,7 +93,7 @@ private fun Sample() {
                 offscreenLimit = 2,
                 // Add some horizontal spacing between items
                 itemSpacing = 4.dp,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).fillMaxWidth()
             ) { page ->
                 Box {
                     // Our page content, displaying a random image

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerTabsSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerTabsSample.kt
@@ -117,7 +117,7 @@ private fun Sample() {
 
             HorizontalPager(
                 state = pagerState,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).fillMaxWidth()
             ) { page ->
                 // Our content for each page
                 Box(modifier = Modifier.fillMaxSize()) {

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerWithIndicatorSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerWithIndicatorSample.kt
@@ -91,7 +91,7 @@ private fun Sample() {
                 state = pagerState,
                 // We increase the offscreen limit, to allow pre-loading of images
                 offscreenLimit = 2,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.weight(1f).fillMaxWidth(),
             ) { page ->
                 Box {
                     // Our page content, displaying a random image

--- a/sample/src/main/java/com/google/accompanist/sample/pager/VerticalPagerBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/VerticalPagerBasicSample.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -93,7 +94,7 @@ private fun Sample() {
                 offscreenLimit = 2,
                 // Add some vertical spacing between items
                 itemSpacing = 8.dp,
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f).fillMaxHeight(),
             ) { page ->
                 Box {
                     // Our page content, displaying a random image


### PR DESCRIPTION
Current Pager blindly uses the maxHeight/Width constraints, which breaks down when the pager is given infinite max constraints.

This PR updates our measure/layout to wrap the page content by default, and then coerces that by the min constraints.

Fixes #300