### PR TITLE
Expose animation spec in animateScrollToPage()

### DIFF
--- a/pager/api/pager.api
+++ b/pager/api/pager.api
@@ -27,8 +27,8 @@ public final class com/google/accompanist/pager/PagerState : androidx/compose/fo
 	public static final field Companion Lcom/google/accompanist/pager/PagerState$Companion;
 	public fun <init> (IIF)V
 	public synthetic fun <init> (IIFILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun animateScrollToPage (IFFLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun animateScrollToPage$default (Lcom/google/accompanist/pager/PagerState;IFFLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun animateScrollToPage (IFLandroidx/compose/animation/core/AnimationSpec;FLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun animateScrollToPage$default (Lcom/google/accompanist/pager/PagerState;IFLandroidx/compose/animation/core/AnimationSpec;FLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public fun dispatchRawDelta (F)F
 	public final fun getCurrentPage ()I
 	public final fun getCurrentPageOffset ()F

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -202,6 +202,7 @@ class PagerState(
     suspend fun animateScrollToPage(
         @IntRange(from = 0) page: Int,
         @FloatRange(from = 0.0, to = 1.0) pageOffset: Float = 0f,
+        animationSpec: AnimationSpec<Float> = spring(),
         initialVelocity: Float = 0f,
     ) {
         requireCurrentPage(page, "page")
@@ -215,6 +216,7 @@ class PagerState(
             animateToPage(
                 page = page.coerceIn(0, lastPageIndex),
                 pageOffset = pageOffset.coerceIn(0f, 1f),
+                animationSpec = animationSpec,
                 initialVelocity = initialVelocity,
             )
         }


### PR DESCRIPTION
This change exposes the animationSpec parameter from `PagerState.animateToPage()` (which is private) to `PagerState.animateScrollToPage()` so that the animation can be changed as needed.