### PR TITLE
Check API files via `check` task

### DIFF
--- a/appcompat-theme/build.gradle
+++ b/appcompat-theme/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -83,11 +82,6 @@ dependencies {
     androidTestImplementation libs.junit
     androidTestImplementation libs.compose.ui.test.junit4
     androidTestImplementation libs.androidx.test.runner
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,27 @@ subprojects {
         }
     }
 
+    // If we have a POM Artifact ID, we should generate API files
+    if (project.hasProperty('POM_ARTIFACT_ID')) {
+        apply plugin: 'me.tylerbwong.gradle.metalava'
+
+        metalava {
+            filename = "api/current.api"
+            reportLintsAsErrors = true
+        }
+
+        // Make the `check` task depend on `metalavaCheckCompatibility`. This is a workaround for
+        // https://github.com/tylerbwong/metalava-gradle/issues/12
+        afterEvaluate {
+            def metalavaCheckCompatibility = tasks.findByName('metalavaCheckCompatibility')
+            if (metalavaCheckCompatibility != null) {
+                tasks.named("check") { check ->
+                    check.dependsOn metalavaCheckCompatibility
+                }
+            }
+        }
+    }
+
     // Must be afterEvaluate or else com.vanniktech.maven.publish will overwrite our
     // dokka and version configuration.
     afterEvaluate {
@@ -170,7 +191,9 @@ subprojects {
                 }
             }
         }
+    }
 
+    afterEvaluate {
         def composeSnapshot = libs.versions.composesnapshot.get()
         if (composeSnapshot.length() > 1) {
             // We're depending on a Jetpack Compose snapshot, update the library version name

--- a/coil/build.gradle
+++ b/coil/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -98,11 +97,6 @@ dependencies {
     androidTestImplementation libs.compose.ui.test.manifest
     androidTestImplementation libs.compose.material.material
     androidTestImplementation libs.androidx.test.runner
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/flowlayout/build.gradle
+++ b/flowlayout/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -86,11 +85,6 @@ dependencies {
     androidTestImplementation libs.compose.ui.test.manifest
     androidTestImplementation libs.compose.ui.ui
     androidTestImplementation libs.androidx.test.runner
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -95,11 +94,6 @@ dependencies {
     androidTestImplementation libs.compose.ui.test.manifest
     androidTestImplementation libs.compose.material.material
     androidTestImplementation libs.androidx.test.runner
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/imageloading-core/build.gradle
+++ b/imageloading-core/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -70,11 +69,6 @@ android {
 dependencies {
     implementation libs.compose.foundation.foundation
     implementation libs.kotlin.coroutines.android
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/insets/build.gradle
+++ b/insets/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -92,11 +91,6 @@ dependencies {
     androidTestImplementation libs.compose.ui.test.manifest
     androidTestImplementation libs.compose.foundation.foundation
     androidTestImplementation libs.androidx.test.runner
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/pager-indicators/build.gradle
+++ b/pager-indicators/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -77,11 +76,6 @@ android {
 dependencies {
     api project(':pager')
     api libs.compose.material.material
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/pager/build.gradle
+++ b/pager/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -89,11 +88,6 @@ dependencies {
     androidTestImplementation libs.compose.ui.test.manifest
     androidTestImplementation libs.compose.foundation.foundation
     androidTestImplementation libs.androidx.test.runner
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/swiperefresh/build.gradle
+++ b/swiperefresh/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -89,11 +88,6 @@ dependencies {
     androidTestImplementation libs.compose.ui.test.manifest
     androidTestImplementation libs.compose.foundation.foundation
     androidTestImplementation libs.androidx.test.runner
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/systemuicontroller/build.gradle
+++ b/systemuicontroller/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
 }
 
 kotlin {
@@ -90,11 +89,6 @@ dependencies {
     androidTestImplementation libs.compose.ui.ui
     androidTestImplementation libs.androidx.test.runner
     androidTestImplementation libs.androidx.test.rules
-}
-
-metalava {
-    filename = "api/current.api"
-    reportLintsAsErrors = true
 }
 
 apply plugin: "com.vanniktech.maven.publish"


### PR DESCRIPTION
Needed to move all of the Metalava plugin configuration to the root `build.gradle`, so that we could ensure that the plugin was applied before trying to fetch the task.

Workaround for https://github.com/tylerbwong/metalava-gradle/issues/12