### PR TITLE
[Permissions] Remove lint checks until a solution is found

### DIFF
--- a/permissions/build.gradle
+++ b/permissions/build.gradle
@@ -83,7 +83,8 @@ dependencies {
     implementation libs.napier
 
     lintChecks(project(":permissions-lint"))
-    lintPublish(project(":permissions-lint"))
+    // TODO: permissions-lint needs to be built as a fat jar
+    // lintPublish(project(":permissions-lint"))
 
     // ======================
     // Test dependencies


### PR DESCRIPTION
`libs.kotlin.metadataJvm` needs to be shipped with the `permissions-lint` module. `implementation` doesn't work with `lintPublish`, therefore, we need to build `permissions-lint` as a fat jar. Meanwhile, let's not add the lint checks.