### PR TITLE
Stop building the tests before running them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,9 +93,6 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build tests
-        run: ./gradlew assembleDebugAndroidTest --scan
-
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
Let Gradle handle the scheduling of the tasks.