### PR TITLE
[Permissions] Improve UX experience in samples and tests

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -31,10 +31,6 @@ and is nice with the user by letting them decide if they don't want to see the r
 private fun FeatureThatRequiresCameraPermission(
     navigateToSettingsScreen: () -> Unit
 ) {
-    // When `true`, the permission request must be presented to the user.
-    // This could happen when the user opens the screen for the first time.
-    var launchPermissionRequest by rememberSaveable { mutableStateOf(false) }
-
     // Track if the user doesn't want to see the rationale any more.
     var doNotShowRationale by rememberSaveable { mutableStateOf(false) }
 
@@ -48,10 +44,10 @@ private fun FeatureThatRequiresCameraPermission(
         cameraPermissionState.hasPermission -> {
             Text("Camera permission Granted")
         }
-        // If the user denied the permission but a rationale should be shown, explain why the
-        // feature is needed by the app and allow the user to be presented with the permission
-        // again or to not see the rationale any more
-        cameraPermissionState.shouldShowRationale -> {
+        // If the user denied the permission but a rationale should be shown, or the user sees
+        // the permission for the first time, explain why the feature is needed by the app and allow
+        // the user to be presented with the permission again or to not see the rationale any more.
+        cameraPermissionState.shouldShowRationale !cameraPermissionState.permissionRequested -> {
             if (doNotShowRationale) {
                 Text("Feature not available")
             } else {
@@ -70,12 +66,6 @@ private fun FeatureThatRequiresCameraPermission(
                 }
             }
         }
-        // The permission is not granted, the rationale shouldn't be shown to the user, and the
-        // permission hasn't been requested previously. Let's update the launchPermissionRequest
-        // flag to trigger the `LaunchedEffect` below.
-        !cameraPermissionState.permissionRequested -> {
-            launchPermissionRequest = true
-        }
         // If the criteria above hasn't been met, the user denied the permission. Let's present
         // the user with a FAQ in case they want to know more and send them to the Settings screen
         // to enable it the future there if they want to.
@@ -90,14 +80,6 @@ private fun FeatureThatRequiresCameraPermission(
                     Text("Open Settings")
                 }
             }
-        }
-    }
-
-    // Trigger a side-effect to request the camera permission if it needs to be presented to the user
-    if (launchPermissionRequest) {
-        LaunchedEffect(cameraPermissionState) {
-            cameraPermissionState.launchPermissionRequest()
-            launchPermissionRequest = false
         }
     }
 }

--- a/permissions/src/androidTest/java/com/google/accompanist/permissions/MultipleAndSinglePermissionsTest.kt
+++ b/permissions/src/androidTest/java/com/google/accompanist/permissions/MultipleAndSinglePermissionsTest.kt
@@ -25,11 +25,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -52,8 +47,12 @@ class MultipleAndSinglePermissionsTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
+    private val instrumentation by lazy {
+        InstrumentationRegistry.getInstrumentation()
+    }
+
     private val uiDevice by lazy {
-        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        UiDevice.getInstance(instrumentation)
     }
 
     @Test
@@ -62,9 +61,13 @@ class MultipleAndSinglePermissionsTest {
             ComposableUnderTest(listOf(android.Manifest.permission.CAMERA))
         }
 
+        composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
     }
@@ -75,11 +78,15 @@ class MultipleAndSinglePermissionsTest {
             ComposableUnderTest(listOf(android.Manifest.permission.CAMERA))
         }
 
+        composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         denyPermissionInDialog()
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
-        composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
         composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
@@ -94,17 +101,22 @@ class MultipleAndSinglePermissionsTest {
             ComposableUnderTest(listOf(android.Manifest.permission.CAMERA))
         }
 
+        composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         denyPermissionInDialog()
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
-        composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
         uiDevice.pressBack()
         composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
         composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
     }
@@ -118,17 +130,22 @@ class MultipleAndSinglePermissionsTest {
             )
         }
 
+        composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         denyPermissionInDialog()
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
-        composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
         uiDevice.pressBack()
         composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
         composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
     }
@@ -144,10 +161,14 @@ class MultipleAndSinglePermissionsTest {
             )
         }
 
+        composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog() // Grant first permission
         grantPermissionInDialog() // Grant second permission
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
     }
@@ -163,12 +184,16 @@ class MultipleAndSinglePermissionsTest {
             )
         }
 
+        composeTestRule.onNodeWithText("MultipleAndSinglePermissionsTest").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         denyPermissionInDialog() // Deny first permission
         denyPermissionInDialog() // Deny second permission
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
         composeTestRule.onNodeWithText("Navigate").performClick()
+        instrumentation.waitForIdleSync()
         composeTestRule.onNodeWithText("PermissionsTestActivity").assertIsDisplayed()
-        composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
         composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog() // Grant the permission
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
@@ -188,8 +213,6 @@ class MultipleAndSinglePermissionsTest {
         permissions: List<String>,
         requestSinglePermission: Boolean = false
     ) {
-        var launchPermissionRequest by rememberSaveable { mutableStateOf(false) }
-
         val state = rememberMultiplePermissionsState(permissions)
         Column {
             Text("MultipleAndSinglePermissionsTest")
@@ -198,17 +221,29 @@ class MultipleAndSinglePermissionsTest {
                 state.allPermissionsGranted -> {
                     Text("Granted")
                 }
-                state.shouldShowRationale -> {
+                state.shouldShowRationale || !state.permissionRequested -> {
                     Column {
-                        Text("ShowRationale")
-                        Button(onClick = { state.launchMultiplePermissionRequest() }) {
+                        if (state.permissionRequested) {
+                            Text("ShowRationale")
+                        } else {
+                            Text("No permission")
+                        }
+                        Button(
+                            onClick = {
+                                if (
+                                    requestSinglePermission &&
+                                    state.permissionRequested &&
+                                    state.revokedPermissions.size == 1
+                                ) {
+                                    state.revokedPermissions[0].launchPermissionRequest()
+                                } else {
+                                    state.launchMultiplePermissionRequest()
+                                }
+                            }
+                        ) {
                             Text("Request")
                         }
                     }
-                }
-                !state.permissionRequested -> {
-                    Text("Requesting")
-                    launchPermissionRequest = true
                 }
                 else -> {
                     Text("Denied")
@@ -223,17 +258,6 @@ class MultipleAndSinglePermissionsTest {
                 }
             ) {
                 Text("Navigate")
-            }
-        }
-
-        LaunchedEffect(launchPermissionRequest, state) {
-            if (launchPermissionRequest) {
-                if (requestSinglePermission && state.revokedPermissions.size == 1) {
-                    state.revokedPermissions[0].launchPermissionRequest()
-                } else {
-                    state.launchMultiplePermissionRequest()
-                }
-                launchPermissionRequest = false
             }
         }
     }

--- a/permissions/src/androidTest/java/com/google/accompanist/permissions/RequestMultiplePermissionsTest.kt
+++ b/permissions/src/androidTest/java/com/google/accompanist/permissions/RequestMultiplePermissionsTest.kt
@@ -23,11 +23,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -52,6 +47,8 @@ class RequestMultiplePermissionsTest {
 
     @Test
     fun permissionTest_grantPermissions() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog() // Grant first permission
         grantPermissionInDialog() // Grant second permission
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
@@ -59,6 +56,8 @@ class RequestMultiplePermissionsTest {
 
     @Test
     fun permissionTest_denyOnePermission() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog() // Grant first permission
         denyPermissionInDialog() // Deny second permission
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
@@ -73,6 +72,8 @@ class RequestMultiplePermissionsTest {
 
     @Test
     fun permissionTest_doNotAskAgainPermission() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog() // Grant first permission
         denyPermissionInDialog() // Deny second permission
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
@@ -89,6 +90,8 @@ class RequestMultiplePermissionsTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun permissionTest_grantInTheBackground() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog() // Grant first permission
         denyPermissionInDialog() // Deny second permission
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
@@ -116,8 +119,6 @@ class RequestMultiplePermissionsTest {
 
     @Composable
     private fun ComposableUnderTest() {
-        var launchPermissionRequest by rememberSaveable { mutableStateOf(false) }
-
         val state = rememberMultiplePermissionsState(
             listOf(
                 android.Manifest.permission.READ_EXTERNAL_STORAGE,
@@ -128,27 +129,20 @@ class RequestMultiplePermissionsTest {
             state.allPermissionsGranted -> {
                 Text("Granted")
             }
-            state.shouldShowRationale -> {
+            state.shouldShowRationale || !state.permissionRequested -> {
                 Column {
-                    Text("ShowRationale")
+                    if (state.permissionRequested) {
+                        Text("ShowRationale")
+                    } else {
+                        Text("No permission")
+                    }
                     Button(onClick = { state.launchMultiplePermissionRequest() }) {
                         Text("Request")
                     }
                 }
             }
-            !state.permissionRequested -> {
-                Text("Requesting")
-                launchPermissionRequest = true
-            }
             else -> {
                 Text("Denied")
-            }
-        }
-
-        LaunchedEffect(launchPermissionRequest, state) {
-            if (launchPermissionRequest) {
-                state.launchMultiplePermissionRequest()
-                launchPermissionRequest = false
             }
         }
     }

--- a/permissions/src/androidTest/java/com/google/accompanist/permissions/RequestPermissionTest.kt
+++ b/permissions/src/androidTest/java/com/google/accompanist/permissions/RequestPermissionTest.kt
@@ -22,11 +22,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -51,12 +46,16 @@ class RequestPermissionTest {
 
     @Test
     fun permissionTest_grantPermission() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         grantPermissionInDialog()
         composeTestRule.onNodeWithText("Granted").assertIsDisplayed()
     }
 
     @Test
     fun permissionTest_denyPermission() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         denyPermissionInDialog()
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
         composeTestRule.onNodeWithText("Request").performClick()
@@ -66,6 +65,8 @@ class RequestPermissionTest {
 
     @Test
     fun permissionTest_doNotAskAgainPermission() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         denyPermissionInDialog()
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
         composeTestRule.onNodeWithText("Request").performClick()
@@ -76,6 +77,8 @@ class RequestPermissionTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun permissionTest_grantInTheBackground() {
+        composeTestRule.onNodeWithText("No permission").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Request").performClick()
         denyPermissionInDialog()
         composeTestRule.onNodeWithText("ShowRationale").assertIsDisplayed()
         composeTestRule.onNodeWithText("Request").performClick()
@@ -94,34 +97,25 @@ class RequestPermissionTest {
 
     @Composable
     private fun ComposableUnderTest() {
-        var launchPermissionRequest by rememberSaveable { mutableStateOf(false) }
-
         val state = rememberPermissionState(android.Manifest.permission.CAMERA)
         when {
             state.hasPermission -> {
                 Text("Granted")
             }
-            state.shouldShowRationale -> {
+            state.shouldShowRationale || !state.permissionRequested -> {
                 Column {
-                    Text("ShowRationale")
+                    if (state.permissionRequested) {
+                        Text("ShowRationale")
+                    } else {
+                        Text("No permission")
+                    }
                     Button(onClick = { state.launchPermissionRequest() }) {
                         Text("Request")
                     }
                 }
             }
-            !state.permissionRequested -> {
-                Text("Requesting")
-                launchPermissionRequest = true
-            }
             else -> {
                 Text("Denied")
-            }
-        }
-
-        LaunchedEffect(launchPermissionRequest, state) {
-            if (launchPermissionRequest) {
-                state.launchPermissionRequest()
-                launchPermissionRequest = false
             }
         }
     }

--- a/permissions/src/androidTest/java/com/google/accompanist/permissions/test/PermissionsTestActivity.kt
+++ b/permissions/src/androidTest/java/com/google/accompanist/permissions/test/PermissionsTestActivity.kt
@@ -25,11 +25,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.Text
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -53,8 +48,6 @@ class PermissionsTestActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            var launchPermissionRequest by rememberSaveable { mutableStateOf(false) }
-
             val state = rememberPermissionState(Manifest.permission.CAMERA)
             Column {
                 Text("PermissionsTestActivity")
@@ -63,28 +56,21 @@ class PermissionsTestActivity : ComponentActivity() {
                     state.hasPermission -> {
                         Text("Granted")
                     }
-                    state.shouldShowRationale -> {
+                    state.shouldShowRationale || !state.permissionRequested -> {
                         Column {
-                            Text("ShowRationale")
+                            if (state.permissionRequested) {
+                                Text("ShowRationale")
+                            } else {
+                                Text("No permission")
+                            }
                             Button(onClick = { state.launchPermissionRequest() }) {
                                 Text("Request")
                             }
                         }
                     }
-                    !state.permissionRequested -> {
-                        Text("Requesting")
-                        launchPermissionRequest = true
-                    }
                     else -> {
                         Text("Denied")
                     }
-                }
-            }
-
-            LaunchedEffect(launchPermissionRequest, state) {
-                if (launchPermissionRequest) {
-                    state.launchPermissionRequest()
-                    launchPermissionRequest = false
                 }
             }
         }

--- a/sample/src/main/java/com/google/accompanist/sample/permissions/RequestPermissionSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/permissions/RequestPermissionSample.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -74,10 +73,6 @@ private fun Sample(
     cameraPermissionState: PermissionState,
     navigateToSettingsScreen: () -> Unit
 ) {
-    // When `true`, the permission request must be presented to the user.
-    // This could happen when the user opens the screen for the first time.
-    var launchPermissionRequest by rememberSaveable { mutableStateOf(false) }
-
     // Track if the user doesn't want to see the rationale any more.
     var doNotShowRationale by rememberSaveable { mutableStateOf(false) }
 
@@ -86,10 +81,10 @@ private fun Sample(
         cameraPermissionState.hasPermission -> {
             Text("Camera permission Granted")
         }
-        // If the user denied the permission but a rationale should be shown, explain why the
-        // feature is needed by the app and allow the user to be presented with the permission
-        // again or to not see the rationale any more
-        cameraPermissionState.shouldShowRationale -> {
+        // If the user denied the permission but a rationale should be shown, or the user sees
+        // the permission for the first time, explain why the feature is needed by the app and allow
+        // the user to be presented with the permission again or to not see the rationale any more.
+        cameraPermissionState.shouldShowRationale || !cameraPermissionState.permissionRequested -> {
             if (doNotShowRationale) {
                 Text("Feature not available")
             } else {
@@ -108,12 +103,6 @@ private fun Sample(
                 }
             }
         }
-        // The permission is not granted, the rationale shouldn't be shown to the user, and the
-        // permission hasn't been requested previously. Let's update the launchPermissionRequest
-        // flag to trigger the `LaunchedEffect` below.
-        !cameraPermissionState.permissionRequested -> {
-            launchPermissionRequest = true
-        }
         // If the criteria above hasn't been met, the user denied the permission. Let's present
         // the user with a FAQ in case they want to know more and send them to the Settings screen
         // to enable it the future there if they want to.
@@ -128,14 +117,6 @@ private fun Sample(
                     Text("Open Settings")
                 }
             }
-        }
-    }
-
-    // Trigger a side-effect to request the camera permission if it needs to be presented to the user
-    if (launchPermissionRequest) {
-        LaunchedEffect(cameraPermissionState) {
-            cameraPermissionState.launchPermissionRequest()
-            launchPermissionRequest = false
         }
     }
 }


### PR DESCRIPTION
It's a bad UX to show the permission as an effect of a navigation event. When the permission is presented, the user should have enough context to grant/deny the permission.