### PR TITLE
[SystemUiController] API fixes

### DIFF
--- a/docs/systemuicontroller.md
+++ b/docs/systemuicontroller.md
@@ -11,7 +11,7 @@ In your layouts you can update the system bar colors like so:
 
 ``` kotlin
 // Remember a SystemUiController
-val systemUiController = rememberAndroidSystemUiController()
+val systemUiController = rememberSystemUiController()
 val useDarkIcons = MaterialTheme.colors.isLight
 
 SideEffect {

--- a/docs/systemuicontroller.md
+++ b/docs/systemuicontroller.md
@@ -5,7 +5,7 @@
 System UI Controller provides easy-to-use utilities for updating the System UI bar colors within Jetpack Compose.
 
 ## Usage
-To control the system UI in your composables, you must need to get a [`SystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-system-ui-controller/) instance. The library provides an [`AndroidSystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-android-system-ui-controller/index.html) implementation and an associated [remember function](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/remember-android-system-ui-controller.html).
+To control the system UI in your composables, you must need to get a [`SystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-system-ui-controller/) instance. The library provides the [`rememberSystemUiController()`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/remember-system-ui-controller.html) function which returns an instance for the current system (currently only Android).
 
 In your layouts you can update the system bar colors like so:
 

--- a/docs/systemuicontroller.md
+++ b/docs/systemuicontroller.md
@@ -5,26 +5,13 @@
 System UI Controller provides easy-to-use utilities for updating the System UI bar colors within Jetpack Compose.
 
 ## Usage
-To control the system UI in your composables, you must provide a [`SystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-system-ui-controller/) instance to the [`LocalSystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-local-system-ui-controller.html)
-composition local. We provide the [`AndroidSystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-android-system-ui-controller/index.html) implementation and an associated [remember function](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/remember-android-system-ui-controller.html).
+To control the system UI in your composables, you must need to get a [`SystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-system-ui-controller/) instance. The library provides an [`AndroidSystemUiController`](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/-android-system-ui-controller/index.html) implementation and an associated [remember function](../api/systemuicontroller/systemuicontroller/com.google.accompanist.systemuicontroller/remember-android-system-ui-controller.html).
 
-This would typically be done near the top level of your composable hierarchy:
-
-``` kotlin
-setContent {
-    // Remember a controller, and provide it to the LocalSystemUiController
-    val controller = rememberAndroidSystemUiController()
-    CompositionLocalProvider(LocalSystemUiController provides controller) {
-        MyHomeScreen()
-    }
-}
-```
-
-Then in your layouts, you can update the system bar colors as necessary like so:
+In your layouts you can update the system bar colors like so:
 
 ``` kotlin
-// Get the current SystemUiController
-val systemUiController = LocalSystemUiController.current
+// Remember a SystemUiController
+val systemUiController = rememberAndroidSystemUiController()
 val useDarkIcons = MaterialTheme.colors.isLight
 
 SideEffect {

--- a/sample/src/main/java/com/google/accompanist/sample/insets/EdgeToEdgeLazyColumn.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/EdgeToEdgeLazyColumn.kt
@@ -59,7 +59,7 @@ import com.google.accompanist.insets.toPaddingValues
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
-import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 class EdgeToEdgeLazyColumn : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -81,7 +81,7 @@ class EdgeToEdgeLazyColumn : ComponentActivity() {
 
 @Composable
 private fun Sample() {
-    val systemUiController = rememberAndroidSystemUiController()
+    val systemUiController = rememberSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/insets/EdgeToEdgeLazyColumn.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/EdgeToEdgeLazyColumn.kt
@@ -37,7 +37,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.primarySurface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,7 +59,6 @@ import com.google.accompanist.insets.toPaddingValues
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
-import com.google.accompanist.systemuicontroller.LocalSystemUiController
 import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
 
 class EdgeToEdgeLazyColumn : ComponentActivity() {
@@ -73,11 +71,8 @@ class EdgeToEdgeLazyColumn : ComponentActivity() {
 
         setContent {
             AccompanistSampleTheme {
-                val controller = rememberAndroidSystemUiController()
-                CompositionLocalProvider(LocalSystemUiController provides controller) {
-                    ProvideWindowInsets {
-                        Sample()
-                    }
+                ProvideWindowInsets {
+                    Sample()
                 }
             }
         }
@@ -86,7 +81,7 @@ class EdgeToEdgeLazyColumn : ComponentActivity() {
 
 @Composable
 private fun Sample() {
-    val systemUiController = LocalSystemUiController.current
+    val systemUiController = rememberAndroidSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/insets/ImeAnimationSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/ImeAnimationSample.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,7 +48,6 @@ import com.google.accompanist.insets.rememberImeNestedScrollConnection
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
-import com.google.accompanist.systemuicontroller.LocalSystemUiController
 import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
 
 @OptIn(ExperimentalAnimatedInsets::class)
@@ -63,11 +61,8 @@ class ImeAnimationSample : ComponentActivity() {
 
         setContent {
             AccompanistSampleTheme {
-                val controller = rememberAndroidSystemUiController()
-                CompositionLocalProvider(LocalSystemUiController provides controller) {
-                    ProvideWindowInsets(windowInsetsAnimationsEnabled = true) {
-                        Sample()
-                    }
+                ProvideWindowInsets(windowInsetsAnimationsEnabled = true) {
+                    Sample()
                 }
             }
         }
@@ -79,7 +74,7 @@ private val listItems = List(40) { randomSampleImageUrl(it) }
 @OptIn(ExperimentalAnimatedInsets::class)
 @Composable
 private fun Sample() {
-    val systemUiController = LocalSystemUiController.current
+    val systemUiController = rememberAndroidSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/insets/ImeAnimationSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/ImeAnimationSample.kt
@@ -48,7 +48,7 @@ import com.google.accompanist.insets.rememberImeNestedScrollConnection
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
-import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @OptIn(ExperimentalAnimatedInsets::class)
 class ImeAnimationSample : ComponentActivity() {
@@ -74,7 +74,7 @@ private val listItems = List(40) { randomSampleImageUrl(it) }
 @OptIn(ExperimentalAnimatedInsets::class)
 @Composable
 private fun Sample() {
-    val systemUiController = rememberAndroidSystemUiController()
+    val systemUiController = rememberSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/insets/InsetsBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/InsetsBasicSample.kt
@@ -30,7 +30,6 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Face
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,7 +41,6 @@ import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.insets.navigationBarsPadding
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
-import com.google.accompanist.systemuicontroller.LocalSystemUiController
 import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
 
 class InsetsBasicSample : ComponentActivity() {
@@ -57,11 +55,8 @@ class InsetsBasicSample : ComponentActivity() {
             AccompanistSampleTheme {
                 // We need to use ProvideWindowInsets to setup the necessary listeners which
                 // power the library
-                val controller = rememberAndroidSystemUiController()
-                CompositionLocalProvider(LocalSystemUiController provides controller) {
-                    ProvideWindowInsets {
-                        Sample()
-                    }
+                ProvideWindowInsets {
+                    Sample()
                 }
             }
         }
@@ -70,7 +65,7 @@ class InsetsBasicSample : ComponentActivity() {
 
 @Composable
 private fun Sample() {
-    val systemUiController = LocalSystemUiController.current
+    val systemUiController = rememberAndroidSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/insets/InsetsBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/InsetsBasicSample.kt
@@ -41,7 +41,7 @@ import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.insets.navigationBarsPadding
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
-import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 class InsetsBasicSample : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -65,7 +65,7 @@ class InsetsBasicSample : ComponentActivity() {
 
 @Composable
 private fun Sample() {
-    val systemUiController = rememberAndroidSystemUiController()
+    val systemUiController = rememberSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/insets/InsetsFragmentSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/InsetsFragmentSample.kt
@@ -52,7 +52,7 @@ import com.google.accompanist.insets.ViewWindowInsetObserver
 import com.google.accompanist.insets.navigationBarsPadding
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
-import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 class InsetsFragmentSample : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -100,7 +100,7 @@ class InsetsFragment : Fragment() {
 
 @Composable
 private fun Sample() {
-    val systemUiController = rememberAndroidSystemUiController()
+    val systemUiController = rememberSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/insets/InsetsFragmentSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/InsetsFragmentSample.kt
@@ -52,7 +52,6 @@ import com.google.accompanist.insets.ViewWindowInsetObserver
 import com.google.accompanist.insets.navigationBarsPadding
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
-import com.google.accompanist.systemuicontroller.LocalSystemUiController
 import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
 
 class InsetsFragmentSample : FragmentActivity() {
@@ -91,11 +90,7 @@ class InsetsFragment : Fragment() {
             AccompanistSampleTheme {
                 // Instead of calling ProvideWindowInsets, we use CompositionLocalProvider to provide
                 // the WindowInsets instance from above to LocalWindowInsets
-                val controller = rememberAndroidSystemUiController()
-                CompositionLocalProvider(
-                    LocalWindowInsets provides windowInsets,
-                    LocalSystemUiController provides controller
-                ) {
+                CompositionLocalProvider(LocalWindowInsets provides windowInsets) {
                     Sample()
                 }
             }
@@ -105,7 +100,7 @@ class InsetsFragment : Fragment() {
 
 @Composable
 private fun Sample() {
-    val systemUiController = LocalSystemUiController.current
+    val systemUiController = rememberAndroidSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
     SideEffect {
         systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)

--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.graphics.Color
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Composable
-fun AndroidSystemUiControllerSample() {
+fun SystemUiControllerSample() {
     // Get the current SystemUiController
     val systemUiController = rememberSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight

--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
@@ -18,25 +18,14 @@ package com.google.accompanist.sample.systemuicontroller
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
-import com.google.accompanist.systemuicontroller.LocalSystemUiController
 import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
 
 @Composable
-fun MyApp() {
-    // Remember a controller, and provide it to the LocalSystemUiController
-    val systemUiController = rememberAndroidSystemUiController()
-    CompositionLocalProvider(LocalSystemUiController provides systemUiController) {
-        MyHomeScreen()
-    }
-}
-
-@Composable
-fun MyHomeScreen() {
+fun AndroidSystemUiControllerSample() {
     // Get the current SystemUiController
-    val systemUiController = LocalSystemUiController.current
+    val systemUiController = rememberAndroidSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
 
     SideEffect {

--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
@@ -20,12 +20,12 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
-import com.google.accompanist.systemuicontroller.rememberAndroidSystemUiController
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Composable
 fun AndroidSystemUiControllerSample() {
     // Get the current SystemUiController
-    val systemUiController = rememberAndroidSystemUiController()
+    val systemUiController = rememberSystemUiController()
     val useDarkIcons = MaterialTheme.colors.isLight
 
     SideEffect {

--- a/systemuicontroller/api/systemuicontroller.api
+++ b/systemuicontroller/api/systemuicontroller.api
@@ -1,12 +1,3 @@
-public final class com/google/accompanist/systemuicontroller/AndroidSystemUiController : com/google/accompanist/systemuicontroller/SystemUiController {
-	public static final field $stable I
-	public fun <init> (Landroid/view/View;)V
-	public fun isNavigationBarContrastEnforced ()Z
-	public fun setNavigationBarColor-Iv8Zu3U (JZZLkotlin/jvm/functions/Function1;)V
-	public fun setStatusBarColor-ek8zF_U (JZLkotlin/jvm/functions/Function1;)V
-	public fun setSystemBarsColor-Iv8Zu3U (JZZLkotlin/jvm/functions/Function1;)V
-}
-
 public abstract interface class com/google/accompanist/systemuicontroller/SystemUiController {
 	public abstract fun isNavigationBarContrastEnforced ()Z
 	public abstract fun setNavigationBarColor-Iv8Zu3U (JZZLkotlin/jvm/functions/Function1;)V
@@ -15,10 +6,7 @@ public abstract interface class com/google/accompanist/systemuicontroller/System
 }
 
 public final class com/google/accompanist/systemuicontroller/SystemUiController$DefaultImpls {
-	public static fun isNavigationBarContrastEnforced (Lcom/google/accompanist/systemuicontroller/SystemUiController;)Z
-	public static fun setNavigationBarColor-Iv8Zu3U (Lcom/google/accompanist/systemuicontroller/SystemUiController;JZZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun setNavigationBarColor-Iv8Zu3U$default (Lcom/google/accompanist/systemuicontroller/SystemUiController;JZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static fun setStatusBarColor-ek8zF_U (Lcom/google/accompanist/systemuicontroller/SystemUiController;JZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun setStatusBarColor-ek8zF_U$default (Lcom/google/accompanist/systemuicontroller/SystemUiController;JZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static fun setSystemBarsColor-Iv8Zu3U (Lcom/google/accompanist/systemuicontroller/SystemUiController;JZZLkotlin/jvm/functions/Function1;)V
 	public static synthetic fun setSystemBarsColor-Iv8Zu3U$default (Lcom/google/accompanist/systemuicontroller/SystemUiController;JZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
@@ -27,5 +15,6 @@ public final class com/google/accompanist/systemuicontroller/SystemUiController$
 public final class com/google/accompanist/systemuicontroller/SystemUiControllerKt {
 	public static final fun getLocalSystemUiController ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun rememberAndroidSystemUiController (Landroid/view/View;Landroidx/compose/runtime/Composer;II)Lcom/google/accompanist/systemuicontroller/SystemUiController;
+	public static final fun rememberSystemUiController (Landroid/view/View;Landroidx/compose/runtime/Composer;II)Lcom/google/accompanist/systemuicontroller/SystemUiController;
 }
 

--- a/systemuicontroller/api/systemuicontroller.api
+++ b/systemuicontroller/api/systemuicontroller.api
@@ -15,6 +15,6 @@ public final class com/google/accompanist/systemuicontroller/SystemUiController$
 public final class com/google/accompanist/systemuicontroller/SystemUiControllerKt {
 	public static final fun getLocalSystemUiController ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun rememberAndroidSystemUiController (Landroid/view/View;Landroidx/compose/runtime/Composer;II)Lcom/google/accompanist/systemuicontroller/SystemUiController;
-	public static final fun rememberSystemUiController (Landroid/view/View;Landroidx/compose/runtime/Composer;II)Lcom/google/accompanist/systemuicontroller/SystemUiController;
+	public static final fun rememberSystemUiController (Landroidx/compose/runtime/Composer;I)Lcom/google/accompanist/systemuicontroller/SystemUiController;
 }
 

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -37,7 +37,7 @@ import androidx.core.view.ViewCompat
  * A class which provides easy-to-use utilities for updating the System UI bar
  * colors within Jetpack Compose.
  *
- * @sample com.google.accompanist.sample.systemuicontroller.AndroidSystemUiControllerSample
+ * @sample com.google.accompanist.sample.systemuicontroller.SystemUiControllerSample
  */
 @Stable
 interface SystemUiController {
@@ -111,23 +111,22 @@ interface SystemUiController {
  * Remembers a [SystemUiController] for the current device.
  */
 @Composable
-fun rememberSystemUiController(
-    view: View = LocalView.current
-): SystemUiController = remember(view) {
-    AndroidSystemUiController(view)
+fun rememberSystemUiController(): SystemUiController {
+    val view = LocalView.current
+    return remember(view) { AndroidSystemUiController(view) }
 }
 
 @Deprecated(
     "Migrate to rememberSystemUiController()",
     ReplaceWith(
-        "rememberSystemUiController(view)",
+        "rememberSystemUiController()",
         "com.google.accompanist.systemuicontroller.rememberSystemUiController"
     )
 )
 @Composable
 fun rememberAndroidSystemUiController(
     view: View = LocalView.current
-): SystemUiController = rememberSystemUiController(view)
+): SystemUiController = remember(view) { AndroidSystemUiController(view) }
 
 /**
  * A helper class for setting the navigation and status bar colors for a [View], gracefully
@@ -199,7 +198,7 @@ internal class AndroidSystemUiController(view: View) : SystemUiController {
  * [LocalSystemUiController]. Defaults to a no-op controller; consumers should
  * [provide][androidx.compose.runtime.CompositionLocalProvider] a real one.
  *
- * @sample com.google.accompanist.sample.systemuicontroller.AndroidSystemUiControllerSample
+ * @sample com.google.accompanist.sample.systemuicontroller.SystemUiControllerSample
  */
 @Deprecated("Use rememberSystemUiController()")
 val LocalSystemUiController = staticCompositionLocalOf<SystemUiController> {

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -37,7 +37,7 @@ import androidx.core.view.ViewCompat
  * A class which provides easy-to-use utilities for updating the System UI bar
  * colors within Jetpack Compose.
  *
- * @sample com.google.accompanist.sample.systemuicontroller.MyHomeScreen
+ * @sample com.google.accompanist.sample.systemuicontroller.AndroidSystemUiControllerSample
  */
 @Stable
 interface SystemUiController {
@@ -54,7 +54,7 @@ interface SystemUiController {
         color: Color,
         darkIcons: Boolean = color.luminance() > 0.5f,
         transformColorForLightContent: (Color) -> Color = BlackScrimmed
-    ) = Unit
+    )
 
     /**
      * Set the navigation bar color.
@@ -75,7 +75,7 @@ interface SystemUiController {
         darkIcons: Boolean = color.luminance() > 0.5f,
         navigationBarContrastEnforced: Boolean = true,
         transformColorForLightContent: (Color) -> Color = BlackScrimmed
-    ) = Unit
+    )
 
     /**
      * Set the status and navigation bars to [color].
@@ -104,26 +104,38 @@ interface SystemUiController {
      *
      * @return true, if API is 29+ and the system is ensuring contrast, false otherwise.
      */
-    fun isNavigationBarContrastEnforced(): Boolean = false
+    fun isNavigationBarContrastEnforced(): Boolean
 }
 
 /**
- * Remembers a [SystemUiController] which supports Android devices.
+ * Remembers a [SystemUiController] for the current device.
  */
 @Composable
-fun rememberAndroidSystemUiController(
+fun rememberSystemUiController(
     view: View = LocalView.current
 ): SystemUiController = remember(view) {
     AndroidSystemUiController(view)
 }
 
+@Deprecated(
+    "Migrate to rememberSystemUiController()",
+    ReplaceWith(
+        "rememberSystemUiController(view)",
+        "com.google.accompanist.systemuicontroller.rememberSystemUiController"
+    )
+)
+@Composable
+fun rememberAndroidSystemUiController(
+    view: View = LocalView.current
+): SystemUiController = rememberSystemUiController(view)
+
 /**
  * A helper class for setting the navigation and status bar colors for a [View], gracefully
  * degrading behavior based upon API level.
  *
- * Typically you would use [rememberAndroidSystemUiController] to remember an instance of this.
+ * Typically you would use [rememberSystemUiController] to remember an instance of this.
  */
-class AndroidSystemUiController(view: View) : SystemUiController {
+internal class AndroidSystemUiController(view: View) : SystemUiController {
     private val window = view.context.findWindow()
     private val windowInsetsController = ViewCompat.getWindowInsetsController(view)
 
@@ -189,7 +201,7 @@ class AndroidSystemUiController(view: View) : SystemUiController {
  *
  * @sample com.google.accompanist.sample.systemuicontroller.AndroidSystemUiControllerSample
  */
-@Deprecated("Use rememberAndroidSystemUiController()")
+@Deprecated("Use rememberSystemUiController()")
 val LocalSystemUiController = staticCompositionLocalOf<SystemUiController> {
     NoOpSystemUiController
 }
@@ -202,4 +214,19 @@ private val BlackScrimmed: (Color) -> Color = { original ->
 /**
  * A no-op implementation, useful as the default value for [LocalSystemUiController].
  */
-private object NoOpSystemUiController : SystemUiController
+private object NoOpSystemUiController : SystemUiController {
+    override fun setStatusBarColor(
+        color: Color,
+        darkIcons: Boolean,
+        transformColorForLightContent: (Color) -> Color
+    ) = Unit
+
+    override fun setNavigationBarColor(
+        color: Color,
+        darkIcons: Boolean,
+        navigationBarContrastEnforced: Boolean,
+        transformColorForLightContent: (Color) -> Color
+    ) = Unit
+
+    override fun isNavigationBarContrastEnforced(): Boolean = false
+}

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -187,8 +187,9 @@ class AndroidSystemUiController(view: View) : SystemUiController {
  * [LocalSystemUiController]. Defaults to a no-op controller; consumers should
  * [provide][androidx.compose.runtime.CompositionLocalProvider] a real one.
  *
- * @sample com.google.accompanist.sample.systemuicontroller.MyApp
+ * @sample com.google.accompanist.sample.systemuicontroller.AndroidSystemUiControllerSample
  */
+@Deprecated("Use rememberAndroidSystemUiController()")
 val LocalSystemUiController = staticCompositionLocalOf<SystemUiController> {
     NoOpSystemUiController
 }


### PR DESCRIPTION
- Deprecated `Local SystemUiController`. There's no real need for a composition local to store the `SystemUiController`. They're infrequently enough that simply using `rememberSystemUiController()` as necessary works.
- Hid `AndroidSystemUiController` class.
- Renamed `rememberAndroidSystemUiController()` to `rememberSystemUiController()`