### PR TITLE
Fix LoadPainter not fetching image with no explicit size

### DIFF
--- a/coil/src/androidTest/java/com/google/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/com/google/accompanist/coil/CoilTest.kt
@@ -20,6 +20,7 @@ import android.graphics.drawable.ShapeDrawable
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -316,6 +317,28 @@ class CoilTest {
                 contentDescription = null,
                 modifier = Modifier.testTag(CoilTestTags.Image),
             )
+        }
+
+        composeTestRule.onNodeWithTag(CoilTestTags.Image)
+            .assertWidthIsAtLeast(1.dp)
+            .assertHeightIsAtLeast(1.dp)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun lazycolumn_nosize() {
+        composeTestRule.setContent {
+            LazyColumn {
+                item {
+                    Image(
+                        painter = rememberCoilPainter(server.url("/image")),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .fillParentMaxWidth()
+                            .testTag(CoilTestTags.Image),
+                    )
+                }
+            }
         }
 
         composeTestRule.onNodeWithTag(CoilTestTags.Image)

--- a/glide/src/androidTest/java/com/google/accompanist/glide/GlideTest.kt
+++ b/glide/src/androidTest/java/com/google/accompanist/glide/GlideTest.kt
@@ -20,6 +20,7 @@ import android.graphics.drawable.ShapeDrawable
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -320,6 +321,36 @@ class GlideTest {
                 contentDescription = null,
                 modifier = Modifier.testTag(GlideTestTags.Image),
             )
+        }
+
+        // Wait until the first image loads
+        composeTestRule.waitUntil(10_000) { requestCompleted }
+
+        composeTestRule.onNodeWithTag(GlideTestTags.Image)
+            .assertWidthIsAtLeast(1.dp)
+            .assertHeightIsAtLeast(1.dp)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun lazycolumn_nosize() {
+        var requestCompleted by mutableStateOf(false)
+
+        composeTestRule.setContent {
+            val painter = rememberGlidePainter(server.url("/image").toString())
+            LaunchedOnRequestComplete(painter) { requestCompleted = true }
+
+            LazyColumn {
+                item {
+                    Image(
+                        painter = painter,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .fillParentMaxWidth()
+                            .testTag(GlideTestTags.Image),
+                    )
+                }
+            }
         }
 
         // Wait until the first image loads

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/LoadPainter.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/LoadPainter.kt
@@ -41,8 +41,11 @@ import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -156,6 +159,9 @@ class LoadPainter<R> internal constructor(
     internal var painter by mutableStateOf<Painter>(EmptyPainter)
     internal var transitionColorFilter by mutableStateOf<ColorFilter?>(null)
 
+    // CoroutineScope for the current request
+    private var requestCoroutineScope: CoroutineScope? = null
+
     /**
      * The current request object.
      */
@@ -180,10 +186,7 @@ class LoadPainter<R> internal constructor(
      * Our size to use when performing the image load request. This is internal due to
      * [ImageSuchDeprecated].
      */
-    internal var requestSize by mutableStateOf(IntSize(-1, -1))
-
-    // Current request job
-    private var job: Job? = null
+    internal var requestSize by mutableStateOf<IntSize?>(null)
 
     override val intrinsicSize: Size
         get() = painter.intrinsicSize
@@ -227,31 +230,48 @@ class LoadPainter<R> internal constructor(
     }
 
     override fun onAbandoned() {
-        // We've been abandoned from composition, so cancel our request handling coroutine
-        job?.cancel()
-        job = null
+        // We've been abandoned from composition, so cancel our request scope
+        requestCoroutineScope?.cancel()
+        requestCoroutineScope = null
     }
 
     override fun onForgotten() {
-        // We've been forgotten from composition, so cancel our request handling coroutine
-        job?.cancel()
-        job = null
+        // We've been forgotten from composition, so cancel our request scope
+        requestCoroutineScope?.cancel()
+        requestCoroutineScope = null
     }
 
     override fun onRemembered() {
-        // Cancel any on-going job (this shouldn't really happen anyway)
-        job?.cancel()
+        // Cancel any on-going scope (this shouldn't really happen anyway)
+        requestCoroutineScope?.cancel()
+
+        // Create a new CoroutineScope for the current request. We use the provided
+        // `coroutineScope` as the source for everything, but we create a new child Job.
+        // This allows us cancel the scope without affecting the parent scope's job.
+        val scope = coroutineScope.coroutineContext.let { context ->
+            CoroutineScope(context + Job(context[Job]))
+        }.also { requestCoroutineScope = it }
 
         // We've been remembered, so launch a coroutine to observe the current request object,
         // and the request size. Whenever either of these values change, the collectLatest block
         // will run and execute the image load (with any on-going request cancelled).
-        job = coroutineScope.launch {
+        scope.launch {
             combine(
                 snapshotFlow { request },
-                snapshotFlow { requestSize },
+                snapshotFlow { requestSize }.filterNotNull(),
                 transform = { request, size -> request to size }
             ).collectLatest { (request, size) ->
                 execute(request, size)
+            }
+        }
+
+        // Our fail-safe. If we don't receive an appropriate size from `onDraw()` we update the
+        // request size to be -1, -1 which will load the original size image.
+        // The ideal fix for this is waiting on https://issuetracker.google.com/186012457
+        scope.launch {
+            delay(32) // 32ms should be enough time for measure/layout/draw to happen.
+            if (requestSize == null) {
+                requestSize = IntSize(-1, -1)
             }
         }
     }

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/LoadPainter.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/LoadPainter.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -181,7 +180,7 @@ class LoadPainter<R> internal constructor(
      * Our size to use when performing the image load request. This is internal due to
      * [ImageSuchDeprecated].
      */
-    internal var requestSize by mutableStateOf<IntSize?>(null)
+    internal var requestSize by mutableStateOf(IntSize(-1, -1))
 
     // Current request job
     private var job: Job? = null
@@ -249,7 +248,7 @@ class LoadPainter<R> internal constructor(
         job = coroutineScope.launch {
             combine(
                 snapshotFlow { request },
-                snapshotFlow { requestSize }.filterNotNull(),
+                snapshotFlow { requestSize },
                 transform = { request, size -> request to size }
             ).collectLatest { (request, size) ->
                 execute(request, size)


### PR DESCRIPTION
We now default the size to be -1, -1, which means that we load the full size image. If a draw happens (due to us having a size), then the request size is overwritten and we load that instead.