### PR TITLE
[Placeholder] Fix that a placeholder modifier is not changed on every recomposition

### DIFF
--- a/placeholder/README.md
+++ b/placeholder/README.md
@@ -1,0 +1,19 @@
+# Placeholder for Jetpack Compose
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-placeholder)](https://search.maven.org/search?q=g:com.google.accompanist)
+
+## Download
+
+```groovy
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "com.google.accompanist:accompanist-placeholder:<version>"
+}
+```
+
+Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap]. These are updated on every commit.
+
+  [snap]: https://oss.sonatype.org/content/repositories/snapshots/com/google/accompanist/accompanist-placeholder/

--- a/placeholder/api/current.api
+++ b/placeholder/api/current.api
@@ -1,7 +1,8 @@
 // Signature format: 4.0
 package com.google.accompanist.placeholder {
 
-  public abstract sealed class PlaceholderAnimatedBrush {
+  public abstract class PlaceholderAnimatedBrush {
+    ctor public PlaceholderAnimatedBrush();
     method public abstract androidx.compose.animation.core.InfiniteRepeatableSpec<java.lang.Float> animationSpec();
     method public abstract androidx.compose.ui.graphics.Brush brush(float progress);
     method public abstract float maximumProgress();

--- a/placeholder/gradle.properties
+++ b/placeholder/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=accompanist-placeholder
+POM_NAME=Accompanist Placeholder
+POM_PACKAGING=aar

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/ImageAssertions.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/ImageAssertions.kt
@@ -29,29 +29,18 @@ import androidx.compose.ui.graphics.addOutline
 import androidx.compose.ui.graphics.asAndroidPath
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert
 import kotlin.math.roundToInt
 
-/**
- * Assert that all of the pixels in this image as of the [expected] color.
- */
-fun ImageBitmap.assertPixels(expected: Color, tolerance: Float = 0.001f) {
-    toPixelMap().buffer.forEach { pixel ->
-        val color = Color(pixel)
-        assertThat(color.red).isWithin(tolerance).of(expected.red)
-        assertThat(color.green).isWithin(tolerance).of(expected.green)
-        assertThat(color.blue).isWithin(tolerance).of(expected.blue)
-        assertThat(color.alpha).isWithin(tolerance).of(expected.alpha)
-    }
-}
+// Copied from AndroidX Compose test-utils:
+// https://github.com/androidx/androidx/blob/androidx-main/compose/test-utils/src/androidMain/kotlin/androidx/compose/testutils/ImageAssertions.android.kt
 
 /**
  * Asserts that the color at a specific pixel in the bitmap at ([x], [y]) is [expected].
  */
-fun PixelMap.assertPixelColor(expected: Color, x: Int, y: Int, tolerance: Float = 0.001f) {
+fun PixelMap.assertPixelColor(expected: Color, x: Int, y: Int, tolerance: Float = 0.02f) {
     val color = this[x, y]
     assertThat(color.red).isWithin(tolerance).of(expected.red)
     assertThat(color.green).isWithin(tolerance).of(expected.green)
@@ -176,48 +165,11 @@ fun ImageBitmap.assertShape(
     }
 }
 
-/**
- * Asserts that the bitmap is fully occupied by the given [shape] with the color [shapeColor]
- * without [horizontalPadding] and [verticalPadding] from the sides. The padded area is expected
- * to have [backgroundColor].
- *
- * @param density current [Density] or the screen
- * @param horizontalPadding the symmetrical padding to be applied from both left and right sides
- * @param verticalPadding the symmetrical padding to be applied from both top and bottom sides
- * @param backgroundColor the color of the background
- * @param shapeColor the color of the shape
- * @param shape defines the [Shape]
- * @param shapeOverlapPixelCount The size of the border area from the shape outline to leave it
- * untested as it is likely anti-aliased. The default is 1 pixel
- */
-fun ImageBitmap.assertShape(
-    density: Density,
-    horizontalPadding: Dp,
-    verticalPadding: Dp,
-    backgroundColor: Color,
-    shapeColor: Color,
-    shape: Shape = RectangleShape,
-    shapeOverlapPixelCount: Float = 1.0f
-) {
-    val fullHorizontalPadding = with(density) { horizontalPadding.toPx() * 2 }
-    val fullVerticalPadding = with(density) { verticalPadding.toPx() * 2 }
-    return assertShape(
-        density = density,
-        shape = shape,
-        shapeColor = shapeColor,
-        backgroundColor = backgroundColor,
-        backgroundShape = RectangleShape,
-        shapeSizeX = width.toFloat() - fullHorizontalPadding,
-        shapeSizeY = height.toFloat() - fullVerticalPadding,
-        shapeOverlapPixelCount = shapeOverlapPixelCount
-    )
-}
-
 private infix fun Float.until(until: Float): IntRange {
     val from = this.roundToInt()
     val to = until.roundToInt()
     if (from <= Int.MIN_VALUE) return IntRange.EMPTY
-    return from..(to - 1)
+    return from until to
 }
 
 private fun pixelCloserToCenter(

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/ImageAssertions.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/ImageAssertions.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.placeholder
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.graphics.asAndroidPath
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert
+import kotlin.math.roundToInt
+
+/**
+ * Assert that all of the pixels in this image as of the [expected] color.
+ */
+fun ImageBitmap.assertPixels(expected: Color, tolerance: Float = 0.001f) {
+    toPixelMap().buffer.forEach { pixel ->
+        val color = Color(pixel)
+        assertThat(color.red).isWithin(tolerance).of(expected.red)
+        assertThat(color.green).isWithin(tolerance).of(expected.green)
+        assertThat(color.blue).isWithin(tolerance).of(expected.blue)
+        assertThat(color.alpha).isWithin(tolerance).of(expected.alpha)
+    }
+}
+
+/**
+ * Asserts that the color at a specific pixel in the bitmap at ([x], [y]) is [expected].
+ */
+fun PixelMap.assertPixelColor(expected: Color, x: Int, y: Int, tolerance: Float = 0.001f) {
+    val color = this[x, y]
+    assertThat(color.red).isWithin(tolerance).of(expected.red)
+    assertThat(color.green).isWithin(tolerance).of(expected.green)
+    assertThat(color.blue).isWithin(tolerance).of(expected.blue)
+    assertThat(color.alpha).isWithin(tolerance).of(expected.alpha)
+}
+
+/**
+ * Tests to see if the given point is within the path. (That is, whether the
+ * point would be in the visible portion of the path if the path was used
+ * with [Canvas.clipPath].)
+ *
+ * The `point` argument is interpreted as an offset from the origin.
+ *
+ * Returns true if the point is in the path, and false otherwise.
+ */
+fun Path.contains(offset: Offset): Boolean {
+    val path = android.graphics.Path()
+    path.addRect(
+        offset.x - 0.01f,
+        offset.y - 0.01f,
+        offset.x + 0.01f,
+        offset.y + 0.01f,
+        android.graphics.Path.Direction.CW
+    )
+    if (path.op(asAndroidPath(), android.graphics.Path.Op.INTERSECT)) {
+        return !path.isEmpty
+    }
+    return false
+}
+
+/**
+ * Asserts that the given [shape] is drawn within the bitmap with the size the dimensions
+ * [shapeSizeX] x [shapeSizeY], centered at ([centerX], [centerY]) with the color [shapeColor].
+ * The bitmap area examined is [sizeX] x [sizeY], centered at ([centerX], [centerY]) and everything
+ * outside the shape is expected to be color [backgroundColor].
+ *
+ * @param density current [Density] or the screen
+ * @param shape defines the [Shape]
+ * @param shapeColor the color of the shape
+ * @param backgroundColor the color of the background
+ * @param backgroundShape defines the [Shape] of the background
+ * @param sizeX width of the area filled with the [backgroundShape]
+ * @param sizeY height of the area filled with the [backgroundShape]
+ * @param shapeSizeX width of the area filled with the [shape]
+ * @param shapeSizeY height of the area filled with the [shape]
+ * @param centerX the X position of the center of the [shape] inside the [sizeX]
+ * @param centerY the Y position of the center of the [shape] inside the [sizeY]
+ * @param shapeOverlapPixelCount The size of the border area from the shape outline to leave it
+ * untested as it is likely anti-aliased. The default is 1 pixel
+ */
+// TODO (mount, malkov) : to investigate why it flakes when shape is not rect
+fun ImageBitmap.assertShape(
+    density: Density,
+    shape: Shape,
+    shapeColor: Color,
+    backgroundColor: Color,
+    backgroundShape: Shape = RectangleShape,
+    sizeX: Float = width.toFloat(),
+    sizeY: Float = height.toFloat(),
+    shapeSizeX: Float = sizeX,
+    shapeSizeY: Float = sizeY,
+    centerX: Float = width / 2f,
+    centerY: Float = height / 2f,
+    shapeOverlapPixelCount: Float = 1.0f
+) {
+    val width = width
+    val height = height
+    val pixels = toPixelMap()
+    Assert.assertTrue(centerX + sizeX / 2 <= width)
+    Assert.assertTrue(centerX - sizeX / 2 >= 0.0f)
+    Assert.assertTrue(centerY + sizeY / 2 <= height)
+    Assert.assertTrue(centerY - sizeY / 2 >= 0.0f)
+    val outline = shape.createOutline(Size(shapeSizeX, shapeSizeY), LayoutDirection.Ltr, density)
+    val path = Path()
+    path.addOutline(outline)
+    val shapeOffset = Offset(
+        (centerX - shapeSizeX / 2f),
+        (centerY - shapeSizeY / 2f)
+    )
+    val backgroundPath = Path()
+    backgroundPath.addOutline(
+        backgroundShape.createOutline(Size(sizeX, sizeY), LayoutDirection.Ltr, density)
+    )
+    for (x in centerX - sizeX / 2 until centerX + sizeX / 2) {
+        for (y in centerY - sizeY / 2 until centerY + sizeY / 2) {
+            val point = Offset(x.toFloat(), y.toFloat())
+            if (!backgroundPath.contains(
+                    pixelFartherFromCenter(
+                            point,
+                            sizeX,
+                            sizeY,
+                            shapeOverlapPixelCount
+                        )
+                )
+            ) {
+                continue
+            }
+            val offset = point - shapeOffset
+            val isInside = path.contains(
+                pixelFartherFromCenter(
+                    offset,
+                    shapeSizeX,
+                    shapeSizeY,
+                    shapeOverlapPixelCount
+                )
+            )
+            val isOutside = !path.contains(
+                pixelCloserToCenter(
+                    offset,
+                    shapeSizeX,
+                    shapeSizeY,
+                    shapeOverlapPixelCount
+                )
+            )
+            if (isInside) {
+                pixels.assertPixelColor(shapeColor, x, y)
+            } else if (isOutside) {
+                pixels.assertPixelColor(backgroundColor, x, y)
+            }
+        }
+    }
+}
+
+/**
+ * Asserts that the bitmap is fully occupied by the given [shape] with the color [shapeColor]
+ * without [horizontalPadding] and [verticalPadding] from the sides. The padded area is expected
+ * to have [backgroundColor].
+ *
+ * @param density current [Density] or the screen
+ * @param horizontalPadding the symmetrical padding to be applied from both left and right sides
+ * @param verticalPadding the symmetrical padding to be applied from both top and bottom sides
+ * @param backgroundColor the color of the background
+ * @param shapeColor the color of the shape
+ * @param shape defines the [Shape]
+ * @param shapeOverlapPixelCount The size of the border area from the shape outline to leave it
+ * untested as it is likely anti-aliased. The default is 1 pixel
+ */
+fun ImageBitmap.assertShape(
+    density: Density,
+    horizontalPadding: Dp,
+    verticalPadding: Dp,
+    backgroundColor: Color,
+    shapeColor: Color,
+    shape: Shape = RectangleShape,
+    shapeOverlapPixelCount: Float = 1.0f
+) {
+    val fullHorizontalPadding = with(density) { horizontalPadding.toPx() * 2 }
+    val fullVerticalPadding = with(density) { verticalPadding.toPx() * 2 }
+    return assertShape(
+        density = density,
+        shape = shape,
+        shapeColor = shapeColor,
+        backgroundColor = backgroundColor,
+        backgroundShape = RectangleShape,
+        shapeSizeX = width.toFloat() - fullHorizontalPadding,
+        shapeSizeY = height.toFloat() - fullVerticalPadding,
+        shapeOverlapPixelCount = shapeOverlapPixelCount
+    )
+}
+
+private infix fun Float.until(until: Float): IntRange {
+    val from = this.roundToInt()
+    val to = until.roundToInt()
+    if (from <= Int.MIN_VALUE) return IntRange.EMPTY
+    return from..(to - 1)
+}
+
+private fun pixelCloserToCenter(
+    offset: Offset,
+    shapeSizeX: Float,
+    shapeSizeY: Float,
+    delta: Float
+): Offset {
+    val centerX = shapeSizeX / 2f
+    val centerY = shapeSizeY / 2f
+    val d = delta
+    val x = when {
+        offset.x > centerX -> offset.x - d
+        offset.x < centerX -> offset.x + d
+        else -> offset.x
+    }
+    val y = when {
+        offset.y > centerY -> offset.y - d
+        offset.y < centerY -> offset.y + d
+        else -> offset.y
+    }
+    return Offset(x, y)
+}
+
+private fun pixelFartherFromCenter(
+    offset: Offset,
+    shapeSizeX: Float,
+    shapeSizeY: Float,
+    delta: Float
+): Offset {
+    val centerX = shapeSizeX / 2f
+    val centerY = shapeSizeY / 2f
+    val d = delta
+    val x = when {
+        offset.x > centerX -> offset.x + d
+        offset.x < centerX -> offset.x - d
+        else -> offset.x
+    }
+    val y = when {
+        offset.y > centerY -> offset.y + d
+        offset.y < centerY -> offset.y - d
+        else -> offset.y
+    }
+    return Offset(x, y)
+}

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/ImageAssertions.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/ImageAssertions.kt
@@ -16,26 +16,11 @@
 
 package com.google.accompanist.placeholder
 
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PixelMap
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.addOutline
-import androidx.compose.ui.graphics.asAndroidPath
 import androidx.compose.ui.graphics.toPixelMap
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assert
-import kotlin.math.roundToInt
-
-// Copied from AndroidX Compose test-utils:
-// https://github.com/androidx/androidx/blob/androidx-main/compose/test-utils/src/androidMain/kotlin/androidx/compose/testutils/ImageAssertions.android.kt
 
 /**
  * Asserts that the color at a specific pixel in the bitmap at ([x], [y]) is [expected].
@@ -49,169 +34,13 @@ fun PixelMap.assertPixelColor(expected: Color, x: Int, y: Int, tolerance: Float 
 }
 
 /**
- * Tests to see if the given point is within the path. (That is, whether the
- * point would be in the visible portion of the path if the path was used
- * with [Canvas.clipPath].)
- *
- * The `point` argument is interpreted as an offset from the origin.
- *
- * Returns true if the point is in the path, and false otherwise.
+ * Asserts that the colors at specific pixels in the vertices of bitmap is [expected].
  */
-fun Path.contains(offset: Offset): Boolean {
-    val path = android.graphics.Path()
-    path.addRect(
-        offset.x - 0.01f,
-        offset.y - 0.01f,
-        offset.x + 0.01f,
-        offset.y + 0.01f,
-        android.graphics.Path.Direction.CW
-    )
-    if (path.op(asAndroidPath(), android.graphics.Path.Op.INTERSECT)) {
-        return !path.isEmpty
+fun ImageBitmap.assertPixelsOfVertices(expected: Color) {
+    toPixelMap().run {
+        assertPixelColor(expected, 0, 0)
+        assertPixelColor(expected, 0, height - 1)
+        assertPixelColor(expected, width - 1, 0)
+        assertPixelColor(expected, width - 1, height - 1)
     }
-    return false
-}
-
-/**
- * Asserts that the given [shape] is drawn within the bitmap with the size the dimensions
- * [shapeSizeX] x [shapeSizeY], centered at ([centerX], [centerY]) with the color [shapeColor].
- * The bitmap area examined is [sizeX] x [sizeY], centered at ([centerX], [centerY]) and everything
- * outside the shape is expected to be color [backgroundColor].
- *
- * @param density current [Density] or the screen
- * @param shape defines the [Shape]
- * @param shapeColor the color of the shape
- * @param backgroundColor the color of the background
- * @param backgroundShape defines the [Shape] of the background
- * @param sizeX width of the area filled with the [backgroundShape]
- * @param sizeY height of the area filled with the [backgroundShape]
- * @param shapeSizeX width of the area filled with the [shape]
- * @param shapeSizeY height of the area filled with the [shape]
- * @param centerX the X position of the center of the [shape] inside the [sizeX]
- * @param centerY the Y position of the center of the [shape] inside the [sizeY]
- * @param shapeOverlapPixelCount The size of the border area from the shape outline to leave it
- * untested as it is likely anti-aliased. The default is 1 pixel
- */
-// TODO (mount, malkov) : to investigate why it flakes when shape is not rect
-fun ImageBitmap.assertShape(
-    density: Density,
-    shape: Shape,
-    shapeColor: Color,
-    backgroundColor: Color,
-    backgroundShape: Shape = RectangleShape,
-    sizeX: Float = width.toFloat(),
-    sizeY: Float = height.toFloat(),
-    shapeSizeX: Float = sizeX,
-    shapeSizeY: Float = sizeY,
-    centerX: Float = width / 2f,
-    centerY: Float = height / 2f,
-    shapeOverlapPixelCount: Float = 1.0f
-) {
-    val width = width
-    val height = height
-    val pixels = toPixelMap()
-    Assert.assertTrue(centerX + sizeX / 2 <= width)
-    Assert.assertTrue(centerX - sizeX / 2 >= 0.0f)
-    Assert.assertTrue(centerY + sizeY / 2 <= height)
-    Assert.assertTrue(centerY - sizeY / 2 >= 0.0f)
-    val outline = shape.createOutline(Size(shapeSizeX, shapeSizeY), LayoutDirection.Ltr, density)
-    val path = Path()
-    path.addOutline(outline)
-    val shapeOffset = Offset(
-        (centerX - shapeSizeX / 2f),
-        (centerY - shapeSizeY / 2f)
-    )
-    val backgroundPath = Path()
-    backgroundPath.addOutline(
-        backgroundShape.createOutline(Size(sizeX, sizeY), LayoutDirection.Ltr, density)
-    )
-    for (x in centerX - sizeX / 2 until centerX + sizeX / 2) {
-        for (y in centerY - sizeY / 2 until centerY + sizeY / 2) {
-            val point = Offset(x.toFloat(), y.toFloat())
-            if (!backgroundPath.contains(
-                    pixelFartherFromCenter(
-                            point,
-                            sizeX,
-                            sizeY,
-                            shapeOverlapPixelCount
-                        )
-                )
-            ) {
-                continue
-            }
-            val offset = point - shapeOffset
-            val isInside = path.contains(
-                pixelFartherFromCenter(
-                    offset,
-                    shapeSizeX,
-                    shapeSizeY,
-                    shapeOverlapPixelCount
-                )
-            )
-            val isOutside = !path.contains(
-                pixelCloserToCenter(
-                    offset,
-                    shapeSizeX,
-                    shapeSizeY,
-                    shapeOverlapPixelCount
-                )
-            )
-            if (isInside) {
-                pixels.assertPixelColor(shapeColor, x, y)
-            } else if (isOutside) {
-                pixels.assertPixelColor(backgroundColor, x, y)
-            }
-        }
-    }
-}
-
-private infix fun Float.until(until: Float): IntRange {
-    val from = this.roundToInt()
-    val to = until.roundToInt()
-    if (from <= Int.MIN_VALUE) return IntRange.EMPTY
-    return from until to
-}
-
-private fun pixelCloserToCenter(
-    offset: Offset,
-    shapeSizeX: Float,
-    shapeSizeY: Float,
-    delta: Float
-): Offset {
-    val centerX = shapeSizeX / 2f
-    val centerY = shapeSizeY / 2f
-    val d = delta
-    val x = when {
-        offset.x > centerX -> offset.x - d
-        offset.x < centerX -> offset.x + d
-        else -> offset.x
-    }
-    val y = when {
-        offset.y > centerY -> offset.y - d
-        offset.y < centerY -> offset.y + d
-        else -> offset.y
-    }
-    return Offset(x, y)
-}
-
-private fun pixelFartherFromCenter(
-    offset: Offset,
-    shapeSizeX: Float,
-    shapeSizeY: Float,
-    delta: Float
-): Offset {
-    val centerX = shapeSizeX / 2f
-    val centerY = shapeSizeY / 2f
-    val d = delta
-    val x = when {
-        offset.x > centerX -> offset.x + d
-        offset.x < centerX -> offset.x - d
-        else -> offset.x
-    }
-    val y = when {
-        offset.y > centerY -> offset.y + d
-        offset.y < centerY -> offset.y - d
-        else -> offset.y
-    }
-    return Offset(x, y)
 }

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderAnimatedBrush.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderAnimatedBrush.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.placeholder
+
+import androidx.compose.animation.core.InfiniteRepeatableSpec
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+
+internal class Solid(
+    private val color: Color,
+    private val animationSpec: InfiniteRepeatableSpec<Float> = infiniteRepeatable(
+        animation = tween(
+            delayMillis = 0,
+            durationMillis = 500
+        ),
+        repeatMode = RepeatMode.Restart
+    )
+) : PlaceholderAnimatedBrush() {
+
+    override fun minimumProgress(): Float = 0f
+
+    override fun maximumProgress(): Float = 1f
+
+    override fun animationSpec(): InfiniteRepeatableSpec<Float> = animationSpec
+
+    override fun brush(progress: Float): Brush {
+        return SolidColor(color)
+    }
+}

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
@@ -236,12 +236,9 @@ class PlaceholderTest {
             .assertWidthIsEqualTo(20.dp)
             .assertHeightIsEqualTo(20.dp)
             .captureToImage()
-            .assertShape(
-                density = composeTestRule.density,
-                shape = CircleShape,
-                shapeColor = Color.Red,
-                backgroundColor = Color.Black
-            )
+            // There is no stable API to assert the shape.
+            // So check the color of the vertices simply.
+            .assertPixelsOfVertices(Color.Black)
     }
 
     @Test
@@ -277,12 +274,9 @@ class PlaceholderTest {
             .assertWidthIsEqualTo(20.dp)
             .assertHeightIsEqualTo(20.dp)
             .captureToImage()
-            .assertShape(
-                density = composeTestRule.density,
-                shape = CircleShape,
-                shapeColor = Color.Red,
-                backgroundColor = Color.Black
-            )
+            // There is no stable API to assert the shape.
+            // So check the color of the vertices simply.
+            .assertPixelsOfVertices(Color.Black)
     }
 
     @Test

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
@@ -113,7 +113,7 @@ class PlaceholderTest {
                     .background(color = Color.Black)
                     .placeholder(
                         visible = visible,
-                        animatedBrush = shimmer(Color.Red, Color.Red)
+                        animatedBrush = Solid(Color.Red)
                     )
                     .testTag(contentTag)
             )
@@ -171,7 +171,7 @@ class PlaceholderTest {
     @Test
     @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
     fun placeholder_switchAnimatedBrush() {
-        var animatedBrush by mutableStateOf(shimmer(Color.Red, Color.Red))
+        var animatedBrush by mutableStateOf(Solid(Color.Red))
 
         composeTestRule.setContent {
             Box(
@@ -193,7 +193,7 @@ class PlaceholderTest {
             .captureToImage()
             .assertPixels(Color.Red)
 
-        animatedBrush = fade(Color.Blue, Color.Blue)
+        animatedBrush = Solid(Color.Blue)
 
         composeTestRule.onNodeWithTag(contentTag)
             .assertIsDisplayed()
@@ -256,7 +256,7 @@ class PlaceholderTest {
                     .background(color = Color.Black)
                     .placeholder(
                         visible = true,
-                        animatedBrush = shimmer(Color.Red, Color.Red),
+                        animatedBrush = Solid(Color.Red),
                         shape = shape
                     )
                     .testTag(contentTag)
@@ -305,6 +305,18 @@ class PlaceholderTest {
         assertThat(modifier.inspectableElements.asIterable()).containsExactly(
             ValueElement("visible", true),
             ValueElement("animatedBrush", shimmer()),
+            ValueElement("shape", RectangleShape)
+        )
+    }
+
+    @Test
+    fun placeholder_inspectableParameter3() {
+        val modifier = Modifier.placeholder(true, fade()) as InspectableValue
+        assertThat(modifier.nameFallback).isEqualTo("placeholder")
+        assertThat(modifier.valueOverride).isEqualTo(true)
+        assertThat(modifier.inspectableElements.asIterable()).containsExactly(
+            ValueElement("visible", true),
+            ValueElement("animatedBrush", fade()),
             ValueElement("shape", RectangleShape)
         )
     }

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.test.filters.LargeTest
 import androidx.test.filters.SdkSuppress
+import com.google.accompanist.imageloading.test.assertPixels
 import com.google.accompanist.placeholder.PlaceholderAnimatedBrush.Companion.fade
 import com.google.accompanist.placeholder.PlaceholderAnimatedBrush.Companion.shimmer
 import com.google.common.truth.Truth.assertThat
@@ -210,7 +211,7 @@ class PlaceholderTest {
         composeTestRule.setContent {
             Box(
                 Modifier
-                    .size(128.dp)
+                    .size(20.dp)
                     .background(color = Color.Black)
                     .placeholder(
                         visible = true,
@@ -223,8 +224,8 @@ class PlaceholderTest {
 
         composeTestRule.onNodeWithTag(contentTag)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(128.dp)
-            .assertHeightIsEqualTo(128.dp)
+            .assertWidthIsEqualTo(20.dp)
+            .assertHeightIsEqualTo(20.dp)
             .captureToImage()
             .assertPixels(Color.Red)
 
@@ -232,8 +233,8 @@ class PlaceholderTest {
 
         composeTestRule.onNodeWithTag(contentTag)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(128.dp)
-            .assertHeightIsEqualTo(128.dp)
+            .assertWidthIsEqualTo(20.dp)
+            .assertHeightIsEqualTo(20.dp)
             .captureToImage()
             .assertShape(
                 density = composeTestRule.density,
@@ -251,7 +252,7 @@ class PlaceholderTest {
         composeTestRule.setContent {
             Box(
                 Modifier
-                    .size(128.dp)
+                    .size(20.dp)
                     .background(color = Color.Black)
                     .placeholder(
                         visible = true,
@@ -264,8 +265,8 @@ class PlaceholderTest {
 
         composeTestRule.onNodeWithTag(contentTag)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(128.dp)
-            .assertHeightIsEqualTo(128.dp)
+            .assertWidthIsEqualTo(20.dp)
+            .assertHeightIsEqualTo(20.dp)
             .captureToImage()
             .assertPixels(Color.Red)
 
@@ -273,8 +274,8 @@ class PlaceholderTest {
 
         composeTestRule.onNodeWithTag(contentTag)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(128.dp)
-            .assertHeightIsEqualTo(128.dp)
+            .assertWidthIsEqualTo(20.dp)
+            .assertHeightIsEqualTo(20.dp)
             .captureToImage()
             .assertShape(
                 density = composeTestRule.density,

--- a/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
+++ b/placeholder/src/androidTest/java/com/google/accompanist/placeholder/PlaceholderTest.kt
@@ -19,6 +19,10 @@ package com.google.accompanist.placeholder
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
@@ -35,7 +39,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import androidx.test.filters.LargeTest
 import androidx.test.filters.SdkSuppress
-import com.google.accompanist.imageloading.test.assertPixels
+import com.google.accompanist.placeholder.PlaceholderAnimatedBrush.Companion.fade
 import com.google.accompanist.placeholder.PlaceholderAnimatedBrush.Companion.shimmer
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
@@ -66,42 +70,218 @@ class PlaceholderTest {
 
     @Test
     @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
-    fun placeholder_hideContentIfVisible() {
+    fun placeholder_switchVisible1() {
+        var visible by mutableStateOf(true)
+
         composeTestRule.setContent {
             Box(
                 Modifier
                     .size(128.dp)
                     .background(color = Color.Black)
-                    .placeholder(visible = true, color = Color.Red)
+                    .placeholder(visible = visible, color = Color.Red)
                     .testTag(contentTag)
             )
         }
+
         composeTestRule.onNodeWithTag(contentTag)
             .assertIsDisplayed()
             .assertWidthIsEqualTo(128.dp)
             .assertHeightIsEqualTo(128.dp)
             .captureToImage()
             .assertPixels(Color.Red)
-    }
 
-    @Test
-    @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
-    fun placeholder_showsContentIfNotVisible() {
-        composeTestRule.setContent {
-            Box(
-                Modifier
-                    .size(128.dp)
-                    .background(color = Color.Black)
-                    .placeholder(visible = false, color = Color.Red)
-                    .testTag(contentTag)
-            )
-        }
+        visible = false
+
         composeTestRule.onNodeWithTag(contentTag)
             .assertIsDisplayed()
             .assertWidthIsEqualTo(128.dp)
             .assertHeightIsEqualTo(128.dp)
             .captureToImage()
             .assertPixels(Color.Black)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
+    fun placeholder_switchVisible2() {
+        var visible by mutableStateOf(true)
+
+        composeTestRule.setContent {
+            Box(
+                Modifier
+                    .size(128.dp)
+                    .background(color = Color.Black)
+                    .placeholder(
+                        visible = visible,
+                        animatedBrush = shimmer(Color.Red, Color.Red)
+                    )
+                    .testTag(contentTag)
+            )
+        }
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Red)
+
+        visible = false
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Black)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
+    fun placeholder_switchColor() {
+        var color by mutableStateOf(Color.Red)
+
+        composeTestRule.setContent {
+            Box(
+                Modifier
+                    .size(128.dp)
+                    .background(color = Color.Black)
+                    .placeholder(visible = true, color = color)
+                    .testTag(contentTag)
+            )
+        }
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Red)
+
+        color = Color.Blue
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Blue)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
+    fun placeholder_switchAnimatedBrush() {
+        var animatedBrush by mutableStateOf(shimmer(Color.Red, Color.Red))
+
+        composeTestRule.setContent {
+            Box(
+                Modifier
+                    .size(128.dp)
+                    .background(color = Color.Black)
+                    .placeholder(
+                        visible = true,
+                        animatedBrush = animatedBrush
+                    )
+                    .testTag(contentTag)
+            )
+        }
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Red)
+
+        animatedBrush = fade(Color.Blue, Color.Blue)
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Blue)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
+    fun placeholder_switchShape1() {
+        var shape by mutableStateOf(RectangleShape)
+
+        composeTestRule.setContent {
+            Box(
+                Modifier
+                    .size(128.dp)
+                    .background(color = Color.Black)
+                    .placeholder(
+                        visible = true,
+                        color = Color.Red,
+                        shape = shape
+                    )
+                    .testTag(contentTag)
+            )
+        }
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Red)
+
+        shape = CircleShape
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertShape(
+                density = composeTestRule.density,
+                shape = CircleShape,
+                shapeColor = Color.Red,
+                backgroundColor = Color.Black
+            )
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 26) // captureToImage is SDK 26+
+    fun placeholder_switchShape2() {
+        var shape by mutableStateOf(RectangleShape)
+
+        composeTestRule.setContent {
+            Box(
+                Modifier
+                    .size(128.dp)
+                    .background(color = Color.Black)
+                    .placeholder(
+                        visible = true,
+                        animatedBrush = shimmer(Color.Red, Color.Red),
+                        shape = shape
+                    )
+                    .testTag(contentTag)
+            )
+        }
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertPixels(Color.Red)
+
+        shape = CircleShape
+
+        composeTestRule.onNodeWithTag(contentTag)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(128.dp)
+            .captureToImage()
+            .assertShape(
+                density = composeTestRule.density,
+                shape = CircleShape,
+                shapeColor = Color.Red,
+                backgroundColor = Color.Black
+            )
     }
 
     @Test

--- a/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
@@ -92,7 +92,7 @@ fun Modifier.placeholder(
         targetValue = animatedBrush.maximumProgress(),
         animationSpec = animatedBrush.animationSpec()
     )
-    remember {
+    remember(animatedBrush, shape) {
         PlaceholderModifier(
             brush = animatedBrush,
             shape = shape

--- a/placeholder/src/main/java/com/google/accompanist/placeholder/PlaceholderAnimatedBrush.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/PlaceholderAnimatedBrush.kt
@@ -37,7 +37,7 @@ object PlaceholderDefaults {
 /**
  * A class which provides a brush to paint placeholder based on progress.
  */
-sealed class PlaceholderAnimatedBrush {
+abstract class PlaceholderAnimatedBrush {
 
     /**
      * A minimum value of animation's progress range.


### PR DESCRIPTION
- Use `remember` with keys.
- Add more tests to validate recomposition situations.
- Add README and gradle.properties missing in #457.

Fixes #466.

| Before | After |
|---------------|--------------|
| <img width="300" src="https://user-images.githubusercontent.com/3405740/120853024-08f62180-c5b6-11eb-9aaa-5ecf914ee874.gif" /> | <img width="300" src="https://user-images.githubusercontent.com/3405740/120853014-05fb3100-c5b6-11eb-826b-c19c3c6e3d5e.gif" /> |