### PR TITLE
Update to Compose SNAPSHOT 7443455

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 compose = "1.0.0-SNAPSHOT"
-composesnapshot = "7418032" # a single character = no snapshot
+composesnapshot = "7443455" # a single character = no snapshot
 
 ktlint = "0.41.0"
 kotlin = "1.5.10"


### PR DESCRIPTION
We can't use `7443347` as there isn't a snapshot build for that build id.

