### PR TITLE
[Pager] In infinite loop mode, allow scrolling to pages out of bounds

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -278,9 +278,13 @@ class PagerState(
         // We don't specifically use the ScrollScope's scrollBy, but
         // we do want to use it's mutex
         scroll {
-            val target = page.floorMod(pageCount)
-
             val currentIndex = currentLayoutPage
+            val target = if (infiniteLoop) {
+                // In infinite loop mode, allow scrolling to pages out of bounds.
+                page
+            } else {
+                page.floorMod(pageCount)
+            }
             val distance = (target - currentIndex).absoluteValue
 
             /**

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerBasicSample.kt
@@ -113,12 +113,13 @@ private fun Sample() {
 internal fun ActionsRow(
     pagerState: PagerState,
     modifier: Modifier = Modifier,
+    infiniteLoop: Boolean = false
 ) {
     Row(modifier) {
         val scope = rememberCoroutineScope()
 
         IconButton(
-            enabled = pagerState.currentPage > 0,
+            enabled = infiniteLoop.not() && pagerState.currentPage > 0,
             onClick = {
                 scope.launch {
                     pagerState.animateScrollToPage(0)
@@ -129,7 +130,7 @@ internal fun ActionsRow(
         }
 
         IconButton(
-            enabled = pagerState.currentPage > 0,
+            enabled = infiniteLoop || pagerState.currentPage > 0,
             onClick = {
                 scope.launch {
                     pagerState.animateScrollToPage(pagerState.currentPage - 1)
@@ -140,7 +141,7 @@ internal fun ActionsRow(
         }
 
         IconButton(
-            enabled = pagerState.currentPage < pagerState.pageCount - 1,
+            enabled = infiniteLoop || pagerState.currentPage < pagerState.pageCount - 1,
             onClick = {
                 scope.launch {
                     pagerState.animateScrollToPage(pagerState.currentPage + 1)
@@ -151,7 +152,7 @@ internal fun ActionsRow(
         }
 
         IconButton(
-            enabled = pagerState.currentPage < pagerState.pageCount - 1,
+            enabled = infiniteLoop.not() && pagerState.currentPage < pagerState.pageCount - 1,
             onClick = {
                 scope.launch {
                     pagerState.animateScrollToPage(pagerState.pageCount - 1)

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerLoopSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerLoopSample.kt
@@ -138,6 +138,12 @@ private fun Sample() {
                     .align(Alignment.CenterHorizontally)
                     .padding(16.dp),
             )
+
+            ActionsRow(
+                pagerState = pagerState,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                infiniteLoop = true
+            )
         }
     }
 }


### PR DESCRIPTION
Currently, `animateScrollToPage()` only accepts `page` in range from first to last.
So if calls `animateScrollToPage()` to scroll from the first to the last, it will move to the **right** direction.

But in infinite loop mode, it would be nice to be able to scroll even in the nearest direction.
Now allow scrolling to **pages out of bounds** in infinite loop mode.

For examples:
- If calls `animateScrollToPage(-1)`, move to the **left** direction. And the current page will be `pages.size`.
- If calls `animateScrollToPage(pages.size)`, move to the **right** direction. And the current page will be `0`.

And add `ActionRow` in loop pager sample.

Fixes #503 

https://user-images.githubusercontent.com/3405740/122672310-f1e63f00-d205-11eb-8ea2-9e6ef2e90665.mp4
