### PR TITLE
[Placeholder] Add cross-fade between content + placeholder

### DIFF
--- a/placeholder-material/api/current.api
+++ b/placeholder-material/api/current.api
@@ -9,7 +9,7 @@ package com.google.accompanist.placeholder.material {
   public final class PlaceholderKt {
     method @androidx.compose.runtime.Composable public static long color-8irKtDA(com.google.accompanist.placeholder.PlaceholderDefaults, optional long backgroundColor, optional long contentColor, optional float contentAlpha);
     method @androidx.compose.runtime.Composable public static long fadeHighlightColor-OEFTRvM(com.google.accompanist.placeholder.PlaceholderDefaults, optional long backgroundColor, optional float alpha);
-    method public static androidx.compose.ui.Modifier placeholder-Uo-R7fc(androidx.compose.ui.Modifier, boolean visible, optional long color, optional androidx.compose.ui.graphics.Shape? shape, optional com.google.accompanist.placeholder.PlaceholderHighlight? highlight);
+    method public static androidx.compose.ui.Modifier placeholder-TMn5paM(androidx.compose.ui.Modifier, boolean visible, optional long color, optional androidx.compose.ui.graphics.Shape? shape, optional com.google.accompanist.placeholder.PlaceholderHighlight? highlight, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.core.Transition.Segment<java.lang.Boolean>,? extends androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float>> placeholderFadeTransitionSpec, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.core.Transition.Segment<java.lang.Boolean>,? extends androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float>> contentFadeTransitionSpec);
     method @androidx.compose.runtime.Composable public static long shimmerHighlightColor-OEFTRvM(com.google.accompanist.placeholder.PlaceholderDefaults, optional long backgroundColor, optional float alpha);
   }
 

--- a/placeholder-material/src/main/java/com/google/accompanist/placeholder/material/Placeholder.kt
+++ b/placeholder-material/src/main/java/com/google/accompanist/placeholder/material/Placeholder.kt
@@ -16,6 +16,9 @@
 
 package com.google.accompanist.placeholder.material
 
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.Transition
+import androidx.compose.animation.core.spring
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
@@ -81,6 +84,10 @@ fun PlaceholderDefaults.shimmerHighlightColor(
  * To customize the color and shape of the placeholder, you can use the foundation version of
  * [Modifier.placeholder], along with the values provided by [PlaceholderDefaults].
  *
+ * A cross-fade transition will be applied to the content and placeholder UI when the [visible]
+ * value changes. The transition can be customized via the [contentFadeTransitionSpec] and
+ * [placeholderFadeTransitionSpec] parameters.
+ *
  * You can provide a [PlaceholderHighlight] which runs an highlight animation on the placeholder.
  * The [shimmer] and [fade] implementations are provided for easy usage.
  *
@@ -96,17 +103,25 @@ fun PlaceholderDefaults.shimmerHighlightColor(
  * @param shape desired shape of the placeholder. If null is provided the placeholder
  * will use the small shape set in [MaterialTheme.shapes].
  * @param highlight optional highlight animation.
+ * @param placeholderFadeTransitionSpec The transition spec to use when fading the placeholder
+ * on/off screen. The boolean parameter defined for the transition is [visible].
+ * @param contentFadeTransitionSpec The transition spec to use when fading the content
+ * on/off screen. The boolean parameter defined for the transition is [visible].
  */
 fun Modifier.placeholder(
     visible: Boolean,
     color: Color = Color.Unspecified,
     shape: Shape? = null,
     highlight: PlaceholderHighlight? = null,
+    placeholderFadeTransitionSpec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> = { spring() },
+    contentFadeTransitionSpec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> = { spring() },
 ): Modifier = composed {
     Modifier.placeholder(
         visible = visible,
         color = if (color.isSpecified) color else PlaceholderDefaults.color(),
         shape = shape ?: MaterialTheme.shapes.small,
         highlight = highlight,
+        placeholderFadeTransitionSpec = placeholderFadeTransitionSpec,
+        contentFadeTransitionSpec = contentFadeTransitionSpec,
     )
 }

--- a/placeholder/api/current.api
+++ b/placeholder/api/current.api
@@ -26,7 +26,7 @@ package com.google.accompanist.placeholder {
   }
 
   public final class PlaceholderKt {
-    method public static androidx.compose.ui.Modifier placeholder-ryuEAks(androidx.compose.ui.Modifier, boolean visible, long color, optional androidx.compose.ui.graphics.Shape shape, optional com.google.accompanist.placeholder.PlaceholderHighlight? highlight);
+    method public static androidx.compose.ui.Modifier placeholder-2Mgfux4(androidx.compose.ui.Modifier, boolean visible, long color, optional androidx.compose.ui.graphics.Shape shape, optional com.google.accompanist.placeholder.PlaceholderHighlight? highlight, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.core.Transition.Segment<java.lang.Boolean>,? extends androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float>> placeholderFadeTransitionSpec, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.core.Transition.Segment<java.lang.Boolean>,? extends androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float>> contentFadeTransitionSpec);
   }
 
 }

--- a/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
@@ -16,12 +16,18 @@
 
 package com.google.accompanist.placeholder
 
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.InfiniteRepeatableSpec
+import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.Transition
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,15 +36,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.node.Ref
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.unit.LayoutDirection
+
 /**
  * Contains default values used by [Modifier.placeholder] and [PlaceholderHighlight].
  */
@@ -73,6 +83,10 @@ object PlaceholderDefaults {
  * You can provide a [PlaceholderHighlight] which runs an highlight animation on the placeholder.
  * The [shimmer] and [fade] implementations are provided for easy usage.
  *
+ * A cross-fade transition will be applied to the content and placeholder UI when the [visible]
+ * value changes. The transition can be customized via the [contentFadeTransitionSpec] and
+ * [placeholderFadeTransitionSpec] parameters.
+ *
  * You can find more information on the pattern at the Material Theming
  * [Placeholder UI](https://material.io/design/communication/launch-screen.html#placeholder-ui)
  * guidelines.
@@ -83,13 +97,19 @@ object PlaceholderDefaults {
  * @param color the color used to draw the placeholder UI.
  * @param shape desired shape of the placeholder. Defaults to [RectangleShape].
  * @param highlight optional highlight animation.
+ * @param placeholderFadeTransitionSpec The transition spec to use when fading the placeholder
+ * on/off screen. The boolean parameter defined for the transition is [visible].
+ * @param contentFadeTransitionSpec The transition spec to use when fading the content
+ * on/off screen. The boolean parameter defined for the transition is [visible].
  */
 fun Modifier.placeholder(
     visible: Boolean,
     color: Color,
     shape: Shape = RectangleShape,
     highlight: PlaceholderHighlight? = null,
-): Modifier = takeIf { visible.not() } ?: composed(
+    placeholderFadeTransitionSpec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> = { spring() },
+    contentFadeTransitionSpec: @Composable Transition.Segment<Boolean>.() -> FiniteAnimationSpec<Float> = { spring() },
+): Modifier = composed(
     inspectorInfo = debugInspectorInfo {
         name = "placeholder"
         value = visible
@@ -99,50 +119,83 @@ fun Modifier.placeholder(
         properties["shape"] = shape
     }
 ) {
-    // TODO: fade the placeholder in and out
-
     // Values used for caching purposes
     val lastSize = remember { Ref<Size>() }
     val lastLayoutDirection = remember { Ref<LayoutDirection>() }
     val lastOutline = remember { Ref<Outline>() }
 
-    // The current animation progress
-    var progress: Float by remember { mutableStateOf(0f) }
+    // The current highlight animation progress
+    var highlightProgress: Float by remember { mutableStateOf(0f) }
 
-    // Run the optional animation spec and update the progress
-    progress = highlight?.animationSpec?.let { spec ->
+    // This is our crossfade transition
+    val transitionState = remember { MutableTransitionState(visible) }.apply {
+        targetState = visible
+    }
+    val transition = updateTransition(transitionState, "placeholder_crossfade")
+
+    val placeholderAlpha by transition.animateFloat(
+        transitionSpec = placeholderFadeTransitionSpec,
+        label = "placeholder_fade",
+        targetValueByState = { placeholderVisible -> if (placeholderVisible) 1f else 0f }
+    )
+    val contentAlpha by transition.animateFloat(
+        transitionSpec = contentFadeTransitionSpec,
+        label = "content_fade",
+        targetValueByState = { placeholderVisible -> if (placeholderVisible) 0f else 1f }
+    )
+
+    // Run the optional animation spec and update the progress if the placeholder is visible
+    val animationSpec = highlight?.animationSpec
+    if (animationSpec != null && (visible || placeholderAlpha >= 0.01f)) {
         val infiniteTransition = rememberInfiniteTransition()
-        infiniteTransition.animateFloat(
+        highlightProgress = infiniteTransition.animateFloat(
             initialValue = 0f,
             targetValue = 1f,
-            animationSpec = spec,
+            animationSpec = animationSpec,
         ).value
-    } ?: 0f
+    }
 
+    val paint = remember { Paint() }
     remember(color, shape, highlight) {
         drawWithContent {
-            // Draw normal composable content first
-            drawContent()
+            // Draw the composable content first
+            if (contentAlpha in 0.01f..0.99f) {
+                // If the content alpha is between 1% and 99%, draw it in a layer with
+                // the alpha applied
+                paint.alpha = contentAlpha
+                withLayer(paint) {
+                    with(this@drawWithContent) {
+                        drawContent()
+                    }
+                }
+            } else if (contentAlpha >= 0.99f) {
+                // If the content alpha is between > 99%, draw it with no alpha
+                drawContent()
+            }
 
-            if (shape === RectangleShape) {
-                // shortcut to avoid Outline calculation and allocation
-                // Draw the initial background color
-                drawRectPlaceholder(
-                    color = color,
-                    highlight = highlight,
-                    progress = progress
-                )
-            } else {
+            fun drawPlaceholder() {
                 // Keep track of our outline
-                lastOutline.value = drawOutlinePlaceholder(
+                lastOutline.value = drawPlaceholder(
                     shape = shape,
                     color = color,
                     highlight = highlight,
-                    progress = progress,
+                    progress = highlightProgress,
                     lastOutline = lastOutline.value,
                     lastLayoutDirection = lastLayoutDirection.value,
                     lastSize = lastSize.value,
                 )
+            }
+
+            if (placeholderAlpha in 0.01f..0.99f) {
+                // If the placeholder alpha is between 1% and 99%, draw it in a layer with
+                // the alpha applied
+                paint.alpha = placeholderAlpha
+                withLayer(paint) {
+                    drawPlaceholder()
+                }
+            } else if (placeholderAlpha >= 0.99f) {
+                // If the placeholder alpha is between > 99%, draw it with no alpha
+                drawPlaceholder()
             }
 
             // Keep track of the last size & layout direction
@@ -152,24 +205,7 @@ fun Modifier.placeholder(
     }
 }
 
-private fun ContentDrawScope.drawRectPlaceholder(
-    color: Color,
-    highlight: PlaceholderHighlight?,
-    progress: Float,
-) {
-    // shortcut to avoid Outline calculation and allocation
-    // Draw the initial background color
-    drawRect(color = color)
-
-    if (highlight != null) {
-        drawRect(
-            brush = highlight.brush(progress, size),
-            alpha = highlight.alpha(progress),
-        )
-    }
-}
-
-private fun ContentDrawScope.drawOutlinePlaceholder(
+private fun DrawScope.drawPlaceholder(
     shape: Shape,
     color: Color,
     highlight: PlaceholderHighlight?,
@@ -177,7 +213,23 @@ private fun ContentDrawScope.drawOutlinePlaceholder(
     lastOutline: Outline?,
     lastLayoutDirection: LayoutDirection?,
     lastSize: Size?,
-): Outline {
+): Outline? {
+    // shortcut to avoid Outline calculation and allocation
+    if (shape === RectangleShape) {
+        // Draw the initial background color
+        drawRect(color = color)
+
+        if (highlight != null) {
+            drawRect(
+                brush = highlight.brush(progress, size),
+                alpha = highlight.alpha(progress),
+            )
+        }
+        // We didn't create an outline so return null
+        return null
+    }
+
+    // Otherwise we need to create an outline from the shape
     val outline = lastOutline.takeIf {
         size == lastSize && layoutDirection == lastLayoutDirection
     } ?: shape.createOutline(size, layoutDirection, this)
@@ -195,4 +247,13 @@ private fun ContentDrawScope.drawOutlinePlaceholder(
 
     // Return the outline we used
     return outline
+}
+
+private inline fun DrawScope.withLayer(
+    paint: Paint,
+    drawBlock: DrawScope.() -> Unit,
+) = drawIntoCanvas { canvas ->
+    canvas.saveLayer(size.toRect(), paint)
+    drawBlock()
+    canvas.restore()
 }

--- a/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
@@ -169,7 +169,7 @@ fun Modifier.placeholder(
                     }
                 }
             } else if (contentAlpha >= 0.99f) {
-                // If the content alpha is between > 99%, draw it with no alpha
+                // If the content alpha is > 99%, draw it with no alpha
                 drawContent()
             }
 
@@ -194,7 +194,7 @@ fun Modifier.placeholder(
                     drawPlaceholder()
                 }
             } else if (placeholderAlpha >= 0.99f) {
-                // If the placeholder alpha is between > 99%, draw it with no alpha
+                // If the placeholder alpha is > 99%, draw it with no alpha
                 drawPlaceholder()
             }
 


### PR DESCRIPTION
The content and placeholder is now cross-faded when the `visible` value changes. The transition can be customized via the new transition spec parameters.

https://user-images.githubusercontent.com/227486/121664312-41f33200-ca9f-11eb-84d2-62b7dde75f53.mp4

