### PR TITLE
Start sharding tests on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,7 @@ jobs:
           profile: Galaxy Nexus
           script: |
             adb logcat > logcat.txt &
-            ./gradlew connectedCheck --scan --continue \
-                -Pandroid.testInstrumentationRunnerArguments.numShards=3 \
-                -Pandroid.testInstrumentationRunnerArguments.shardIndex=${{ matrix.shard }}
+            ./gradlew connectedCheck --scan --continue -Pandroid.testInstrumentationRunnerArguments.numShards=3 -Pandroid.testInstrumentationRunnerArguments.shardIndex=${{ matrix.shard }}
 
       - name: Clean secrets
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,8 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        include:
-          - api-level: 29
-            target: default
-          - api-level: 28
-            target: default
-          - api-level: 26
-            target: default
-          - api-level: 22
-            target: default
+        api-level: [22, 26, 28, 29]
+        shard: [0, 1, 2]
 
     env:
       TERM: dumb
@@ -108,10 +101,11 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           profile: Galaxy Nexus
-          target: ${{ matrix.target }}
           script: |
             adb logcat > logcat.txt &
-            ./gradlew connectedCheck --scan --continue
+            ./gradlew connectedCheck --scan --continue \
+                -Pandroid.testInstrumentationRunnerArguments.numShards=3 \
+                -Pandroid.testInstrumentationRunnerArguments.shardIndex=${{ matrix.shard }}
 
       - name: Clean secrets
         if: always()
@@ -121,14 +115,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-${{ matrix.api-level }}-${{ matrix.target }}
+          name: logs-${{ matrix.api-level }}-${{ matrix.shard }}
           path: logcat.txt
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test-results-${{ matrix.api-level }}-${{ matrix.target }}
+          name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
           path: "**/build/outputs/*/connected/*.xml"
 
   deploy:

--- a/appcompat-theme/src/androidTest/java/com/google/accompanist/appcompattheme/DummyTests.kt
+++ b/appcompat-theme/src/androidTest/java/com/google/accompanist/appcompattheme/DummyTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.appcompattheme
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Dummy tests to help with sharding: https://github.com/android/android-test/issues/973
+ */
+@RunWith(JUnit4::class)
+class DummyTests {
+    @Test
+    fun dummy1() = Unit
+
+    @Test
+    fun dummy2() = Unit
+
+    @Test
+    fun dummy3() = Unit
+
+    @Test
+    fun dummy4() = Unit
+
+    @Test
+    fun dummy5() = Unit
+
+    @Test
+    fun dummy6() = Unit
+
+    @Test
+    fun dummy7() = Unit
+
+    @Test
+    fun dummy8() = Unit
+
+    @Test
+    fun dummy9() = Unit
+
+    @Test
+    fun dummy10() = Unit
+}

--- a/insets/src/androidTest/java/com/google/accompanist/insets/DummyTests.kt
+++ b/insets/src/androidTest/java/com/google/accompanist/insets/DummyTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.insets
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Dummy tests to help with sharding: https://github.com/android/android-test/issues/973
+ */
+@RunWith(JUnit4::class)
+class DummyTests {
+    @Test
+    fun dummy1() = Unit
+
+    @Test
+    fun dummy2() = Unit
+
+    @Test
+    fun dummy3() = Unit
+
+    @Test
+    fun dummy4() = Unit
+
+    @Test
+    fun dummy5() = Unit
+
+    @Test
+    fun dummy6() = Unit
+
+    @Test
+    fun dummy7() = Unit
+
+    @Test
+    fun dummy8() = Unit
+
+    @Test
+    fun dummy9() = Unit
+
+    @Test
+    fun dummy10() = Unit
+}

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/DummyTests.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/DummyTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.placeholder
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Dummy tests to help with sharding: https://github.com/android/android-test/issues/973
+ */
+@RunWith(JUnit4::class)
+class DummyTests {
+    @Test
+    fun dummy1() = Unit
+
+    @Test
+    fun dummy2() = Unit
+
+    @Test
+    fun dummy3() = Unit
+
+    @Test
+    fun dummy4() = Unit
+
+    @Test
+    fun dummy5() = Unit
+
+    @Test
+    fun dummy6() = Unit
+
+    @Test
+    fun dummy7() = Unit
+
+    @Test
+    fun dummy8() = Unit
+
+    @Test
+    fun dummy9() = Unit
+
+    @Test
+    fun dummy10() = Unit
+}

--- a/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/DummyTests.kt
+++ b/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/DummyTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.swiperefresh
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Dummy tests to help with sharding: https://github.com/android/android-test/issues/973
+ */
+@RunWith(JUnit4::class)
+class DummyTests {
+    @Test
+    fun dummy1() = Unit
+
+    @Test
+    fun dummy2() = Unit
+
+    @Test
+    fun dummy3() = Unit
+
+    @Test
+    fun dummy4() = Unit
+
+    @Test
+    fun dummy5() = Unit
+
+    @Test
+    fun dummy6() = Unit
+
+    @Test
+    fun dummy7() = Unit
+
+    @Test
+    fun dummy8() = Unit
+
+    @Test
+    fun dummy9() = Unit
+
+    @Test
+    fun dummy10() = Unit
+}

--- a/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
+++ b/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
@@ -72,6 +72,24 @@ class SwipeRefreshTest {
     }
 
     @Test
+    fun indicatorVisibility() {
+        lateinit var state: SwipeRefreshState
+
+        rule.setContent {
+            state = rememberSwipeRefreshState(false)
+            SwipeRefreshTestContent(state) {}
+        }
+
+        // Assert that the indicator is not displayed
+        indicatorNode.assertIsNotDisplayed()
+
+        // Set refreshing to true and assert that the indicator is displayed
+        state.isRefreshing = true
+
+        indicatorNode.assertIsDisplayed()
+    }
+
+    @Test
     fun refreshingInitially() {
         rule.setContent {
             SwipeRefreshTestContent(rememberSwipeRefreshState(true)) {}

--- a/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
+++ b/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
@@ -86,6 +86,7 @@ class SwipeRefreshTest {
         // Set refreshing to true and assert that the indicator is displayed
         state.isRefreshing = true
 
+        rule.waitForIdle()
         indicatorNode.assertIsDisplayed()
     }
 

--- a/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
+++ b/swiperefresh/src/androidTest/java/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
@@ -72,6 +72,7 @@ class SwipeRefreshTest {
     }
 
     @Test
+    @Ignore("https://issuetracker.google.com/issues/185814751")
     fun indicatorVisibility() {
         lateinit var state: SwipeRefreshState
 

--- a/systemuicontroller/src/androidTest/java/com/google/accompanist/systemuicontroller/DummyTests.kt
+++ b/systemuicontroller/src/androidTest/java/com/google/accompanist/systemuicontroller/DummyTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.systemuicontroller
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Dummy tests to help with sharding: https://github.com/android/android-test/issues/973
+ */
+@RunWith(JUnit4::class)
+class DummyTests {
+    @Test
+    fun dummy1() = Unit
+
+    @Test
+    fun dummy2() = Unit
+
+    @Test
+    fun dummy3() = Unit
+
+    @Test
+    fun dummy4() = Unit
+
+    @Test
+    fun dummy5() = Unit
+
+    @Test
+    fun dummy6() = Unit
+
+    @Test
+    fun dummy7() = Unit
+
+    @Test
+    fun dummy8() = Unit
+
+    @Test
+    fun dummy9() = Unit
+
+    @Test
+    fun dummy10() = Unit
+}


### PR DESCRIPTION
This PR now shards the instrumented tests over 3 emulator runs per API level. Each shard now takes ~20 mins to run, whereas previously each API level would take ~40-50 mins.

We have needed to add a bunch of 'dummy' tests to each module. If the resulting number of tests in a shard is 0 we hit 'No tests found' errors. The dummy tests bulk out the number of tests to reduce/stop the chance of a shard having 0 tests. See https://github.com/android/android-test/issues/973.