### PR TITLE
[Insets] Fix attach state change listener not being removed

### DIFF
--- a/insets/src/main/java/com/google/accompanist/insets/Insets.kt
+++ b/insets/src/main/java/com/google/accompanist/insets/Insets.kt
@@ -373,10 +373,6 @@ class ViewWindowInsetObserver(private val view: View) {
 
         // Add an OnAttachStateChangeListener to request an inset pass each time we're attached
         // to the window
-        val attachListener = object : View.OnAttachStateChangeListener {
-            override fun onViewAttachedToWindow(v: View) = v.requestApplyInsets()
-            override fun onViewDetachedFromWindow(v: View) = Unit
-        }
         view.addOnAttachStateChangeListener(attachListener)
 
         if (windowInsetsAnimationsEnabled) {


### PR DESCRIPTION
We were accidentally adding a new attach listener every time, which meant that the one being removed wasn't actually attached.

Fixes #364