### PR TITLE
[All] Only run tests on affected modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,6 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [22, 26, 28, 29]
-        shard: [0, 1, 2]
 
     env:
       TERM: dumb
@@ -112,14 +111,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-${{ matrix.api-level }}-${{ matrix.shard }}
+          name: logs-${{ matrix.api-level }}
           path: logcat.txt
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
+          name: test-results-${{ matrix.api-level }}
           path: |
             "**/build/outputs/*/connected/**"
             "**/build/reports/**"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           profile: Galaxy Nexus
           # We run all affected tests of the PR (or commit)
-          script: ./scripts/run-device-tests.sh --log-file=logcat.txt --run-affected --affected-base=ref=$BASE_REF
+          script: ./scripts/run-device-tests.sh --log-file=logcat.txt --run-affected --affected-base-ref=$BASE_REF
 
       - name: Clean secrets
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
   test:
     runs-on: macOS-latest
     needs: build
-    timeout-minutes: 70
+    timeout-minutes: 45
     
     strategy:
       # Allow tests to continue on other devices if they fail on one device.
@@ -101,9 +101,7 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           profile: Galaxy Nexus
-          script: |
-            adb logcat > logcat.txt &
-            ./gradlew connectedCheck --scan --continue -Pandroid.testInstrumentationRunnerArguments.numShards=3 -Pandroid.testInstrumentationRunnerArguments.shardIndex=${{ matrix.shard }}
+          script: ./scripts/run-device-tests.sh --log-file=logcat.txt --shard-index=${{ matrix.shard }} --shard-count=3 
 
       - name: Clean secrets
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
   test:
     runs-on: macOS-latest
     needs: build
-    timeout-minutes: 45
+    timeout-minutes: 70
     
     strategy:
       # Allow tests to continue on other devices if they fail on one device.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,8 +120,8 @@ jobs:
         with:
           name: test-results-${{ matrix.api-level }}
           path: |
-            "**/build/outputs/*/connected/**"
-            "**/build/reports/**"
+            **/build/reports/*
+            **/build/outputs/*/connected/*
 
   deploy:
     if: github.event_name == 'push' # only deploy for pushed commits (not PRs)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # 0 == fetch all history, which is needed for affected module detection
+          fetch-depth: '0'
 
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
@@ -93,15 +96,13 @@ jobs:
             ~/.gradle/caches/build-cache-*
           key: gradle-${{ hashFiles('checksum.txt') }}
 
-      - name: Build tests
-        run: ./gradlew assembleDebugAndroidTest --scan
-
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           profile: Galaxy Nexus
-          script: ./scripts/run-device-tests.sh --log-file=logcat.txt --shard-index=${{ matrix.shard }} --shard-count=3 
+          # We run all affected tests of the PR (or commit)
+          script: ./scripts/run-device-tests.sh --log-file=logcat.txt --run-affected --affected-base=ref=$BASE_REF
 
       - name: Clean secrets
         if: always()
@@ -119,7 +120,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
-          path: "**/build/outputs/*/connected/*.xml"
+          path: |
+            "**/build/outputs/*/connected/**"
+            "**/build/reports/**"
 
   deploy:
     if: github.event_name == 'push' # only deploy for pushed commits (not PRs)

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -68,5 +68,5 @@ jobs:
         with:
           name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
           path: |
-            "**/build/outputs/*/connected/**"
-            "**/build/reports/**"
+             **/build/reports/*
+             **/build/outputs/*/connected/*

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -1,0 +1,72 @@
+name: Instrumented tests on device
+
+on:
+  schedule:
+    # Run this twice per day, at 6:13 and 16:13
+    - cron:  '13 6,16 * * *'
+
+jobs:
+  android-test:
+    runs-on: macOS-latest
+    needs: build
+    timeout-minutes: 40
+
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level: [22, 26, 28, 29]
+        shard: [0, 1, 2] # Need to update shard-count below if this changes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Decrypt secrets
+        run: release/signing-setup.sh ${{ secrets.ENCRYPT_KEY }}
+
+      - name: Generate cache key
+        run: ./checksum.sh checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          profile: Galaxy Nexus
+          # We run all tests, sharding them over 3 shards
+          script: ./scripts/run-device-tests.sh --log-file=logcat.txt --shard-index=${{ matrix.shard }} --shard-count=3
+
+      - name: Clean secrets
+        if: always()
+        run: release/signing-cleanup.sh
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: logcat.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: |
+            "**/build/outputs/*/connected/**"
+            "**/build/reports/**"

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,9 @@ affectedModuleDetector {
     String baseRef = findProperty("affected_base_ref")
     // If we have a base ref to diff against, extract the branch name and use it
     if (baseRef != null && !baseRef.isEmpty()) {
-        specifiedBranch = baseRef.split('/').last()
+        // Remove the prefix from the head.
+        // TODO: need to support other types of git refs
+        specifiedBranch = baseRef.replace('refs/heads/', '')
         compareFrom = "SpecifiedBranchCommit"
     } else {
         // Otherwise we use the previous commit. This is mostly used for commits to main.

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ buildscript {
         classpath libs.dokka
 
         classpath libs.metalavaGradle
+
+        classpath libs.affectedmoduledetector
     }
 }
 
@@ -37,10 +39,34 @@ plugins {
 }
 
 apply plugin: 'org.jetbrains.dokka'
+apply plugin: 'com.dropbox.affectedmoduledetector'
 
 tasks.withType(org.jetbrains.dokka.gradle.DokkaMultiModuleTask).configureEach {
     outputDirectory = rootProject.file('docs/api')
     failOnWarning = true
+}
+
+affectedModuleDetector {
+    baseDir = "${project.rootDir}"
+    pathsAffectingAllModules = [
+            "gradle/libs.versions.toml",
+    ]
+    excludedModules = [
+            "sample"
+    ]
+
+    logFilename = "output.log"
+    logFolder = "${rootProject.buildDir}/affectedModuleDetector"
+
+    String baseRef = findProperty("affected_base_ref")
+    // If we have a base ref to diff against, extract the branch name and use it
+    if (baseRef != null && !baseRef.isEmpty()) {
+        specifiedBranch = baseRef.split('/').last()
+        compareFrom = "SpecifiedBranchCommit"
+    } else {
+        // Otherwise we use the previous commit. This is mostly used for commits to main.
+        compareFrom = "PreviousCommit"
+    }
 }
 
 allprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,3 +56,5 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxt
 junit = "junit:junit:4.13"
 truth = "com.google.truth:truth:1.1.2"
 testparameterinjection = "com.google.testparameterinjector:test-parameter-injector:1.3"
+
+affectedmoduledetector = "com.dropbox.affectedmoduledetector:affectedmoduledetector:0.1.2"

--- a/scripts/run-device-tests.sh
+++ b/scripts/run-device-tests.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2021 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on error and print out commands
+set -ex
+
+# By default we don't shard
+SHARD_COUNT=0
+SHARD_INDEX=0
+# By default we don't log
+LOG_FILE=""
+# By default we run all tests
+TASK="connectedCheck"
+
+# Parse parameters
+for i in "$@"; do
+  case $i in
+    --shard-count=*)
+    SHARD_COUNT="${i#*=}"
+    shift
+    ;;
+    --shard-index=*)
+    SHARD_INDEX="${i#*=}"
+    shift
+    ;;
+    --log-file=*)
+    LOG_FILE="${i#*=}"
+    shift
+    ;;
+    *)
+    echo "Unknown option"
+    exit 1
+    ;;
+  esac
+done
+
+# Start logcat if we have a file to log to
+if [[ ! -z "$LOG_FILE" ]]; then
+  adb logcat > $LOG_FILE &
+fi
+
+SHARD_OPTS=""
+if [ "$SHARD_COUNT" -gt "0" ]; then
+  # If we have a shard count value, create the necessary Gradle property args.
+  # We assume that SHARD_INDEX has been set too
+  SHARD_OPTS="-Pandroid.testInstrumentationRunnerArguments.numShards=$SHARD_COUNT"
+  SHARD_OPTS="$SHARD_OPTS -Pandroid.testInstrumentationRunnerArguments.shardIndex=$SHARD_INDEX"
+fi
+
+./gradlew  --scan --continue $TASK $SHARD_OPTS

--- a/scripts/run-device-tests.sh
+++ b/scripts/run-device-tests.sh
@@ -40,6 +40,14 @@ for i in "$@"; do
     LOG_FILE="${i#*=}"
     shift
     ;;
+    --run-affected)
+    RUN_AFFECTED=true
+    shift
+    ;;
+    --affected-base-ref=*)
+    BASE_REF="${i#*=}"
+    shift
+    ;;
     *)
     echo "Unknown option"
     exit 1
@@ -50,6 +58,15 @@ done
 # Start logcat if we have a file to log to
 if [[ ! -z "$LOG_FILE" ]]; then
   adb logcat > $LOG_FILE &
+fi
+
+# If we're set to only run affected test, update the Gradle task
+if [[ ! -z "$RUN_AFFECTED" ]]; then
+  TASK="runAffectedAndroidTests -Paffected_module_detector.enable"
+  # If we have a base branch set, add the Gradle property
+  if [[ ! -z "$BASE_REF" ]]; then
+    TASK="$TASK -Paffected_base_ref=$BASE_REF"
+  fi
 fi
 
 SHARD_OPTS=""


### PR DESCRIPTION
We now use https://github.com/dropbox/AffectedModuleDetector to only run tests from affected modules for PRs and commits (i.e. to main).

We also now have a twice-daily workflow which runs all tests on emulators, for sanity checking purposes.

Confirmed that this works in #473 
