### PR TITLE
[Pager] Supports infinite loop

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
@@ -87,7 +87,7 @@ fun HorizontalPagerIndicator(
         Box(
             Modifier
                 .offset {
-                    val scrollPosition = pagerState.currentPage + pagerState.currentPageOffset
+                    val scrollPosition = pagerState.scrollPosition
                     IntOffset(
                         x = ((spacing + indicatorWidth) * scrollPosition).roundToPx(),
                         y = 0
@@ -153,7 +153,7 @@ fun VerticalPagerIndicator(
         Box(
             Modifier
                 .offset {
-                    val scrollPosition = pagerState.currentPage + pagerState.currentPageOffset
+                    val scrollPosition = pagerState.scrollPosition
                     IntOffset(
                         x = 0,
                         y = ((spacing + indicatorHeight) * scrollPosition).roundToPx(),

--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
@@ -87,7 +87,8 @@ fun HorizontalPagerIndicator(
         Box(
             Modifier
                 .offset {
-                    val scrollPosition = pagerState.scrollPosition
+                    val scrollPosition = (pagerState.currentPage + pagerState.currentPageOffset)
+                        .coerceIn(0f, (pagerState.pageCount - 1).toFloat())
                     IntOffset(
                         x = ((spacing + indicatorWidth) * scrollPosition).roundToPx(),
                         y = 0
@@ -153,7 +154,8 @@ fun VerticalPagerIndicator(
         Box(
             Modifier
                 .offset {
-                    val scrollPosition = pagerState.scrollPosition
+                    val scrollPosition = (pagerState.currentPage + pagerState.currentPageOffset)
+                        .coerceIn(0f, (pagerState.pageCount - 1).toFloat())
                     IntOffset(
                         x = 0,
                         y = ((spacing + indicatorHeight) * scrollPosition).roundToPx(),

--- a/pager/api/current.api
+++ b/pager/api/current.api
@@ -23,7 +23,7 @@ package com.google.accompanist.pager {
   }
 
   @androidx.compose.runtime.Stable @com.google.accompanist.pager.ExperimentalPagerApi public final class PagerState implements androidx.compose.foundation.gestures.ScrollableState {
-    ctor public PagerState(@IntRange(from=0) int pageCount, @IntRange(from=0) int currentPage, @FloatRange(from=0.0, to=1.0) float currentPageOffset, int offscreenLimit);
+    ctor public PagerState(@IntRange(from=0) int pageCount, @IntRange(from=0) int currentPage, @FloatRange(from=0.0, to=1.0) float currentPageOffset, int offscreenLimit, boolean infiniteLoop);
     method public suspend Object? animateScrollToPage(@IntRange(from=0) int page, optional @FloatRange(from=0.0, to=1.0) float pageOffset, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec, optional float initialVelocity, optional boolean skipPages, optional kotlin.coroutines.Continuation<? super kotlin.Unit> p);
     method public float dispatchRawDelta(float delta);
     method @IntRange(from=0) public int getCurrentPage();
@@ -48,7 +48,7 @@ package com.google.accompanist.pager {
   }
 
   public final class PagerStateKt {
-    method @androidx.compose.runtime.Composable @com.google.accompanist.pager.ExperimentalPagerApi public static com.google.accompanist.pager.PagerState rememberPagerState(@IntRange(from=0) int pageCount, optional @IntRange(from=0) int initialPage, optional @FloatRange(from=0.0, to=1.0) float initialPageOffset, optional @IntRange(from=1) int initialOffscreenLimit);
+    method @androidx.compose.runtime.Composable @com.google.accompanist.pager.ExperimentalPagerApi public static com.google.accompanist.pager.PagerState rememberPagerState(@IntRange(from=0) int pageCount, optional @IntRange(from=0) int initialPage, optional @FloatRange(from=0.0, to=1.0) float initialPageOffset, optional @IntRange(from=1) int initialOffscreenLimit, optional boolean infiniteLoop);
   }
 
 }

--- a/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerTest.kt
@@ -52,49 +52,52 @@ class HorizontalPagerTest(
     override val offscreenLimit: Int,
     private val layoutDirection: LayoutDirection,
     private val reverseLayout: Boolean,
+    override val infiniteLoop: Boolean,
 ) : PagerTest() {
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> = listOf(
+        fun data(): Collection<Array<Any>> = dataset(false) + dataset(true)
+
+        private fun dataset(looping: Boolean): Collection<Array<Any>> = listOf(
             // itemWidthFraction, horizontalAlignment, itemSpacing,
-            // offscreenLimit, layoutDirection, reverseLayout
+            // offscreenLimit, layoutDirection, reverseLayout, infiniteLoop
 
             // Test typical full-width items
-            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Ltr, false),
-            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Ltr, false),
-            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Ltr, false),
-            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Rtl, false),
-            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Rtl, false),
-            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Rtl, false),
+            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Rtl, false, looping),
+            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Rtl, false, looping),
+            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Rtl, false, looping),
 
             // Full-width items with item spacing
-            arrayOf(1f, Alignment.Start, 4, 2, LayoutDirection.Ltr, false),
-            arrayOf(1f, Alignment.CenterHorizontally, 4, 2, LayoutDirection.Ltr, false),
-            arrayOf(1f, Alignment.End, 4, 2, LayoutDirection.Ltr, false),
-            arrayOf(1f, Alignment.Start, 4, 2, LayoutDirection.Rtl, false),
-            arrayOf(1f, Alignment.CenterHorizontally, 4, 2, LayoutDirection.Rtl, false),
-            arrayOf(1f, Alignment.End, 4, 2, LayoutDirection.Rtl, false),
+            arrayOf(1f, Alignment.Start, 4, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(1f, Alignment.CenterHorizontally, 4, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(1f, Alignment.End, 4, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(1f, Alignment.Start, 4, 2, LayoutDirection.Rtl, false, looping),
+            arrayOf(1f, Alignment.CenterHorizontally, 4, 2, LayoutDirection.Rtl, false, looping),
+            arrayOf(1f, Alignment.End, 4, 2, LayoutDirection.Rtl, false, looping),
 
             // Full-width items with reverseLayout = true
-            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Ltr, true),
-            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Ltr, true),
-            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Ltr, true),
-            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Rtl, true),
-            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Rtl, true),
-            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Rtl, true),
+            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Ltr, true, looping),
+            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Ltr, true, looping),
+            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Ltr, true, looping),
+            arrayOf(1f, Alignment.Start, 0, 2, LayoutDirection.Rtl, true, looping),
+            arrayOf(1f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Rtl, true, looping),
+            arrayOf(1f, Alignment.End, 0, 2, LayoutDirection.Rtl, true, looping),
 
             // Test an increased offscreenLimit
-            arrayOf(1f, Alignment.CenterHorizontally, 0, 4, LayoutDirection.Ltr, false),
-            arrayOf(1f, Alignment.CenterHorizontally, 0, 4, LayoutDirection.Rtl, false),
+            arrayOf(1f, Alignment.CenterHorizontally, 0, 4, LayoutDirection.Ltr, false, looping),
+            arrayOf(1f, Alignment.CenterHorizontally, 0, 4, LayoutDirection.Rtl, false, looping),
 
             // Test items with 80% widths
-            arrayOf(0.8f, Alignment.Start, 0, 2, LayoutDirection.Ltr, false),
-            arrayOf(0.8f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Ltr, false),
-            arrayOf(0.8f, Alignment.End, 0, 2, LayoutDirection.Ltr, false),
-            arrayOf(0.8f, Alignment.Start, 0, 2, LayoutDirection.Rtl, false),
-            arrayOf(0.8f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Rtl, false),
-            arrayOf(0.8f, Alignment.End, 0, 2, LayoutDirection.Rtl, false),
+            arrayOf(0.8f, Alignment.Start, 0, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(0.8f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(0.8f, Alignment.End, 0, 2, LayoutDirection.Ltr, false, looping),
+            arrayOf(0.8f, Alignment.Start, 0, 2, LayoutDirection.Rtl, false, looping),
+            arrayOf(0.8f, Alignment.CenterHorizontally, 0, 2, LayoutDirection.Rtl, false, looping),
+            arrayOf(0.8f, Alignment.End, 0, 2, LayoutDirection.Rtl, false, looping),
         )
     }
 
@@ -158,7 +161,8 @@ class HorizontalPagerTest(
         val pagerState = PagerState(
             pageCount = pageCount,
             offscreenLimit = offscreenLimit,
-        )
+            infiniteLoop = infiniteLoop,
+        ).apply { testing = true }
         composeTestRule.setContent(layoutDirection) {
             applierScope = rememberCoroutineScope()
 

--- a/pager/src/androidTest/java/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/PagerTest.kt
@@ -309,23 +309,17 @@ abstract class PagerTest {
         // offscreenLimit and page limit
         val pageRange = (currentPage - offscreenLimit)..(currentPage + offscreenLimit)
         val expectedLaidOutPages = if (infiniteLoop) {
-            pageRange
-                .map { it to (it - currentPage) }
-                .toList()
+            pageRange.toList()
         } else {
-            pageRange
-                .filter { it in 0 until pageCount }
-                .map { it to (it - currentPage) }
-                .toList()
+            pageRange.filter { it in 0 until pageCount }.toList()
         }
 
         // Go through all of the pages, and assert the expected layout state
         (0 until pageCount).forEach { _page ->
-            val expectedPage = expectedLaidOutPages.find { it.first == _page }
-            if (expectedPage != null) {
+            val page = expectedLaidOutPages.find { it == _page }
+            if (page != null) {
                 // If this page is expected to be laid out, assert that it exists and is
                 // laid out in the correct position
-                val page = expectedPage.first
                 composeTestRule.onNodeWithTag(page.toString())
                     .assertExists()
                     .assertLaidOutItemPosition(page, currentPage)

--- a/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerTest.kt
@@ -51,30 +51,33 @@ class VerticalPagerTest(
     private val itemSpacingDp: Int,
     override val offscreenLimit: Int,
     private val reverseLayout: Boolean,
+    override val infiniteLoop: Boolean,
 ) : PagerTest() {
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> = listOf(
-            // verticalAlignment, itemSpacingDp, offscreenLimit, reverseLayout
+        fun data(): Collection<Array<Any>> = dataset(false) + dataset(true)
+
+        private fun dataset(looping: Boolean): Collection<Array<Any>> = listOf(
+            // verticalAlignment, itemSpacingDp, offscreenLimit, reverseLayout, infiniteLoop
 
             // Test typical full-width items
-            arrayOf(Alignment.CenterVertically, 0, 2, false),
-            arrayOf(Alignment.Top, 0, 2, false),
-            arrayOf(Alignment.Bottom, 0, 2, false),
+            arrayOf(Alignment.CenterVertically, 0, 2, false, looping),
+            arrayOf(Alignment.Top, 0, 2, false, looping),
+            arrayOf(Alignment.Bottom, 0, 2, false, looping),
 
             // Full-width items with spacing
-            arrayOf(Alignment.CenterVertically, 4, 2, false),
-            arrayOf(Alignment.Top, 4, 2, false),
-            arrayOf(Alignment.Bottom, 4, 2, false),
+            arrayOf(Alignment.CenterVertically, 4, 2, false, looping),
+            arrayOf(Alignment.Top, 4, 2, false, looping),
+            arrayOf(Alignment.Bottom, 4, 2, false, looping),
 
             // Full-width items with reverseLayout = true
-            arrayOf(Alignment.CenterVertically, 0, 2, true),
-            arrayOf(Alignment.Top, 0, 2, true),
-            arrayOf(Alignment.Bottom, 0, 2, true),
+            arrayOf(Alignment.CenterVertically, 0, 2, true, looping),
+            arrayOf(Alignment.Top, 0, 2, true, looping),
+            arrayOf(Alignment.Bottom, 0, 2, true, looping),
 
             // Test an increased offscreenLimit
-            arrayOf(Alignment.CenterVertically, 0, 4, false),
+            arrayOf(Alignment.CenterVertically, 0, 4, false, looping),
         )
     }
 
@@ -128,7 +131,8 @@ class VerticalPagerTest(
         val pagerState = PagerState(
             pageCount = pageCount,
             offscreenLimit = offscreenLimit,
-        )
+            infiniteLoop = infiniteLoop,
+        ).apply { testing = true }
         // Stick to LTR for vertical tests
         composeTestRule.setContent(LayoutDirection.Ltr) {
             applierScope = rememberCoroutineScope()

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -280,7 +280,7 @@ internal fun Pager(
             // drop/recreate state.
             val pages = state.layoutPages.mapNotNull { it.page }
             for (_page in pages) {
-                val page = _page.floorMod(state.pageCount)
+                val page = state.pageOf(_page)
                 key(page) {
                     val itemSemantics = Modifier.semantics {
                         this.selected = page == state.currentPage

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -279,14 +279,15 @@ internal fun Pager(
             // for page content is consistent as the user scrolls, otherwise content will
             // drop/recreate state.
             val pages = state.layoutPages.mapNotNull { it.page }
-            for (page in pages) {
+            for (_page in pages) {
+                val page = _page.floorMod(state.pageCount)
                 key(page) {
                     val itemSemantics = Modifier.semantics {
                         this.selected = page == state.currentPage
                     }
                     Box(
                         contentAlignment = Alignment.Center,
-                        modifier = itemSemantics.then(PageData(page))
+                        modifier = itemSemantics.then(PageData(_page))
                     ) {
                         val scope = remember(this, state) {
                             PagerScopeImpl(this, state)

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -150,10 +150,16 @@ class PagerState(
         get() = layoutPages[currentLayoutPageIndex]
 
     /**
-     * The current scroll position, as a float value between `0 until pageSize`
+     * The current scroll position, as a float value between `firstPageIndex until lastPageIndex`
      */
     private inline val absolutePosition: Float
         get() = currentLayoutPage + currentLayoutPageOffset
+
+    /**
+     * The current scroll position, as a float value between `0 until pageSize`
+     */
+    val scrollPosition: Float
+        get() = absolutePosition.coerceIn(0f, (pageCount - 1).toFloat())
 
     internal inline val firstPageIndex: Int
         get() = if (infiniteLoop) -1 else 0

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -111,6 +111,11 @@ class PagerState(
     private var _currentLayoutPageOffset by mutableStateOf(currentPageOffset)
 
     /**
+     * When set to true, `page` of [Pager] content can be different in [infiniteLoop] mode.
+     */
+    internal var testing = false
+
+    /**
      * This is the array of all the pages to be laid out. In effect, this contains the
      * 'current' page, plus the `offscreenLimit` on either side. Each PageLayoutInfo holds the page
      * index it should be displaying, and it's current layout size. Pager reads these values
@@ -637,6 +642,16 @@ class PagerState(
         }
     }
 
+    /**
+     * Considering infinite loop, returns page between 0 until [pageCount].
+     */
+    internal fun pageOf(rawPage: Int): Int {
+        if (testing) {
+            return rawPage
+        }
+        return rawPage.floorMod(pageCount)
+    }
+
     companion object {
         /**
          * The default [Saver] implementation for [PagerState].
@@ -650,6 +665,16 @@ class PagerState(
                 )
             }
         )
+
+        /**
+         * Calculates the floor modulus in the range of -abs([other]) < r < +abs([other]).
+         */
+        private fun Int.floorMod(other: Int): Int {
+            return when (other) {
+                0 -> this
+                else -> (this % other + other) % other
+            }
+        }
     }
 }
 
@@ -660,12 +685,5 @@ internal class PageLayoutInfo {
 
     override fun toString(): String {
         return "PageLayoutInfo(page = $page, layoutSize=$layoutSize)"
-    }
-}
-
-internal fun Int.floorMod(other: Int): Int {
-    return when (other) {
-        0 -> this
-        else -> (this % other + other) % other
     }
 }

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -58,6 +58,7 @@ private const val LogTag = "PagerState"
  * @param initialPageOffset the initial value for [PagerState.currentPageOffset]
  * @param initialOffscreenLimit the number of pages that should be retained on either side of the
  * current page. This value is required to be `1` or greater.
+ * @param infiniteLoop Whether to support infinite looping effect.
  */
 @ExperimentalPagerApi
 @Composable
@@ -94,6 +95,7 @@ fun rememberPagerState(
  * @param currentPageOffset the initial value for [PagerState.currentPageOffset]
  * @param offscreenLimit the number of pages that should be retained on either side of the
  * current page. This value is required to be `1` or greater.
+ * @param infiniteLoop Whether to support infinite looping effect.
  */
 @ExperimentalPagerApi
 @Stable
@@ -473,7 +475,10 @@ class PagerState(
      */
     private fun scrollByOffset(deltaOffset: Float): Float {
         val current = absolutePosition
-        val target = (current + deltaOffset).coerceIn(firstPageIndex.toFloat(), lastPageIndex.toFloat())
+        val target = (current + deltaOffset).coerceIn(
+            minimumValue = firstPageIndex.toFloat(),
+            maximumValue = lastPageIndex.toFloat()
+        )
 
         if (DebugLog) {
             Napier.d(

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -157,12 +157,6 @@ class PagerState(
     private inline val absolutePosition: Float
         get() = currentLayoutPage + currentLayoutPageOffset
 
-    /**
-     * The current scroll position, as a float value between `0 until pageSize`
-     */
-    val scrollPosition: Float
-        get() = absolutePosition.coerceIn(0f, (pageCount - 1).toFloat())
-
     internal inline val firstPageIndex: Int
         get() = if (infiniteLoop) -1 else 0
 

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -158,11 +158,11 @@ class PagerState(
         get() = currentLayoutPage + currentLayoutPageOffset
 
     internal inline val firstPageIndex: Int
-        get() = if (infiniteLoop) -1 else 0
+        get() = if (infiniteLoop) Int.MIN_VALUE else 0
 
     internal inline val lastPageIndex: Int
         get() = if (infiniteLoop) {
-            pageCount.coerceAtLeast(1)
+            Int.MAX_VALUE
         } else {
             (pageCount - 1).coerceAtLeast(0)
         }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -168,6 +168,15 @@
         </activity>
 
         <activity
+            android:name=".pager.HorizontalPagerLoopSample"
+            android:label="@string/horiz_pager_title_loop">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".pager.VerticalPagerBasicSample"
             android:label="@string/vertical_pager_title_basics">
             <intent-filter>
@@ -185,6 +194,14 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".pager.VerticalPagerLoopSample"
+            android:label="@string/vertical_pager_title_loop">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
 
         <activity
             android:name=".pager.NestedPagersSample"

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerLoopSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerLoopSample.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.sample.pager
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.ScrollableTabRow
+import androidx.compose.material.Surface
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRowDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.HorizontalPagerIndicator
+import com.google.accompanist.pager.pagerTabIndicatorOffset
+import com.google.accompanist.pager.rememberPagerState
+import com.google.accompanist.sample.AccompanistSampleTheme
+import com.google.accompanist.sample.R
+import kotlinx.coroutines.launch
+
+class HorizontalPagerLoopSample : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AccompanistSampleTheme {
+                Surface {
+                    Sample()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+private fun Sample() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.horiz_pager_title_loop)) },
+                backgroundColor = MaterialTheme.colors.surface,
+            )
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        val pages = remember {
+            listOf("Home", "Shows", "Movies", "Books", "Really long movies", "Short audiobooks")
+        }
+
+        Column(Modifier.fillMaxSize()) {
+            val coroutineScope = rememberCoroutineScope()
+
+            // Remember a PagerState with our tab count
+            val pagerState = rememberPagerState(
+                pageCount = pages.size,
+                // Allows infinite loop
+                infiniteLoop = true
+            )
+            ScrollableTabRow(
+                // Our selected tab is our current page
+                selectedTabIndex = pagerState.currentPage,
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        Modifier.pagerTabIndicatorOffset(pagerState, tabPositions)
+                    )
+                }
+            ) {
+                // Add tabs for all of our pages
+                pages.forEachIndexed { index, title ->
+                    Tab(
+                        text = { Text(title) },
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            // Animate to the selected page when clicked
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        }
+                    )
+                }
+            }
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) { page ->
+                // Our content for each page
+                Box(modifier = Modifier.fillMaxSize()) {
+                    Card(Modifier.padding(16.dp)) {
+                        Box(Modifier.fillMaxSize()) {
+                            Text(
+                                text = "Page: ${pages[page]}",
+                                style = MaterialTheme.typography.h4,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        }
+                    }
+                }
+            }
+
+            HorizontalPagerIndicator(
+                pagerState = pagerState,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(16.dp),
+            )
+        }
+    }
+}

--- a/sample/src/main/java/com/google/accompanist/sample/pager/VerticalPagerLoopSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/VerticalPagerLoopSample.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.sample.pager
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.VerticalPager
+import com.google.accompanist.pager.VerticalPagerIndicator
+import com.google.accompanist.pager.rememberPagerState
+import com.google.accompanist.sample.AccompanistSampleTheme
+import com.google.accompanist.sample.R
+
+class VerticalPagerLoopSample : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AccompanistSampleTheme {
+                Surface {
+                    Sample()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+private fun Sample() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.vertical_pager_title_loop)) },
+                backgroundColor = MaterialTheme.colors.surface,
+            )
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            // Display 10 items
+            val pagerState = rememberPagerState(
+                pageCount = 10,
+                // We increase the offscreen limit, to allow pre-loading of images
+                initialOffscreenLimit = 2,
+                // Allows infinite loop
+                infiniteLoop = true
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f),
+            ) {
+                VerticalPager(
+                    state = pagerState,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                ) { page ->
+                    PagerSampleItem(
+                        page = page,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f),
+                    )
+                }
+
+                VerticalPagerIndicator(
+                    pagerState = pagerState,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+
+            ActionsRow(
+                pagerState = pagerState,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+        }
+    }
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -33,10 +33,12 @@
     <string name="horiz_pager_title_basics">Horizontal Pager: Basic</string>
     <string name="horiz_pager_with_indicator_title">Horizontal Pager: Indicator</string>
     <string name="horiz_pager_with_transition_title">Horizontal Pager: Transition</string>
-    <string name="horiz_pager_title_tabs">HorizontalPager: Tabs</string>
+    <string name="horiz_pager_title_tabs">Horizontal Pager: Tabs</string>
+    <string name="horiz_pager_title_loop">Horizontal Pager: Loop</string>
 
     <string name="vertical_pager_title_basics">Vertical Pager: Basic</string>
     <string name="vertical_pager_with_indicator_title">Vertical Pager: Indicator</string>
+    <string name="vertical_pager_title_loop">Vertical Pager: Loop</string>
 
     <string name="pagers_title_nested">Pagers: Nested</string>
 


### PR DESCRIPTION
Currently, the pager can only scroll within a limited range, so it can only scroll in one direction on the first or last page.

This PR provides the option to allow the pager to scroll infinitely.

Fixes: #429

### Screenshots
https://user-images.githubusercontent.com/3405740/119264584-c714c500-bc1e-11eb-9f69-2e43d142e441.mp4

https://user-images.githubusercontent.com/3405740/119264589-cbd97900-bc1e-11eb-9a1f-9f9eb6721214.mp4