### PR TITLE
[Image loading] Support placeholder drawables

### DIFF
--- a/coil/src/androidTest/java/com/google/accompanist/coil/DeprecatedCoilTest.kt
+++ b/coil/src/androidTest/java/com/google/accompanist/coil/DeprecatedCoilTest.kt
@@ -19,7 +19,6 @@ package com.google.accompanist.coil
 import android.graphics.drawable.ShapeDrawable
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -37,7 +36,6 @@ import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
 import androidx.test.filters.LargeTest
 import androidx.test.filters.SdkSuppress
@@ -59,7 +57,6 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
 import org.junit.Before
@@ -67,8 +64,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 @Suppress("DEPRECATION") // This is testing the deprecated functions
@@ -479,50 +474,6 @@ class DeprecatedCoilTest {
             .assertIsDisplayed()
             .captureToImage()
             .assertPixels(Color.Cyan, 0.05f)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @Test
-    fun loading_slot() {
-        val loadLatch = CountDownLatch(1)
-
-        // Create a test dispatcher and immediately pause it
-        val dispatcher = TestCoroutineDispatcher()
-        dispatcher.pauseDispatcher()
-
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        val imageLoader = ImageLoader.Builder(context)
-            // Load on our test dispatcher
-            .dispatcher(dispatcher)
-            // Disable memory cache. If the item is in the cache, the fetch is
-            // synchronous and the dispatcher pause has no effect
-            .memoryCachePolicy(CachePolicy.DISABLED)
-            .build()
-
-        composeTestRule.setContent {
-            CoilImage(
-                data = server.url("/image"),
-                imageLoader = imageLoader,
-                contentDescription = null,
-                modifier = Modifier.size(128.dp, 128.dp),
-                loading = { Text(text = "Loading") },
-                onRequestCompleted = { loadLatch.countDown() }
-            )
-        }
-
-        // Assert that the loading component is displayed
-        composeTestRule.onNodeWithText("Loading").assertIsDisplayed()
-
-        // Now resume the dispatcher to start the Coil request
-        dispatcher.resumeDispatcher()
-
-        // We now wait for the request to complete
-        loadLatch.await(5, TimeUnit.SECONDS)
-
-        // And assert that the loading component no longer exists
-        composeTestRule.onNodeWithText("Loading").assertDoesNotExist()
-
-        dispatcher.cleanupTestCoroutines()
     }
 
     @Test

--- a/coil/src/main/java/com/google/accompanist/coil/Coil.kt
+++ b/coil/src/main/java/com/google/accompanist/coil/Coil.kt
@@ -139,7 +139,9 @@ internal class CoilLoader(
             requestBuilder?.invoke(this, size)
         }.target(
             onStart = { placeholder ->
-                launch { send(ImageLoadState.Loading(placeholder, request)) }
+                launch {
+                    if (!isClosedForSend) send(ImageLoadState.Loading(placeholder, request))
+                }
             }
         ).build()
 
@@ -159,7 +161,9 @@ internal class CoilLoader(
             else -> return@channelFlow
         }
 
-        send(imageLoader.execute(sizedRequest).toResult(request))
+        val result = imageLoader.execute(sizedRequest).toResult(request)
+
+        if (!isClosedForSend) send(result)
     }
 }
 

--- a/coil/src/main/java/com/google/accompanist/coil/DeprecatedCoil.kt
+++ b/coil/src/main/java/com/google/accompanist/coil/DeprecatedCoil.kt
@@ -314,7 +314,7 @@ fun CoilImage(
                 )
             }
             is ImageLoadState.Error -> if (error != null) error(imageState)
-            ImageLoadState.Loading -> if (loading != null) loading()
+            is ImageLoadState.Loading -> if (loading != null) loading()
             else -> Unit
         }
     }

--- a/glide/src/androidTest/java/com/google/accompanist/glide/DeprecatedGlideTest.kt
+++ b/glide/src/androidTest/java/com/google/accompanist/glide/DeprecatedGlideTest.kt
@@ -21,7 +21,6 @@ import android.graphics.drawable.ShapeDrawable
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Text
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,7 +39,6 @@ import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.test.filters.LargeTest
@@ -149,7 +147,9 @@ class DeprecatedGlideTest {
             GlideImage(
                 data = server.url("/image").toString(),
                 contentDescription = null,
-                modifier = Modifier.size(128.dp, 128.dp).testTag(GlideTestTags.Image),
+                modifier = Modifier
+                    .size(128.dp, 128.dp)
+                    .testTag(GlideTestTags.Image),
                 onRequestCompleted = { requestCompleted = true }
             )
         }
@@ -172,7 +172,9 @@ class DeprecatedGlideTest {
             GlideImage(
                 data = resourceUri(R.drawable.red_rectangle),
                 contentDescription = null,
-                modifier = Modifier.size(128.dp, 128.dp).testTag(GlideTestTags.Image),
+                modifier = Modifier
+                    .size(128.dp, 128.dp)
+                    .testTag(GlideTestTags.Image),
                 onRequestCompleted = { requestCompleted = true }
             )
         }
@@ -199,7 +201,9 @@ class DeprecatedGlideTest {
             GlideImage(
                 data = data.toString(),
                 contentDescription = null,
-                modifier = Modifier.size(128.dp, 128.dp).testTag(GlideTestTags.Image),
+                modifier = Modifier
+                    .size(128.dp, 128.dp)
+                    .testTag(GlideTestTags.Image),
                 onRequestCompleted = { loadCompleteSignal = true }
             )
         }
@@ -241,7 +245,9 @@ class DeprecatedGlideTest {
             GlideImage(
                 data = server.url("/red").toString(),
                 contentDescription = null,
-                modifier = Modifier.size(size).testTag(GlideTestTags.Image),
+                modifier = Modifier
+                    .size(size)
+                    .testTag(GlideTestTags.Image),
                 onRequestCompleted = { loadCompleteSignal.offer(it) }
             )
         }
@@ -344,7 +350,9 @@ class DeprecatedGlideTest {
             GlideImage(
                 data = server.url("/noimage").toString(),
                 contentDescription = null,
-                modifier = Modifier.size(128.dp, 128.dp).testTag(GlideTestTags.Image),
+                modifier = Modifier
+                    .size(128.dp, 128.dp)
+                    .testTag(GlideTestTags.Image),
                 onRequestCompleted = { requestCompleted = true }
             )
         }
@@ -425,7 +433,9 @@ class DeprecatedGlideTest {
         composeTestRule.setContent {
             GlideImage(
                 data = server.url("/image").toString(),
-                modifier = Modifier.size(128.dp, 128.dp).testTag(GlideTestTags.Image),
+                modifier = Modifier
+                    .size(128.dp, 128.dp)
+                    .testTag(GlideTestTags.Image),
                 onRequestCompleted = { requestCompleted = true }
             ) {
                 // Return an Image which just draws cyan
@@ -448,37 +458,6 @@ class DeprecatedGlideTest {
     }
 
     @Test
-    fun loading_slot() = runBlockingTest {
-        var requestCompleted by mutableStateOf(false)
-
-        // Create a test dispatcher and immediately pause it
-        pauseDispatcher()
-
-        composeTestRule.setContent {
-            GlideImage(
-                data = server.url("/image").toString(),
-                contentDescription = null,
-                modifier = Modifier.size(128.dp, 128.dp),
-                loading = { Text(text = "Loading") },
-                onRequestCompleted = { requestCompleted = true }
-            )
-        }
-
-        // Assert that the loading component is displayed
-        composeTestRule.onNodeWithText("Loading").assertIsDisplayed()
-
-        // Now resume the dispatcher to start the Glide request
-        resumeDispatcher()
-
-        // We now wait for the request to complete
-        composeTestRule.waitUntil(10_000) { requestCompleted }
-        composeTestRule.waitForIdle()
-
-        // And assert that the loading component no longer exists
-        composeTestRule.onNodeWithText("Loading").assertDoesNotExist()
-    }
-
-    @Test
     @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
     fun error_slot() {
         var requestCompleted by mutableStateOf(false)
@@ -495,7 +474,9 @@ class DeprecatedGlideTest {
                     )
                 },
                 contentDescription = null,
-                modifier = Modifier.size(128.dp, 128.dp).testTag(GlideTestTags.Image),
+                modifier = Modifier
+                    .size(128.dp, 128.dp)
+                    .testTag(GlideTestTags.Image),
                 onRequestCompleted = { requestCompleted = true }
             )
         }

--- a/glide/src/androidTest/java/com/google/accompanist/glide/DeprecatedGlideTest.kt
+++ b/glide/src/androidTest/java/com/google/accompanist/glide/DeprecatedGlideTest.kt
@@ -467,7 +467,7 @@ class DeprecatedGlideTest {
         // Assert that the loading component is displayed
         composeTestRule.onNodeWithText("Loading").assertIsDisplayed()
 
-        // Now resume the dispatcher to start the Coil request
+        // Now resume the dispatcher to start the Glide request
         resumeDispatcher()
 
         // We now wait for the request to complete

--- a/glide/src/main/java/com/google/accompanist/glide/DeprecatedGlide.kt
+++ b/glide/src/main/java/com/google/accompanist/glide/DeprecatedGlide.kt
@@ -245,7 +245,7 @@ fun GlideImage(
                 )
             }
             is ImageLoadState.Error -> if (error != null) error(imageState)
-            ImageLoadState.Loading -> if (loading != null) loading()
+            is ImageLoadState.Loading -> if (loading != null) loading()
             else -> Unit
         }
     }

--- a/glide/src/main/java/com/google/accompanist/glide/Glide.kt
+++ b/glide/src/main/java/com/google/accompanist/glide/Glide.kt
@@ -17,6 +17,8 @@
 package com.google.accompanist.glide
 
 import android.graphics.drawable.Drawable
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,7 +45,10 @@ import com.google.accompanist.imageloading.Loader
 import com.google.accompanist.imageloading.ShouldRefetchOnSizeChange
 import com.google.accompanist.imageloading.rememberLoadPainter
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Composition local containing the preferred [RequestManager] to use
@@ -118,34 +123,39 @@ internal class GlideLoader(
     var requestManager by mutableStateOf(requestManager)
     var requestBuilder by mutableStateOf(requestBuilder)
 
+    private val handler = Handler(Looper.getMainLooper())
+
+    /**
+     * Don't remove the explicit type `<ImageLoadState>` on [callbackFlow]. The IR compiler
+     * doesn't like the implicit type.
+     */
+    @Suppress("RemoveExplicitTypeArguments")
     @OptIn(ExperimentalCoroutinesApi::class)
-    override suspend fun load(
+    override fun load(
         request: Any,
         size: IntSize
-    ): ImageLoadState = suspendCancellableCoroutine { cont ->
+    ): Flow<ImageLoadState> = callbackFlow<ImageLoadState> {
         var failException: Throwable? = null
 
         val target = object : EmptyCustomTarget(
             if (size.width > 0) size.width else Target.SIZE_ORIGINAL,
             if (size.height > 0) size.height else Target.SIZE_ORIGINAL
         ) {
+            override fun onLoadStarted(placeholder: Drawable?) {
+                sendBlocking(ImageLoadState.Loading(placeholder, request))
+            }
+
             override fun onLoadFailed(errorDrawable: Drawable?) {
-                if (cont.isCompleted) {
-                    // If we've already completed, ignore this
-                    return
-                }
-
-                val result = ImageLoadState.Error(
-                    result = errorDrawable,
-                    request = request,
-                    throwable = failException
-                        ?: IllegalArgumentException("Error while loading $request")
+                sendBlocking(
+                    ImageLoadState.Error(
+                        result = errorDrawable,
+                        request = request,
+                        throwable = failException
+                            ?: IllegalArgumentException("Error while loading $request")
+                    )
                 )
-
-                cont.resume(result) {
-                    // Clear any resources from the target if cancelled
-                    requestManager.clear(this)
-                }
+                // Close the channel[Flow]
+                channel.close()
             }
         }
 
@@ -157,22 +167,9 @@ internal class GlideLoader(
                 dataSource: com.bumptech.glide.load.DataSource,
                 isFirstResource: Boolean
             ): Boolean {
-                if (cont.isCompleted) {
-                    // If we've already completed, ignore this
-                    return true
-                }
-
-                val result = ImageLoadState.Success(
-                    result = drawable,
-                    request = request,
-                    source = dataSource.toDataSource()
-                )
-
-                cont.resume(result) {
-                    // Clear any resources from the target if cancelled
-                    requestManager.clear(target)
-                }
-
+                sendBlocking(ImageLoadState.Success(drawable, dataSource.toDataSource(), request))
+                // Close the channel[Flow]
+                channel.close()
                 // Return true so that the target doesn't receive the drawable
                 return true
             }
@@ -198,9 +195,11 @@ internal class GlideLoader(
             .addListener(listener)
             .into(target)
 
-        // If we're cancelled, clear the request from Glide
-        cont.invokeOnCancellation {
-            requestManager.clear(target)
+        // When we're cancelled/closed, clear the request from Glide
+        awaitClose {
+            // Unfortunately we need to post the clear. Glide will crash if the close happens
+            // in the same call frame as the Target calls above (happens in testing)
+            handler.post { requestManager.clear(target) }
         }
     }
 }

--- a/imageloading-core/api/current.api
+++ b/imageloading-core/api/current.api
@@ -24,21 +24,28 @@ package com.google.accompanist.imageloading {
   }
 
   public static final class ImageLoadState.Error extends com.google.accompanist.imageloading.ImageLoadState {
-    ctor public ImageLoadState.Error(android.graphics.drawable.Drawable? result, Object request, Throwable throwable);
-    method public android.graphics.drawable.Drawable? component1();
-    method public Object component2();
-    method public Throwable component3();
-    method public com.google.accompanist.imageloading.ImageLoadState.Error copy(android.graphics.drawable.Drawable? result, Object request, Throwable throwable);
+    ctor public ImageLoadState.Error(Object request, android.graphics.drawable.Drawable? result, Throwable? throwable);
+    method public Object component1();
+    method public android.graphics.drawable.Drawable? component2();
+    method public Throwable? component3();
+    method public com.google.accompanist.imageloading.ImageLoadState.Error copy(Object request, android.graphics.drawable.Drawable? result, Throwable? throwable);
     method public Object getRequest();
     method public android.graphics.drawable.Drawable? getResult();
-    method public Throwable getThrowable();
+    method public Throwable? getThrowable();
     property public final Object request;
     property public final android.graphics.drawable.Drawable? result;
-    property public final Throwable throwable;
+    property public final Throwable? throwable;
   }
 
   public static final class ImageLoadState.Loading extends com.google.accompanist.imageloading.ImageLoadState {
-    field public static final com.google.accompanist.imageloading.ImageLoadState.Loading INSTANCE;
+    ctor public ImageLoadState.Loading(android.graphics.drawable.Drawable? placeholder, Object request);
+    method public android.graphics.drawable.Drawable? component1();
+    method public Object component2();
+    method public com.google.accompanist.imageloading.ImageLoadState.Loading copy(android.graphics.drawable.Drawable? placeholder, Object request);
+    method public android.graphics.drawable.Drawable? getPlaceholder();
+    method public Object getRequest();
+    property public final android.graphics.drawable.Drawable? placeholder;
+    property public final Object request;
   }
 
   public static final class ImageLoadState.Success extends com.google.accompanist.imageloading.ImageLoadState {
@@ -85,8 +92,8 @@ package com.google.accompanist.imageloading {
     method @androidx.compose.runtime.Composable public static <R> com.google.accompanist.imageloading.LoadPainter<R> rememberLoadPainter(com.google.accompanist.imageloading.Loader<R> loader, R? request, com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange, optional boolean fadeIn, optional int fadeInDurationMs, optional @DrawableRes int previewPlaceholder);
   }
 
-  @androidx.compose.runtime.Stable public interface Loader<R> {
-    method public suspend Object? load-X1Y6Dhk(R? request, long size, kotlin.coroutines.Continuation<? super com.google.accompanist.imageloading.ImageLoadState> p);
+  @androidx.compose.runtime.Stable public fun interface Loader<R> {
+    method public kotlinx.coroutines.flow.Flow<com.google.accompanist.imageloading.ImageLoadState> load-CDCt4V4(R? request, long size);
   }
 
   public final class MaterialLoadingImage {

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/ImageLoadState.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/ImageLoadState.kt
@@ -30,7 +30,10 @@ sealed class ImageLoadState {
     /**
      * Indicates that the request is currently in progress.
      */
-    object Loading : ImageLoadState()
+    data class Loading(
+        val placeholder: Drawable?,
+        val request: Any,
+    ) : ImageLoadState()
 
     /**
      * Indicates that the request completed successfully.
@@ -53,9 +56,9 @@ sealed class ImageLoadState {
      * @param request The original request for this result.
      */
     data class Error(
-        val result: Drawable? = null,
         val request: Any,
-        val throwable: Throwable
+        val result: Drawable? = null,
+        val throwable: Throwable? = null
     ) : ImageLoadState()
 }
 
@@ -70,6 +73,7 @@ internal inline val ImageLoadState.drawable: Drawable?
     get() = when (this) {
         is ImageLoadState.Success -> result
         is ImageLoadState.Error -> result
+        is ImageLoadState.Loading -> placeholder
         else -> null
     }
 

--- a/imageloading-testutils/src/main/java/com/google/accompanist/imageloading/test/ImageAssetAssertions.kt
+++ b/imageloading-testutils/src/main/java/com/google/accompanist/imageloading/test/ImageAssetAssertions.kt
@@ -19,6 +19,7 @@ package com.google.accompanist.imageloading.test
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import com.google.common.truth.Truth.assertThat
 
 /**
@@ -32,4 +33,26 @@ fun ImageBitmap.assertPixels(expected: Color, tolerance: Float = 0.001f) {
         assertThat(color.blue).isWithin(tolerance).of(expected.blue)
         assertThat(color.alpha).isWithin(tolerance).of(expected.alpha)
     }
+}
+
+/**
+ * Run the [SemanticsNodeInteraction] provided by [block] repeatedly until either
+ * the assertion succeeds, or the execution runs past [timeoutMillis].
+ */
+fun SemanticsNodeInteraction.assertWithTimeout(
+    timeoutMillis: Long,
+    block: SemanticsNodeInteraction.() -> SemanticsNodeInteraction,
+): SemanticsNodeInteraction {
+    val startTime = System.nanoTime()
+    while (System.nanoTime() - startTime <= timeoutMillis * 1_000_000) {
+        try {
+            return block()
+        } catch (error: AssertionError) {
+            // If the assertion failed, sleep for 10ms before the next loop iteration
+            Thread.sleep(10)
+        }
+    }
+    // If we reach here, each assertion has failed and we've reached the time out.
+    // Run block one last time...
+    return block()
 }

--- a/sample/src/main/java/com/google/accompanist/sample/coil/CoilBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/coil/CoilBasicSample.kt
@@ -82,6 +82,20 @@ private fun Sample() {
             }
 
             item {
+                // Data parameter with placeholder
+                Image(
+                    painter = rememberCoilPainter(
+                        request = rememberRandomSampleImageUrl(),
+                        requestBuilder = {
+                            placeholder(R.drawable.placeholder)
+                        }
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier.size(128.dp),
+                )
+            }
+
+            item {
                 // Load GIF
                 Image(
                     painter = rememberCoilPainter(
@@ -119,7 +133,7 @@ private fun Sample() {
                     )
 
                     Crossfade(coilPainter.loadState) { state ->
-                        if (state == ImageLoadState.Loading) {
+                        if (state is ImageLoadState.Loading) {
                             CircularProgressIndicator(Modifier.align(Alignment.Center))
                         }
                     }

--- a/sample/src/main/java/com/google/accompanist/sample/glide/GlideBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/glide/GlideBasicSample.kt
@@ -78,6 +78,21 @@ private fun Sample() {
             }
 
             item {
+                // Data parameter with placeholder
+                Image(
+                    painter = rememberGlidePainter(
+                        request = rememberRandomSampleImageUrl(),
+                        previewPlaceholder = R.drawable.placeholder,
+                        requestBuilder = {
+                            placeholder(R.drawable.placeholder)
+                        }
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier.size(128.dp),
+                )
+            }
+
+            item {
                 // Load GIF
                 Image(
                     painter = rememberGlidePainter("https://cataas.com/cat/gif"),
@@ -103,7 +118,7 @@ private fun Sample() {
                             .align(Alignment.Center)
                             .padding(16.dp)
                     ) { state ->
-                        if (state == ImageLoadState.Loading) {
+                        if (state is ImageLoadState.Loading) {
                             CircularProgressIndicator()
                         }
                     }
@@ -134,7 +149,7 @@ private fun Sample() {
                     )
 
                     Crossfade(glidePainter.loadState) { state ->
-                        if (state == ImageLoadState.Loading) {
+                        if (state is ImageLoadState.Loading) {
                             CircularProgressIndicator(Modifier.align(Alignment.Center))
                         }
                     }
@@ -152,7 +167,7 @@ private fun Sample() {
                     )
 
                     Crossfade(glidePainter.loadState) { state ->
-                        if (state == ImageLoadState.Loading) {
+                        if (state is ImageLoadState.Loading) {
                             CircularProgressIndicator(Modifier.align(Alignment.Center))
                         }
                     }


### PR DESCRIPTION
`Loader` now returns a `Flow<ImageLoadState>` which allows the loader to control the entire stream, including the
'Loading' state. This allows the loading state to contain any placeholder drawables which may be set on the request.

Example:

``` kotlin
Image(
    painter = rememberCoilPainter(
        request = "some.url",
        requestBuilder = {
            placeholder(R.drawable.placeholder)
        }
    ),
    contentDescription = null,
)
```