### PR TITLE
[SwipeRefresh] Increase SwipeRefreshIndicator elevation

### DIFF
--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
@@ -112,7 +112,7 @@ fun SwipeRefreshIndicator(
     shape: Shape = MaterialTheme.shapes.small.copy(CornerSize(percent = 50)),
     refreshingOffset: Dp = 16.dp,
     largeIndication: Boolean = false,
-    elevation: Dp = 4.dp,
+    elevation: Dp = 6.dp,
 ) {
     val adjustedElevation = when {
         state.isRefreshing -> elevation


### PR DESCRIPTION
Previously we used a default of 4.dp, which is looking slightly too faint. 6.dp feels like a good value, both in light and dark themes. 

![light](https://user-images.githubusercontent.com/227486/115701968-44b78d80-a360-11eb-8cf6-3970c01cec12.png)
![dark](https://user-images.githubusercontent.com/227486/115701972-45e8ba80-a360-11eb-8077-69962f0303da.png)

