### PR TITLE
Expose the Drawable in DrawablePainter

### DIFF
--- a/imageloading-core/api/current.api
+++ b/imageloading-core/api/current.api
@@ -9,11 +9,13 @@ package com.google.accompanist.imageloading {
 
   public final class DrawablePainter extends androidx.compose.ui.graphics.painter.Painter implements androidx.compose.runtime.RememberObserver {
     ctor public DrawablePainter(android.graphics.drawable.Drawable drawable);
+    method public android.graphics.drawable.Drawable getDrawable();
     method public long getIntrinsicSize();
     method public void onAbandoned();
     method protected void onDraw(androidx.compose.ui.graphics.drawscope.DrawScope);
     method public void onForgotten();
     method public void onRemembered();
+    property public final android.graphics.drawable.Drawable drawable;
     property public long intrinsicSize;
   }
 

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/DrawablePainter.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/DrawablePainter.kt
@@ -56,7 +56,7 @@ private val MAIN_HANDLER by lazy(LazyThreadSafetyMode.NONE) {
  * Instances are usually retrieved from [rememberDrawablePainter].
  */
 class DrawablePainter(
-    private val drawable: Drawable
+    val drawable: Drawable
 ) : Painter(), RememberObserver {
     private var invalidateTick by mutableStateOf(0)
 


### PR DESCRIPTION
I have a use case where I need to both render the drawable loaded by Glide and extract it's bitmap to generate a glowing effect around it. With the change in https://github.com/google/accompanist/pull/402 that replaced the `drawable` result param for a `Painter` broke our implementation and I couldn't find an alternative solution to achieve the same effect with the `Painter` and have thus opened this PR.

Thanks for the consideration! 