### PR TITLE
README: Copy-edit overview section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
 ![Accompanist logo](docs/header.png)
 
-Accompanist is a group of libraries which aim to supplement [Jetpack Compose][compose] with features which are commonly required by developers, but not yet available.
+Accompanist is a group of libraries that aim to supplement [Jetpack Compose][compose] with features that are commonly required by developers but not yet available.
 
-Currently Accompanist contains:
+Currently, Accompanist contains:
 
-### 🖼️ Image loading
-A number of libraries which integrate popular image loading libraries into Jetpack Compose: [Coil](./coil/) and [Glide](./glide/).
+### 🖼️ Image loading libraries
+Jetpack Compose implementations of two popular image loading libraries: [Coil](./coil/) and [Glide](./glide/).
 
 ### 📐 [Insets](./insets/)
-A library which brings [WindowInsets](https://developer.android.com/reference/kotlin/android/view/WindowInsets) support to Jetpack Compose.
+A library that brings [WindowInsets][windowinsets] support to Jetpack Compose.
 
 ### 🍫 [System UI Controller](./systemuicontroller/)
-A library which provides easy-to-use utilities for updating the System UI (status and navigation bars) colors from Jetpack Compose.
+A library that provides easy-to-use utilities for recoloring the Android system bars from Jetpack Compose.
 
 ### 🎨 [AppCompat Theme Adapter](./appcompat-theme/)
-A library that enables reuse of [AppCompat][appcompat] XML themes for theming in [Jetpack Compose][compose].
+A library that enables the reuse of [AppCompat][appcompat] XML themes for theming in Jetpack Compose.
 
 ### 📖 [Pager](./pager/)
-A library which provides paging layouts for Jetpack Compose, similar to Android's [`ViewPager`](https://developer.android.com/reference/kotlin/androidx/viewpager/widget/ViewPager).
+A library that provides utilities for building paginated layouts in Jetpack Compose, similar to Android's [ViewPager][viewpager].
 
 ### 📫 [Permissions](./permissions/)
-A library which provides [Android runtime permissions](https://developer.android.com/guide/topics/permissions/overview) support for Jetpack Compose.
+A library that provides [Android runtime permissions][runtimepermissions] support for Jetpack Compose.
 
 ### ⏳ [Placeholder](./placeholder/)
-A library which provides easy-to-use modifiers for displaying 'placeholder' UI while content is loading.
+A library that provides easy-to-use modifiers for displaying a placeholder UI while content is loading.
 
-### 🌊 [Flow layouts](./flowlayout/)
-A library that adds a 'flexbox'-like layout to [Jetpack Compose][compose].
+### 🌊 [Flow Layouts](./flowlayout/)
+A library that adds Flexbox-like layout components to Jetpack Compose.
 
-### ⬆️ [Swipe To refresh](./swiperefresh/)
-A library which provides a layout which provides the swipe-to-refresh UX pattern, similar to Android's SwipeRefreshLayout.
+### ⬇️ [Swipe to Refresh](./swiperefresh/)
+A library that provides a layout implementing the swipe-to-refresh UX pattern, similar to Android's [SwipeRefreshLayout](https://developer.android.com/jetpack/androidx/releases/swiperefreshlayout).
 
 ---
 
@@ -82,3 +82,6 @@ limitations under the License.
 [compose]: https://developer.android.com/jetpack/compose
 [snap]: https://oss.sonatype.org/content/repositories/snapshots/com/google/accompanist/
 [mdc]: https://material.io/develop/android/
+[windowinsets]: https://developer.android.com/reference/kotlin/android/view/WindowInsets
+[viewpager]: https://developer.android.com/reference/kotlin/androidx/viewpager/widget/ViewPager
+[runtimepermissions]: https://developer.android.com/guide/topics/permissions/overview


### PR DESCRIPTION
Hello! First, thanks so much for your work on Accompanist – it’s been of great utility. I’d like to suggest some stylistic and linguistic tweaks to the overview section of the README. I’ve referenced the [Google developer documentation style guide](https://developers.google.com/style) and [_AP Stylebook_](https://www.apstylebook.com/) in introducing these edits. Here’s a line-by-line description:

- Line 3: _Which_ should be used for non-essential clauses, whereas _that_ should be used for essential clauses. From the _AP Stylebook_: ‘... If you can drop the clause and not lose the meaning of the sentence, use _which_; otherwise, use _that_.’ Additionally, _but_ shouldn’t be preceded by a comma here because, as per the _AP Stylebook_, commas are to be placed before a conjunction only when it ‘links two clauses that could stand alone as separate sentences.’

- Line 5: The Google developer documentation style guide calls for commas after introductory phrases (see [here](https://developers.google.com/style/commas#commas-after-introductory-words-and-phrases)).

- Line 7: This heading follows the introductory phrase _Currently, Accompanist contains:_ and should match it. Accompanist provides image loading libraries rather than image loading itself.

- Line 8: I’d say that the repetition of _libraries_ made this sentence hard to read. Additionally, phrases such as _a number of_ or _multiple_ generally imply more than two. 

- Line 11: Please see the comparison between _which_ and _that_ in the description for line 3.

- Line 14: I’d suggest simplifying this sentence by using the terms _Android system bars_ and _recoloring_. Please also see the comparison between _which_ and _that_ in the description for line 3.

- Line 17: The word _reuse_ was missing an article here.

- Line 20: It appears that the words _paging_ and _paginated_ were confused in this sentence. Additionally, I believe it would be more accurate to say that Accompanist provides the means to build paginated layouts rather than providing the layouts as such. Please also see the comparison between _which_ and _that_ in the description for line 3.

- Line 23: Please see the comparison between _which_ and _that_ in the description for line 3.

- Line 26: _Placeholder_ is used in its literal sense here, so quotation marks aren’t needed. Secondly, the word was missing an article. Please also see the comparison between _which_ and _that_ in the description for line 3.

- Line 28: It’s my understanding that _Flow Layouts_ functions as a proper noun, similarly to the names of the other libraries included with Accompanist. For consistency, it should be in title case just like them.

- Line 29: From what I can tell, _Flexbox_ functions as a proper noun (see, for example, [here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox)). It should thus be capitalised, and no quotation marks are necessary. Additionally, I believe it would be more accurate to say that Accompanist provides Flexbox-like layout components rather than actual layouts.

- Line 31: Please see the description for line 28, but replace _Flow Layouts_ with _Swipe to Refresh_.

- Line 32: I’d say that the repetition of _which provides_ made this sentence hard to read. Please also see the comparison between _which_ and _that_ in the description for line 3.