### PR TITLE
[Coil] Fix lazycolumn_nosize on CI

### DIFF
--- a/coil/src/androidTest/java/com/google/accompanist/coil/CoilIdlingResource.kt
+++ b/coil/src/androidTest/java/com/google/accompanist/coil/CoilIdlingResource.kt
@@ -29,6 +29,8 @@ import coil.request.ImageResult
 class CoilIdlingResource : EventListener, IdlingResource {
     private val ongoingRequests = mutableSetOf<ImageRequest>()
 
+    var finishedRequests = 0
+
     override val isIdleNow: Boolean
         get() = ongoingRequests.isEmpty()
 
@@ -42,9 +44,11 @@ class CoilIdlingResource : EventListener, IdlingResource {
 
     override fun onError(request: ImageRequest, throwable: Throwable) {
         ongoingRequests.remove(request)
+        finishedRequests++
     }
 
     override fun onSuccess(request: ImageRequest, metadata: ImageResult.Metadata) {
         ongoingRequests.remove(request)
+        finishedRequests++
     }
 }

--- a/coil/src/androidTest/java/com/google/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/com/google/accompanist/coil/CoilTest.kt
@@ -82,7 +82,7 @@ class CoilTest {
     // Our MockWebServer. We use a response delay to simulate real-world conditions
     private val server = ImageMockWebServer()
 
-    private val idlingResource = CoilIdlingResource()
+    private val coilRequestTracker = CoilIdlingResource()
 
     @Before
     fun setup() {
@@ -93,17 +93,17 @@ class CoilTest {
         val imageLoader = ImageLoader.Builder(composeTestRule.activity.applicationContext)
             .diskCachePolicy(CachePolicy.DISABLED)
             .memoryCachePolicy(CachePolicy.DISABLED)
-            .eventListener(idlingResource)
+            .eventListener(coilRequestTracker)
             .build()
 
         Coil.setImageLoader(imageLoader)
 
-        composeTestRule.registerIdlingResource(idlingResource)
+        composeTestRule.registerIdlingResource(coilRequestTracker)
     }
 
     @After
     fun teardown() {
-        composeTestRule.unregisterIdlingResource(idlingResource)
+        composeTestRule.unregisterIdlingResource(coilRequestTracker)
 
         // Shutdown our mock web server
         server.shutdown()
@@ -340,6 +340,8 @@ class CoilTest {
                 }
             }
         }
+
+        composeTestRule.waitUntil { coilRequestTracker.finishedRequests > 0 }
 
         composeTestRule.onNodeWithTag(CoilTestTags.Image)
             .assertWidthIsAtLeast(1.dp)


### PR DESCRIPTION
Works fine locally, but there must be a race condition
when running on slower machines (i.e. CI).