### PR TITLE
Fix docs build actions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,25 +1,37 @@
 name: Publish docs
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - v*
 
 jobs:
   deploy_docs:
     runs-on: ubuntu-latest
     env:
-      JAVA_TOOL_OPTIONS: -Xmx5120m
-      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dkotlin.compiler.execution.strategy=in-process
       TERM: dumb
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
       - name: set up JDK
         uses: actions/setup-java@v1
         with:
           java-version: 11
+
+      - name: Generate cache key
+        run: ./checksum.sh checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/generate_docs.sh
+++ b/generate_docs.sh
@@ -32,7 +32,7 @@ sed -i.bak 's/$dokka.linkExtension:md/$dokka.linkExtension:html/g' package-list-
 # Clear out the old API docs
 [ -d docs/api ] && rm -r docs/api
 # Build the docs with dokka
-./gradlew clean dokkaHtmlMultiModule
+./gradlew clean dokkaHtmlMultiModule || exit 1
 
 # Re-word the Dokka call out
 find docs/api/ -type f -name '*.html' -exec sed -i -e 's/Sponsored and developed/Documentation generated/g' {} \;


### PR DESCRIPTION
Highlighted by #331. 

The [docs push](https://github.com/google/accompanist/actions/runs/7268044290) for v0.7.1 reported as successful, but actually failed:

```
e: org.jetbrains.kotlin.backend.common.BackendException: Backend Internal error: Exception during code generation
File being compiled: /home/runner/work/accompanist/accompanist/imageloading-core/src/main/java/com/google/accompanist/imageloading/AndroidDrawablePainter.kt
The root cause java.lang.OutOfMemoryError was thrown at: unknown
```