### PR TITLE
[Pager] Fix flings not being cancelled early

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -546,14 +546,14 @@ class PagerState(
                 scrollBy(coerced - (currentLayoutPageOffset * currentLayoutPageSize))
 
                 // If we've scroll our target page (or beyond it), cancel the animation
-                if ((initialVelocity < 0 && absolutePosition < target) ||
+                if ((initialVelocity < 0 && absolutePosition <= target) ||
                     (initialVelocity > 0 && absolutePosition >= target)
                 ) {
                     // If we reach the bounds of the allowed offset, cancel the animation
                     cancelAnimation()
-                    snapToPage(target)
                 }
             }
+            snapToPage(target)
         } else {
             // Otherwise we animate to the next item, or spring-back depending on the offset
             val target = currentLayoutPage + determineSpringBackOffset(


### PR DESCRIPTION
This PR fixes the issues of decay flings not being finished once they've hit their boundary. This stopped the `currentPage` being updated, which affects things like tabs, indicators, etc.