### PR TITLE
[Pager] Fix clipping on the cross-axis

### DIFF
--- a/pager/api/current.api
+++ b/pager/api/current.api
@@ -1,6 +1,9 @@
 // Signature format: 4.0
 package com.google.accompanist.pager {
 
+  public final class ClippingKt {
+  }
+
   @kotlin.RequiresOptIn(message="Accompanist Pager is experimental. The API may be changed in the future.") @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention) public @interface ExperimentalPagerApi {
   }
 

--- a/pager/src/main/java/com/google/accompanist/pager/Clipping.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Clipping.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.pager
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+
+/**
+ * In the scrollable containers we want to clip the main axis sides in order to not display the
+ * content which is scrolled out. But once we apply clipToBounds() modifier on such containers it
+ * causes unexpected behavior as we also clip the content on the cross axis sides. It is
+ * unexpected as Compose components are not clipping by default. The most common case how it
+ * could be reproduced is a horizontally scrolling list of Cards. Cards have the elevation by
+ * default and such Cards will be drawn with clipped shadows on top and bottom. This was harder
+ * to reproduce in the Views system as usually scrolling containers like RecyclerView didn't have
+ * an opaque background which means the ripple was drawn on the surface on the first parent with
+ * background. In Compose as we don't clip by default we draw shadows right in place.
+ * We faced similar issue in Compose already with Androids Popups and Dialogs where we decided to
+ * just predefine some constant with a maximum elevation size we are not going to clip. We are
+ * going to reuse this technique here. This will improve how it works in most common cases. If the
+ * user will need to have a larger unclipped area for some reason they can always add the needed
+ * padding inside the scrollable area.
+ *
+ * Copied from https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
+ */
+internal fun Modifier.clipScrollableContainer(isVertical: Boolean) = clip(
+    shape = if (isVertical) VerticalClipShape else HorizontalClipShape
+)
+
+private val MaxSupportedElevation = 30.dp
+
+private object HorizontalClipShape : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val inflateSize = with(density) { MaxSupportedElevation.roundToPx().toFloat() }
+        return Outline.Rectangle(
+            Rect(
+                left = 0f,
+                top = -inflateSize,
+                right = size.width,
+                bottom = size.height + inflateSize
+            )
+        )
+    }
+}
+
+private object VerticalClipShape : Shape {
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val inflateSize = with(density) { MaxSupportedElevation.roundToPx().toFloat() }
+        return Outline.Rectangle(
+            Rect(
+                left = -inflateSize,
+                top = 0f,
+                right = size.width + inflateSize,
+                bottom = size.height
+            )
+        )
+    }
+}

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -37,7 +37,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -267,7 +266,7 @@ internal fun Pager(
             .then(scrollable)
             // Add a NestedScrollConnection which consumes all post fling/scrolls
             .nestedScroll(connection = ConsumeFlingNestedScrollConnection)
-            .clipToBounds(),
+            .clipScrollableContainer(isVertical),
         content = {
             if (DebugLog) {
                 val firstPage = state.layoutPages.firstOrNull { it.page != null }


### PR DESCRIPTION
We've used the same approach that LazyColumn and LazyRow use.
https://android-review.googlesource.com/c/platform/frameworks/support/+/1713918

Fixes #498