### PR TITLE
[Pager] Consume post flings and scrolls from nested scrolling content

### DIFF
--- a/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerScrollingContentTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/HorizontalPagerScrollingContentTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.pager
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.filters.LargeTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@OptIn(ExperimentalPagerApi::class) // Pager is currently experimental
+@LargeTest
+@RunWith(JUnit4::class)
+class HorizontalPagerScrollingContentTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun horizontalPagerScrollingContentTest() {
+        lateinit var pagerState: PagerState
+
+        rule.setContent {
+            pagerState = rememberPagerState(pageCount = 2)
+
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize().testTag(TestTag)
+            ) { page ->
+                BoxWithConstraints(Modifier.fillMaxWidth()) {
+                    // We make the scrolling Row content 2x the width, so that it scrolls
+                    val width = with(LocalDensity.current) { (constraints.maxWidth * 2).toDp() }
+
+                    Row(Modifier.horizontalScroll(rememberScrollState())) {
+                        val background = if (page == 0) Color.Green else Color.Red
+
+                        Box(
+                            Modifier
+                                .fillMaxHeight()
+                                .width(width)
+                                .background(
+                                    brush = Brush.horizontalGradient(
+                                        listOf(background, Color.Black)
+                                    )
+                                )
+                        )
+                    }
+                }
+            }
+        }
+
+        // Perform a very quick, high velocity scroll which will scroll the inner content to it's
+        // opposite/end edge
+        rule.onNodeWithTag(TestTag)
+            .swipeAcrossCenterWithVelocity(velocity = 15_000f, distancePercentageX = -0.5f)
+
+        // Wait for the flings to end
+        rule.waitForIdle()
+
+        // Assert that we're still on page 0
+        assertThat(pagerState.currentPage).isEqualTo(0)
+        assertThat(pagerState.currentPageOffset).isWithin(0.01f).of(0f)
+    }
+
+    companion object {
+        const val TestTag = "Pager"
+    }
+}

--- a/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerScrollingContentTest.kt
+++ b/pager/src/androidTest/java/com/google/accompanist/pager/VerticalPagerScrollingContentTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.pager
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.filters.LargeTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@OptIn(ExperimentalPagerApi::class) // Pager is currently experimental
+@LargeTest
+@RunWith(JUnit4::class)
+class VerticalPagerScrollingContentTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun verticalPagerScrollingContentTest() {
+        lateinit var pagerState: PagerState
+
+        rule.setContent {
+            pagerState = rememberPagerState(pageCount = 2)
+
+            VerticalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize().testTag(TestTag)
+            ) { page ->
+                BoxWithConstraints(Modifier.fillMaxSize()) {
+                    // We make the scrolling Column content 2x the height, so that it scrolls
+                    val width = with(LocalDensity.current) { (constraints.maxHeight * 2).toDp() }
+
+                    Column(Modifier.verticalScroll(rememberScrollState())) {
+                        val background = if (page == 0) Color.Green else Color.Red
+
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .height(width)
+                                .background(
+                                    brush = Brush.verticalGradient(
+                                        listOf(background, Color.Black)
+                                    )
+                                )
+                        )
+                    }
+                }
+            }
+        }
+
+        // Perform a very quick, high velocity scroll which will scroll the inner content to it's
+        // opposite/end edge
+        rule.onNodeWithTag(TestTag)
+            .swipeAcrossCenterWithVelocity(velocity = 15_000f, distancePercentageY = -0.5f)
+
+        // Wait for the flings to end
+        rule.waitForIdle()
+
+        // Assert that we're still on page 0
+        assertThat(pagerState.currentPage).isEqualTo(0)
+        assertThat(pagerState.currentPageOffset).isWithin(0.01f).of(0f)
+    }
+
+    companion object {
+        const val TestTag = "Pager"
+    }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -187,6 +187,15 @@
         </activity>
 
         <activity
+            android:name=".pager.HorizontalPagerScrollingContentSample"
+            android:label="@string/horiz_pager_title_scroll_content">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".pager.VerticalPagerBasicSample"
             android:label="@string/vertical_pager_title_basics">
             <intent-filter>

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerScrollingContentSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerScrollingContentSample.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.sample.pager
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.rememberPagerState
+import com.google.accompanist.sample.AccompanistSampleTheme
+import com.google.accompanist.sample.R
+
+class HorizontalPagerScrollingContentSample : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AccompanistSampleTheme {
+                Surface {
+                    Sample()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalPagerApi::class)
+@Composable
+private fun Sample() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.horiz_pager_title_scroll_content)) },
+                backgroundColor = MaterialTheme.colors.surface,
+            )
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            // Display 10 items
+            val pagerState = rememberPagerState(
+                pageCount = 10,
+                // We increase the offscreen limit, to allow pre-loading of images
+                initialOffscreenLimit = 2,
+            )
+
+            HorizontalPager(
+                state = pagerState,
+                // Add some horizontal spacing between items
+                itemSpacing = 4.dp,
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) { page ->
+                Row(
+                    Modifier
+                        .fillMaxWidth(0.8f)
+                        .aspectRatio(1f)
+                        .horizontalScroll(rememberScrollState())
+                ) {
+                    PagerSampleItem(
+                        page = page,
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .aspectRatio(1f)
+                    )
+
+                    PagerSampleItem(
+                        page = page,
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .aspectRatio(1f)
+                    )
+
+                    PagerSampleItem(
+                        page = page,
+                        modifier = Modifier
+                            .fillMaxHeight()
+                            .aspectRatio(1f)
+                    )
+                }
+            }
+
+            ActionsRow(
+                pagerState = pagerState,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+        }
+    }
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="horiz_pager_with_transition_title">Horizontal Pager: Transition</string>
     <string name="horiz_pager_title_tabs">Horizontal Pager: Tabs</string>
     <string name="horiz_pager_title_loop">Horizontal Pager: Loop</string>
+    <string name="horiz_pager_title_scroll_content">Horizontal Pager: Scrolling content</string>
 
     <string name="vertical_pager_title_basics">Vertical Pager: Basic</string>
     <string name="vertical_pager_with_indicator_title">Vertical Pager: Indicator</string>


### PR DESCRIPTION
Currently any nested unused scrolls + flings from child content is handled by the Pager. This is different to how `ViewPager[2]` behaves and is usually unwanted behavior.

This PR adds a `NestedScrollConnection` which consumes those events before the Pager gets them. It's not perfect, but it's close enough for now.

Fixes #347