### PR TITLE
[SwipeRefresh] Update indicator to fade-in during drag

### DIFF
--- a/swiperefresh/api/current.api
+++ b/swiperefresh/api/current.api
@@ -5,7 +5,7 @@ package com.google.accompanist.swiperefresh {
   }
 
   public final class SwipeRefreshIndicatorKt {
-    method @androidx.compose.runtime.Composable public static void SwipeRefreshIndicator-E1VOmL8(com.google.accompanist.swiperefresh.SwipeRefreshState state, float refreshTriggerDistance, optional androidx.compose.ui.Modifier modifier, optional boolean scale, optional boolean arrowEnabled, optional long backgroundColor, optional long contentColor, optional androidx.compose.ui.graphics.Shape shape, optional float refreshingOffset, optional boolean largeIndication, optional float elevation);
+    method @androidx.compose.runtime.Composable public static void SwipeRefreshIndicator-V_RBFTI(com.google.accompanist.swiperefresh.SwipeRefreshState state, float refreshTriggerDistance, optional androidx.compose.ui.Modifier modifier, optional boolean fade, optional boolean scale, optional boolean arrowEnabled, optional long backgroundColor, optional long contentColor, optional androidx.compose.ui.graphics.Shape shape, optional float refreshingOffset, optional boolean largeIndication, optional float elevation);
   }
 
   public final class SwipeRefreshKt {

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/Slingshot.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/Slingshot.kt
@@ -62,7 +62,7 @@ internal fun rememberUpdatedSlingshot(
     val strokeStart = adjustedPercent * 0.8f
 
     val startTrim = 0f
-    val endTrim = strokeStart.coerceAtLeast(MaxProgressArc)
+    val endTrim = min(MaxProgressArc, strokeStart)
 
     val rotation = (-0.25f + 0.4f * adjustedPercent + tensionPercent * 2) * 0.5f
     val arrowScale = min(1f, adjustedPercent)

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/Slingshot.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/Slingshot.kt
@@ -62,7 +62,7 @@ internal fun rememberUpdatedSlingshot(
     val strokeStart = adjustedPercent * 0.8f
 
     val startTrim = 0f
-    val endTrim = min(MaxProgressArc, strokeStart)
+    val endTrim = strokeStart.coerceAtMost(MaxProgressArc)
 
     val rotation = (-0.25f + 0.4f * adjustedPercent + tensionPercent * 2) * 0.5f
     val arrowScale = min(1f, adjustedPercent)

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
@@ -91,6 +91,7 @@ private val LargeSizes = SwipeRefreshIndicatorSizes(
  *
  * @param state The [SwipeRefreshState] passed into the [SwipeRefresh] `indicator` block.
  * @param modifier The modifier to apply to this layout.
+ * @param fade Whether the arrow should fade in/out as it is scrolled in. Defaults to true.
  * @param scale Whether the indicator should scale up/down as it is scrolled in. Defaults to false.
  * @param arrowEnabled Whether an arrow should be drawn on the indicator. Defaults to true.
  * @param backgroundColor The color of the indicator background surface.
@@ -122,12 +123,6 @@ fun SwipeRefreshIndicator(
     val sizes = if (largeIndication) LargeSizes else DefaultSizes
 
     val indicatorRefreshTrigger = with(LocalDensity.current) { refreshTriggerDistance.toPx() }
-
-    val alpha = if (fade) {
-        (state.indicatorOffset / indicatorRefreshTrigger).coerceIn(0f, 1f)
-    } else {
-        1f
-    }
 
     val indicatorHeight = with(LocalDensity.current) { sizes.size.roundToPx() }
     val refreshingOffsetPx = with(LocalDensity.current) { refreshingOffset.toPx() }
@@ -190,6 +185,11 @@ fun SwipeRefreshIndicator(
         painter.arrowHeight = sizes.arrowHeight
         painter.arrowEnabled = arrowEnabled && !state.isRefreshing
         painter.color = contentColor
+        val alpha = if (fade) {
+            (state.indicatorOffset / indicatorRefreshTrigger).coerceIn(0f, 1f)
+        } else {
+            1f
+        }
         painter.alpha = alpha
 
         painter.startTrim = slingshot.startTrim

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
@@ -124,7 +124,7 @@ fun SwipeRefreshIndicator(
     val indicatorRefreshTrigger = with(LocalDensity.current) { refreshTriggerDistance.toPx() }
 
     val alpha = if (fade) {
-        (state.indicatorOffset / indicatorRefreshTrigger).coerceIn(0f,  1f)
+        (state.indicatorOffset / indicatorRefreshTrigger).coerceIn(0f, 1f)
     } else {
         1f
     }

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
@@ -19,7 +19,6 @@ package com.google.accompanist.swiperefresh
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animate
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
@@ -105,6 +104,7 @@ fun SwipeRefreshIndicator(
     state: SwipeRefreshState,
     refreshTriggerDistance: Dp,
     modifier: Modifier = Modifier,
+    fade: Boolean = true,
     scale: Boolean = false,
     arrowEnabled: Boolean = true,
     backgroundColor: Color = MaterialTheme.colors.surface,
@@ -123,14 +123,11 @@ fun SwipeRefreshIndicator(
 
     val indicatorRefreshTrigger = with(LocalDensity.current) { refreshTriggerDistance.toPx() }
 
-    val animatedAlpha by animateFloatAsState(
-        targetValue = when {
-            state.isRefreshing -> MaxAlpha
-            state.indicatorOffset >= indicatorRefreshTrigger -> MaxAlpha
-            else -> MinAlpha
-        },
-        animationSpec = tween()
-    )
+    val alpha = if (fade) {
+        (state.indicatorOffset / indicatorRefreshTrigger).coerceIn(0f,  1f)
+    } else {
+        1f
+    }
 
     val indicatorHeight = with(LocalDensity.current) { sizes.size.roundToPx() }
     val refreshingOffsetPx = with(LocalDensity.current) { refreshingOffset.toPx() }
@@ -193,7 +190,7 @@ fun SwipeRefreshIndicator(
         painter.arrowHeight = sizes.arrowHeight
         painter.arrowEnabled = arrowEnabled && !state.isRefreshing
         painter.color = contentColor
-        painter.alpha = animatedAlpha
+        painter.alpha = alpha
 
         painter.startTrim = slingshot.startTrim
         painter.endTrim = slingshot.endTrim
@@ -228,6 +225,4 @@ fun SwipeRefreshIndicator(
     }
 }
 
-private const val MaxAlpha = 1f
-private const val MinAlpha = 0.3f
 private const val CrossfadeDurationMs = 100


### PR DESCRIPTION
Also fix arc `endTrim` drawing.

Before:

https://user-images.githubusercontent.com/12491712/119508190-d5262b00-bd6f-11eb-8987-482ccb11ec9b.mp4

After:

https://user-images.githubusercontent.com/12491712/119508210-d9524880-bd6f-11eb-83ea-c1c9881ddb1b.mp4

resolves #431