### PR TITLE
Update currentPager after calling scrollToPage()

### DIFF
--- a/pager/src/androidTest/java/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/PagerTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.performScrollTo
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.produceIn
 import org.junit.Ignore
@@ -178,6 +179,34 @@ abstract class PagerTest {
 
         // Cancel the channel
         pageChangedChannel.cancel()
+    }
+
+    @Test
+    fun scrollToPage() = suspendTest {
+        val pagerState = setPagerContent(pageCount = 10)
+
+        pagerState.scrollToPage(3)
+        assertThat(pagerState.currentPage).isEqualTo(3)
+        assertPagerLayout(3)
+
+        pagerState.scrollToPage(0)
+        assertThat(pagerState.currentPage).isEqualTo(0)
+        assertPagerLayout(0)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    @Ignore("https://issuetracker.google.com/185228750")
+    fun animateScrollToPage() = suspendTest {
+        val pagerState = setPagerContent(pageCount = 10)
+
+        pagerState.animateScrollToPage(3)
+        assertThat(pagerState.currentPage).isEqualTo(3)
+        assertPagerLayout(3)
+
+        pagerState.animateScrollToPage(0)
+        assertThat(pagerState.currentPage).isEqualTo(0)
+        assertPagerLayout(0)
     }
 
     @Test

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -245,6 +245,7 @@ class PagerState(
         scroll {
             currentLayoutPage = page
             currentLayoutPageOffset = pageOffset
+            snapToNearestPage()
         }
     }
 


### PR DESCRIPTION
We were missing a `snapToNearestPage()`

Fixes #337