### PR TITLE
[SwipeRefresh] Add clipIndicatorToPadding parameter

### DIFF
--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshContentPaddingSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshContentPaddingSample.kt
@@ -99,6 +99,8 @@ private fun Sample() {
                 onRefresh = { refreshing = true },
                 // Shift the indicator to match the list content padding
                 indicatorPadding = contentPadding,
+                // We want the indicator to draw within the padding
+                clipIndicatorToPadding = false,
                 // Tweak the indicator to scale up/down
                 indicator = { state, refreshTriggerDistance ->
                     SwipeRefreshIndicator(

--- a/swiperefresh/api/current.api
+++ b/swiperefresh/api/current.api
@@ -9,7 +9,7 @@ package com.google.accompanist.swiperefresh {
   }
 
   public final class SwipeRefreshKt {
-    method @androidx.compose.runtime.Composable public static void SwipeRefresh-GdvqWcI(com.google.accompanist.swiperefresh.SwipeRefreshState state, kotlin.jvm.functions.Function0<kotlin.Unit> onRefresh, optional androidx.compose.ui.Modifier modifier, optional boolean swipeEnabled, optional float refreshTriggerDistance, optional androidx.compose.ui.Alignment indicatorAlignment, optional androidx.compose.foundation.layout.PaddingValues indicatorPadding, optional kotlin.jvm.functions.Function2<? super com.google.accompanist.swiperefresh.SwipeRefreshState,? super androidx.compose.ui.unit.Dp,kotlin.Unit> indicator, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void SwipeRefresh-NapciQ8(com.google.accompanist.swiperefresh.SwipeRefreshState state, kotlin.jvm.functions.Function0<kotlin.Unit> onRefresh, optional androidx.compose.ui.Modifier modifier, optional boolean swipeEnabled, optional float refreshTriggerDistance, optional androidx.compose.ui.Alignment indicatorAlignment, optional androidx.compose.foundation.layout.PaddingValues indicatorPadding, optional kotlin.jvm.functions.Function2<? super com.google.accompanist.swiperefresh.SwipeRefreshState,? super androidx.compose.ui.unit.Dp,kotlin.Unit> indicator, optional boolean clipIndicatorToPadding, kotlin.jvm.functions.Function0<kotlin.Unit> content);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.swiperefresh.SwipeRefreshState rememberSwipeRefreshState(boolean isRefreshing);
   }
 


### PR DESCRIPTION
We now clip the indicator to the bounds of the content, or the indicatorPadding, depending on what value is provided.

Fixes #377