### PR TITLE
[Pager] Re-enable animateScrollToPage() test

### DIFF
--- a/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -159,6 +160,8 @@ class HorizontalPagerTest(
     ): PagerState {
         val pagerState = PagerState(pageCount = pageCount)
         composeTestRule.setContent(layoutDirection) {
+            applierScope = rememberCoroutineScope()
+
             HorizontalPager(
                 state = pagerState,
                 itemSpacing = itemSpacingDp.dp,

--- a/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -122,6 +123,8 @@ class VerticalPagerTest(
         val pagerState = PagerState(pageCount = pageCount)
         // Stick to LTR for vertical tests
         composeTestRule.setContent(LayoutDirection.Ltr) {
+            applierScope = rememberCoroutineScope()
+
             VerticalPager(
                 state = pagerState,
                 offscreenLimit = offscreenLimit,


### PR DESCRIPTION
Using a workaround for https://issuetracker.google.com/issues/179492185