### PR TITLE
[Coil][Glide] Deprecate the libraries

### DIFF
--- a/coil/api/current.api
+++ b/coil/api/current.api
@@ -2,13 +2,13 @@
 package com.google.accompanist.coil {
 
   public final class CoilKt {
-    method public static androidx.compose.runtime.ProvidableCompositionLocal<coil.ImageLoader> getLocalImageLoader();
-    method @androidx.compose.runtime.Composable public static com.google.accompanist.imageloading.LoadPainter<java.lang.Object> rememberCoilPainter(Object? request, optional coil.ImageLoader imageLoader, optional com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange, optional kotlin.jvm.functions.Function2<? super coil.request.ImageRequest.Builder,? super androidx.compose.ui.unit.IntSize,coil.request.ImageRequest.Builder>? requestBuilder, optional boolean fadeIn, optional int fadeInDurationMs, optional @DrawableRes int previewPlaceholder);
+    method @Deprecated public static androidx.compose.runtime.ProvidableCompositionLocal<coil.ImageLoader> getLocalImageLoader();
+    method @Deprecated @androidx.compose.runtime.Composable public static com.google.accompanist.imageloading.LoadPainter<java.lang.Object> rememberCoilPainter(Object? request, optional coil.ImageLoader imageLoader, optional com.google.accompanist.imageloading.ShouldRefetchOnSizeChange? shouldRefetchOnSizeChange, optional kotlin.jvm.functions.Function2<? super coil.request.ImageRequest.Builder,? super androidx.compose.ui.unit.IntSize,coil.request.ImageRequest.Builder>? requestBuilder, optional boolean fadeIn, optional int fadeInDurationMs, optional @DrawableRes int previewPlaceholder);
   }
 
-  public final class CoilPainterDefaults {
-    method @androidx.compose.runtime.Composable public coil.ImageLoader defaultImageLoader();
-    field public static final com.google.accompanist.coil.CoilPainterDefaults INSTANCE;
+  @Deprecated public final class CoilPainterDefaults {
+    method @Deprecated @androidx.compose.runtime.Composable public coil.ImageLoader defaultImageLoader();
+    field @Deprecated public static final com.google.accompanist.coil.CoilPainterDefaults INSTANCE;
   }
 
 }

--- a/coil/build.gradle
+++ b/coil/build.gradle
@@ -72,7 +72,7 @@ android {
 
 dependencies {
     api project(':imageloading-core')
-    api libs.coil.coil
+    api libs.coil.compose
 
     implementation libs.androidx.core
     implementation libs.compose.foundation.foundation

--- a/coil/src/androidTest/java/com/google/accompanist/coil/CoilTest.kt
+++ b/coil/src/androidTest/java/com/google/accompanist/coil/CoilTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.coil
 
 import android.graphics.drawable.ShapeDrawable

--- a/coil/src/main/java/com/google/accompanist/coil/Coil.kt
+++ b/coil/src/main/java/com/google/accompanist/coil/Coil.kt
@@ -24,14 +24,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.IntSize
 import coil.ImageLoader
-import coil.imageLoader
+import coil.compose.LocalImageLoader
 import coil.request.ImageRequest
 import coil.request.ImageResult
 import coil.size.Precision
@@ -52,20 +51,33 @@ import kotlinx.coroutines.flow.channelFlow
  * Composition local containing the preferred [ImageLoader] to be used by
  * [rememberCoilPainter].
  */
-val LocalImageLoader = staticCompositionLocalOf<ImageLoader?> { null }
+@Deprecated(
+    "Replace with coil-compose LocalImageLoader. See https://coil-kt.github.io/coil/compose",
+    ReplaceWith(
+        "LocalImageLoader",
+        "coil.compose.LocalImageLoader"
+    )
+)
+val LocalImageLoader = coil.compose.LocalImageLoader
 
 /**
  * Contains some default values used by [rememberCoilPainter].
  */
+@Deprecated("No longer necessary with coil-compose. See https://coil-kt.github.io/coil/compose")
 object CoilPainterDefaults {
     /**
      * Returns the default [ImageLoader] value for the `imageLoader` parameter
      * in [rememberCoilPainter].
      */
+    @Deprecated(
+        "Replace with coil-compose LocalImageLoader. See https://coil-kt.github.io/coil/compose",
+        ReplaceWith(
+            "LocalImageLoader.current",
+            "coil.compose.LocalImageLoader"
+        )
+    )
     @Composable
-    fun defaultImageLoader(): ImageLoader {
-        return LocalImageLoader.current ?: LocalContext.current.imageLoader
-    }
+    fun defaultImageLoader(): ImageLoader = LocalImageLoader.current
 }
 
 /**
@@ -85,12 +97,29 @@ object CoilPainterDefaults {
  * @param previewPlaceholder Drawable resource ID which will be displayed when this function is
  * ran in preview mode.
  */
+@Deprecated(
+    "Replace with coil-compose rememberImagePainter(). See https://coil-kt.github.io/coil/compose",
+    ReplaceWith(
+        """rememberImagePainter(
+                data = request,
+                imageLoader = imageLoader,
+                builder = {
+                    if (fadeIn == true) crossfade(fadeInDurationMs)
+                    placeholder(previewPlaceholder)
+                    requestBuilder(this)
+                }
+            )""",
+        "coil.compose.rememberImagePainter",
+        "coil.compose.LocalImageLoader",
+        "com.google.accompanist.imageloading.LoadPainterDefaults",
+    )
+)
 @Composable
 fun rememberCoilPainter(
     request: Any?,
-    imageLoader: ImageLoader = CoilPainterDefaults.defaultImageLoader(),
-    shouldRefetchOnSizeChange: ShouldRefetchOnSizeChange = ShouldRefetchOnSizeChange { _, _ -> false },
-    requestBuilder: (ImageRequest.Builder.(size: IntSize) -> ImageRequest.Builder)? = null,
+    imageLoader: ImageLoader = LocalImageLoader.current,
+    shouldRefetchOnSizeChange: ShouldRefetchOnSizeChange? = null,
+    requestBuilder: (ImageRequest.Builder.(size: IntSize) -> ImageRequest.Builder)? = { this },
     fadeIn: Boolean = false,
     fadeInDurationMs: Int = LoadPainterDefaults.FadeInTransitionDuration,
     @DrawableRes previewPlaceholder: Int = 0,
@@ -107,7 +136,7 @@ fun rememberCoilPainter(
     return rememberLoadPainter(
         loader = coilLoader,
         request = checkData(request),
-        shouldRefetchOnSizeChange = shouldRefetchOnSizeChange,
+        shouldRefetchOnSizeChange = shouldRefetchOnSizeChange ?: ShouldRefetchOnSizeChange { _, _ -> false },
         fadeIn = fadeIn,
         fadeInDurationMs = fadeInDurationMs,
         previewPlaceholder = previewPlaceholder,

--- a/coil/src/main/java/com/google/accompanist/coil/Coil.kt
+++ b/coil/src/main/java/com/google/accompanist/coil/Coil.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DeprecatedCallableAddReplaceWith", "DEPRECATION")
+
 package com.google.accompanist.coil
 
 import android.content.Context

--- a/docs/coil.md
+++ b/docs/coil.md
@@ -2,6 +2,13 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-coil)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+!!! warning
+    The Accompanist-Coil library is now deprecated (as of v0.14), replaced with the Coil for Jetpack Compose extension library.
+    Automated replacements have been added to the relevant functions, but there may be instances where manual migration is necessary.
+    See [here](https://coil-kt.github.io/coil/compose/) for more information. The Accompanist-Coil library library will be removed at a future point in time (before v1.0).
+
+---
+
 This library provides easy-to-use [Painter][painter] which can fetch and display images from external sources, such as network, using the [Coil][coil] image loading library.
 
 <img src="https://coil-kt.github.io/coil/logo.svg" width="480" alt="Coil logo">

--- a/docs/glide.md
+++ b/docs/glide.md
@@ -2,6 +2,12 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-glide)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+!!! warning
+    The Accompanist-Glide library is now deprecated (as of v0.14), and will be removed at a future point in time (before v1.0).
+    Apps should consider migrating to [Coil](https://coil-kt.github.io/coil/compose/) for similar functionality.
+
+---
+
 This library brings easy-to-use [Painter][painter] which can fetch and display images from external sources, such as network, using the [Glide][glide] image loading library.
 
 <img src="https://github.com/bumptech/glide/blob/master/static/glide_logo.png?raw=true" width="480" alt="Glide logo">

--- a/glide/api/current.api
+++ b/glide/api/current.api
@@ -2,13 +2,13 @@
 package com.google.accompanist.glide {
 
   public final class GlideKt {
-    method public static androidx.compose.runtime.ProvidableCompositionLocal<com.bumptech.glide.RequestManager> getLocalRequestManager();
-    method @androidx.compose.runtime.Composable public static com.google.accompanist.imageloading.LoadPainter<java.lang.Object> rememberGlidePainter(Object? request, optional com.bumptech.glide.RequestManager requestManager, optional com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange, optional kotlin.jvm.functions.Function2<? super com.bumptech.glide.RequestBuilder<android.graphics.drawable.Drawable>,? super androidx.compose.ui.unit.IntSize,? extends com.bumptech.glide.RequestBuilder<android.graphics.drawable.Drawable>>? requestBuilder, optional boolean fadeIn, optional int fadeInDurationMs, optional @DrawableRes int previewPlaceholder);
+    method @Deprecated public static androidx.compose.runtime.ProvidableCompositionLocal<com.bumptech.glide.RequestManager> getLocalRequestManager();
+    method @Deprecated @androidx.compose.runtime.Composable public static com.google.accompanist.imageloading.LoadPainter<java.lang.Object> rememberGlidePainter(Object? request, optional com.bumptech.glide.RequestManager requestManager, optional com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange, optional kotlin.jvm.functions.Function2<? super com.bumptech.glide.RequestBuilder<android.graphics.drawable.Drawable>,? super androidx.compose.ui.unit.IntSize,? extends com.bumptech.glide.RequestBuilder<android.graphics.drawable.Drawable>>? requestBuilder, optional boolean fadeIn, optional int fadeInDurationMs, optional @DrawableRes int previewPlaceholder);
   }
 
-  public final class GlidePainterDefaults {
-    method @androidx.compose.runtime.Composable public com.bumptech.glide.RequestManager defaultRequestManager();
-    field public static final com.google.accompanist.glide.GlidePainterDefaults INSTANCE;
+  @Deprecated public final class GlidePainterDefaults {
+    method @Deprecated @androidx.compose.runtime.Composable public com.bumptech.glide.RequestManager defaultRequestManager();
+    field @Deprecated public static final com.google.accompanist.glide.GlidePainterDefaults INSTANCE;
   }
 
 }

--- a/glide/src/androidTest/java/com/google/accompanist/glide/GlideTest.kt
+++ b/glide/src/androidTest/java/com/google/accompanist/glide/GlideTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.glide
 
 import android.graphics.drawable.ShapeDrawable

--- a/glide/src/main/java/com/google/accompanist/glide/Glide.kt
+++ b/glide/src/main/java/com/google/accompanist/glide/Glide.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DeprecatedCallableAddReplaceWith", "DEPRECATION")
+
 package com.google.accompanist.glide
 
 import android.graphics.drawable.Drawable
@@ -53,16 +55,19 @@ import kotlinx.coroutines.flow.callbackFlow
  * Composition local containing the preferred [RequestManager] to use
  * for [rememberGlidePainter].
  */
+@Deprecated("Accompanist-Glide is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 val LocalRequestManager = staticCompositionLocalOf<RequestManager?> { null }
 
 /**
  * Contains some default values used for [rememberGlidePainter].
  */
+@Deprecated("Accompanist-Glide is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 object GlidePainterDefaults {
     /**
      * Returns the default [RequestManager] value for the `requestManager` parameter
      * in [rememberGlidePainter].
      */
+    @Deprecated("Accompanist-Glide is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
     @Composable
     fun defaultRequestManager(): RequestManager {
         // By default Glide tries to install lifecycle listeners to automatically re-trigger
@@ -88,6 +93,7 @@ object GlidePainterDefaults {
  * @param previewPlaceholder Drawable resource ID which will be displayed when this function is
  * ran in preview mode.
  */
+@Deprecated("Accompanist-Glide is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 @Composable
 fun rememberGlidePainter(
     request: Any?,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ ktlint = "0.41.0"
 kotlin = "1.5.10"
 coroutines = "1.5.0"
 okhttp = "3.12.13"
-coil = "1.2.1"
+coil = "1.3.0"
 
 androidxtest = "1.3.0"
 
@@ -48,6 +48,7 @@ okhttp-mockWebServer = { module = "com.squareup.okhttp3:mockwebserver", version.
 
 coil-coil = { module = "io.coil-kt:coil", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 androidx-appcompat = "androidx.appcompat:appcompat:1.3.0"
 androidx-core = "androidx.core:core-ktx:1.5.0"

--- a/imageloading-core/api/current.api
+++ b/imageloading-core/api/current.api
@@ -1,10 +1,10 @@
 // Signature format: 4.0
 package com.google.accompanist.imageloading {
 
-  public enum DataSource {
-    enum_constant public static final com.google.accompanist.imageloading.DataSource DISK;
-    enum_constant public static final com.google.accompanist.imageloading.DataSource MEMORY;
-    enum_constant public static final com.google.accompanist.imageloading.DataSource NETWORK;
+  @Deprecated public enum DataSource {
+    enum_constant @Deprecated public static final com.google.accompanist.imageloading.DataSource DISK;
+    enum_constant @Deprecated public static final com.google.accompanist.imageloading.DataSource MEMORY;
+    enum_constant @Deprecated public static final com.google.accompanist.imageloading.DataSource NETWORK;
   }
 
   public final class DrawablePainter extends androidx.compose.ui.graphics.painter.Painter implements androidx.compose.runtime.RememberObserver {
@@ -23,91 +23,91 @@ package com.google.accompanist.imageloading {
     method @androidx.compose.runtime.Composable public static androidx.compose.ui.graphics.painter.Painter rememberDrawablePainter(android.graphics.drawable.Drawable? drawable);
   }
 
-  public abstract sealed class ImageLoadState {
+  @Deprecated public abstract sealed class ImageLoadState {
   }
 
-  public static final class ImageLoadState.Empty extends com.google.accompanist.imageloading.ImageLoadState {
-    field public static final com.google.accompanist.imageloading.ImageLoadState.Empty INSTANCE;
+  @Deprecated public static final class ImageLoadState.Empty extends com.google.accompanist.imageloading.ImageLoadState {
+    field @Deprecated public static final com.google.accompanist.imageloading.ImageLoadState.Empty INSTANCE;
   }
 
-  public static final class ImageLoadState.Error extends com.google.accompanist.imageloading.ImageLoadState {
-    ctor public ImageLoadState.Error(Object request, optional androidx.compose.ui.graphics.painter.Painter? result, optional Throwable? throwable);
-    method public Object component1();
-    method public androidx.compose.ui.graphics.painter.Painter? component2();
-    method public Throwable? component3();
-    method public com.google.accompanist.imageloading.ImageLoadState.Error copy(Object request, androidx.compose.ui.graphics.painter.Painter? result, Throwable? throwable);
-    method public Object getRequest();
-    method public androidx.compose.ui.graphics.painter.Painter? getResult();
-    method public Throwable? getThrowable();
+  @Deprecated public static final class ImageLoadState.Error extends com.google.accompanist.imageloading.ImageLoadState {
+    ctor @Deprecated public ImageLoadState.Error(Object request, optional androidx.compose.ui.graphics.painter.Painter? result, optional Throwable? throwable);
+    method @Deprecated public Object component1();
+    method @Deprecated public androidx.compose.ui.graphics.painter.Painter? component2();
+    method @Deprecated public Throwable? component3();
+    method @Deprecated public com.google.accompanist.imageloading.ImageLoadState.Error copy(Object request, androidx.compose.ui.graphics.painter.Painter? result, Throwable? throwable);
+    method @Deprecated public Object getRequest();
+    method @Deprecated public androidx.compose.ui.graphics.painter.Painter? getResult();
+    method @Deprecated public Throwable? getThrowable();
     property public final Object request;
     property public final androidx.compose.ui.graphics.painter.Painter? result;
     property public final Throwable? throwable;
   }
 
-  public static final class ImageLoadState.Loading extends com.google.accompanist.imageloading.ImageLoadState {
-    ctor public ImageLoadState.Loading(androidx.compose.ui.graphics.painter.Painter? placeholder, Object request);
-    method public androidx.compose.ui.graphics.painter.Painter? component1();
-    method public Object component2();
-    method public com.google.accompanist.imageloading.ImageLoadState.Loading copy(androidx.compose.ui.graphics.painter.Painter? placeholder, Object request);
-    method public androidx.compose.ui.graphics.painter.Painter? getPlaceholder();
-    method public Object getRequest();
+  @Deprecated public static final class ImageLoadState.Loading extends com.google.accompanist.imageloading.ImageLoadState {
+    ctor @Deprecated public ImageLoadState.Loading(androidx.compose.ui.graphics.painter.Painter? placeholder, Object request);
+    method @Deprecated public androidx.compose.ui.graphics.painter.Painter? component1();
+    method @Deprecated public Object component2();
+    method @Deprecated public com.google.accompanist.imageloading.ImageLoadState.Loading copy(androidx.compose.ui.graphics.painter.Painter? placeholder, Object request);
+    method @Deprecated public androidx.compose.ui.graphics.painter.Painter? getPlaceholder();
+    method @Deprecated public Object getRequest();
     property public final androidx.compose.ui.graphics.painter.Painter? placeholder;
     property public final Object request;
   }
 
-  public static final class ImageLoadState.Success extends com.google.accompanist.imageloading.ImageLoadState {
-    ctor public ImageLoadState.Success(androidx.compose.ui.graphics.painter.Painter result, com.google.accompanist.imageloading.DataSource source, Object request);
-    method public androidx.compose.ui.graphics.painter.Painter component1();
-    method public com.google.accompanist.imageloading.DataSource component2();
-    method public Object component3();
-    method public com.google.accompanist.imageloading.ImageLoadState.Success copy(androidx.compose.ui.graphics.painter.Painter result, com.google.accompanist.imageloading.DataSource source, Object request);
-    method public Object getRequest();
-    method public androidx.compose.ui.graphics.painter.Painter getResult();
-    method public com.google.accompanist.imageloading.DataSource getSource();
+  @Deprecated public static final class ImageLoadState.Success extends com.google.accompanist.imageloading.ImageLoadState {
+    ctor @Deprecated public ImageLoadState.Success(androidx.compose.ui.graphics.painter.Painter result, com.google.accompanist.imageloading.DataSource source, Object request);
+    method @Deprecated public androidx.compose.ui.graphics.painter.Painter component1();
+    method @Deprecated public com.google.accompanist.imageloading.DataSource component2();
+    method @Deprecated public Object component3();
+    method @Deprecated public com.google.accompanist.imageloading.ImageLoadState.Success copy(androidx.compose.ui.graphics.painter.Painter result, com.google.accompanist.imageloading.DataSource source, Object request);
+    method @Deprecated public Object getRequest();
+    method @Deprecated public androidx.compose.ui.graphics.painter.Painter getResult();
+    method @Deprecated public com.google.accompanist.imageloading.DataSource getSource();
     property public final Object request;
     property public final androidx.compose.ui.graphics.painter.Painter result;
     property public final com.google.accompanist.imageloading.DataSource source;
   }
 
   public final class ImageLoadStateKt {
-    method public static boolean isFinalState(com.google.accompanist.imageloading.ImageLoadState);
+    method @Deprecated public static boolean isFinalState(com.google.accompanist.imageloading.ImageLoadState);
   }
 
-  public final class LoadPainter<R> extends androidx.compose.ui.graphics.painter.Painter implements androidx.compose.runtime.RememberObserver {
-    method public long getIntrinsicSize();
-    method public com.google.accompanist.imageloading.ImageLoadState getLoadState();
-    method public R? getRequest();
-    method public com.google.accompanist.imageloading.ShouldRefetchOnSizeChange getShouldRefetchOnSizeChange();
-    method public void onAbandoned();
-    method protected void onDraw(androidx.compose.ui.graphics.drawscope.DrawScope);
-    method public void onForgotten();
-    method public void onRemembered();
-    method public void setRequest(R? request);
-    method public void setShouldRefetchOnSizeChange(com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange);
+  @Deprecated public final class LoadPainter<R> extends androidx.compose.ui.graphics.painter.Painter implements androidx.compose.runtime.RememberObserver {
+    method @Deprecated public long getIntrinsicSize();
+    method @Deprecated public com.google.accompanist.imageloading.ImageLoadState getLoadState();
+    method @Deprecated public R? getRequest();
+    method @Deprecated public com.google.accompanist.imageloading.ShouldRefetchOnSizeChange getShouldRefetchOnSizeChange();
+    method @Deprecated public void onAbandoned();
+    method @Deprecated protected void onDraw(androidx.compose.ui.graphics.drawscope.DrawScope);
+    method @Deprecated public void onForgotten();
+    method @Deprecated public void onRemembered();
+    method @Deprecated public void setRequest(R? request);
+    method @Deprecated public void setShouldRefetchOnSizeChange(com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange);
     property public long intrinsicSize;
     property public final com.google.accompanist.imageloading.ImageLoadState loadState;
     property public final R? request;
     property public final com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange;
   }
 
-  public final class LoadPainterDefaults {
-    field public static final int FadeInTransitionDuration = 1000; // 0x3e8
-    field public static final com.google.accompanist.imageloading.LoadPainterDefaults INSTANCE;
+  @Deprecated public final class LoadPainterDefaults {
+    field @Deprecated public static final int FadeInTransitionDuration = 1000; // 0x3e8
+    field @Deprecated public static final com.google.accompanist.imageloading.LoadPainterDefaults INSTANCE;
   }
 
   public final class LoadPainterKt {
-    method @androidx.compose.runtime.Composable public static <R> com.google.accompanist.imageloading.LoadPainter<R> rememberLoadPainter(com.google.accompanist.imageloading.Loader<R> loader, R? request, com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange, optional boolean fadeIn, optional int fadeInDurationMs, optional @DrawableRes int previewPlaceholder);
+    method @Deprecated @androidx.compose.runtime.Composable public static <R> com.google.accompanist.imageloading.LoadPainter<R> rememberLoadPainter(com.google.accompanist.imageloading.Loader<R> loader, R? request, com.google.accompanist.imageloading.ShouldRefetchOnSizeChange shouldRefetchOnSizeChange, optional boolean fadeIn, optional int fadeInDurationMs, optional @DrawableRes int previewPlaceholder);
   }
 
-  @androidx.compose.runtime.Stable public fun interface Loader<R> {
-    method public kotlinx.coroutines.flow.Flow<com.google.accompanist.imageloading.ImageLoadState> load(R? request, long size);
+  @Deprecated @androidx.compose.runtime.Stable public fun interface Loader<R> {
+    method @Deprecated public kotlinx.coroutines.flow.Flow<com.google.accompanist.imageloading.ImageLoadState> load(R? request, long size);
   }
 
   public final class MaterialLoadingImage {
   }
 
-  public fun interface ShouldRefetchOnSizeChange {
-    method public operator boolean invoke(com.google.accompanist.imageloading.ImageLoadState currentState, long size);
+  @Deprecated public fun interface ShouldRefetchOnSizeChange {
+    method @Deprecated public operator boolean invoke(com.google.accompanist.imageloading.ImageLoadState currentState, long size);
   }
 
 }

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/DataSource.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/DataSource.kt
@@ -16,6 +16,7 @@
 
 package com.google.accompanist.imageloading
 
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 enum class DataSource {
     /**
      * Represents an in-memory data source or cache (e.g. bitmap, ByteBuffer).

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/ImageLoadState.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/ImageLoadState.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DeprecatedCallableAddReplaceWith", "DEPRECATION")
+
 package com.google.accompanist.imageloading
 
 import androidx.compose.ui.graphics.painter.Painter
@@ -21,15 +23,18 @@ import androidx.compose.ui.graphics.painter.Painter
 /**
  * Represents the state of a [LoadPainter].
  */
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 sealed class ImageLoadState {
     /**
      * Indicates that a request is not in progress.
      */
+    @Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
     object Empty : ImageLoadState()
 
     /**
      * Indicates that the request is currently in progress.
      */
+    @Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
     data class Loading(
         val placeholder: Painter?,
         val request: Any,
@@ -42,6 +47,7 @@ sealed class ImageLoadState {
      * @param source The data source that the image was loaded from.
      * @param request The original request for this result.
      */
+    @Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
     data class Success(
         val result: Painter,
         val source: DataSource,
@@ -55,6 +61,7 @@ sealed class ImageLoadState {
      * @param throwable The optional throwable that caused the request failure.
      * @param request The original request for this result.
      */
+    @Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
     data class Error(
         val request: Any,
         val result: Painter? = null,
@@ -65,6 +72,7 @@ sealed class ImageLoadState {
 /**
  * Returns true if this state represents the final state for the current request.
  */
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 fun ImageLoadState.isFinalState(): Boolean {
     return this is ImageLoadState.Success || this is ImageLoadState.Error
 }

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/LoadPainter.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/LoadPainter.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.imageloading
 
 import android.annotation.SuppressLint
@@ -61,6 +63,7 @@ import kotlin.math.roundToInt
  * @param R The data or input parameter type.
  */
 @Stable
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 fun interface Loader<R> {
     /**
      * Execute the 'load' with the given parameters.
@@ -75,10 +78,12 @@ fun interface Loader<R> {
 /**
  * Object which holds default values for [rememberLoadPainter].
  */
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 object LoadPainterDefaults {
     /**
      * Default duration in milliseconds for the fade-in animation.
      */
+    @Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
     const val FadeInTransitionDuration: Int = 1000
 }
 
@@ -97,6 +102,7 @@ object LoadPainterDefaults {
  * ran in preview mode.
  */
 @Composable
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 fun <R> rememberLoadPainter(
     loader: Loader<R>,
     request: R?,
@@ -136,6 +142,7 @@ fun <R> rememberLoadPainter(
 /**
  * Interface that allows apps to control whether a request is re-run once the size changes.
  */
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 fun interface ShouldRefetchOnSizeChange {
     /**
      * Return `true` if the request should be re-run if the [size] has changed.
@@ -153,6 +160,7 @@ fun interface ShouldRefetchOnSizeChange {
  *
  * Instances can be created and remembered via the [rememberLoadPainter] function.
  */
+@Deprecated("Accompanist-ImageLoading is now deprecated. Consider using Coil: https://coil-kt.github.io/coil/compose")
 class LoadPainter<R> internal constructor(
     private val loader: Loader<R>,
     private val coroutineScope: CoroutineScope,

--- a/imageloading-core/src/main/java/com/google/accompanist/imageloading/MaterialLoadingImage.kt
+++ b/imageloading-core/src/main/java/com/google/accompanist/imageloading/MaterialLoadingImage.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
 @file:JvmName("MaterialLoadingImage")
 
 package com.google.accompanist.imageloading

--- a/imageloading-testutils/src/main/java/com/google/accompanist/imageloading/test/ImageRequest.kt
+++ b/imageloading-testutils/src/main/java/com/google/accompanist/imageloading/test/ImageRequest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.imageloading.test
 
 import androidx.compose.runtime.Composable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ repo_url: 'https://github.com/google/accompanist'
 # Navigation
 nav:
   - 'Overview': index.md
-  - 'Coil':
+  - 'Coil (deprecated)':
     - 'Guide': coil.md
     - 'API': api/coil/
     - 'Migration from CoilImage': coil/migration-coilimage.md

--- a/sample/src/main/java/com/google/accompanist/sample/coil/CoilBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/coil/CoilBasicSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.coil
 
 import android.content.Context

--- a/sample/src/main/java/com/google/accompanist/sample/coil/CoilLazyColumnSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/coil/CoilLazyColumnSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.coil
 
 import android.os.Bundle

--- a/sample/src/main/java/com/google/accompanist/sample/coil/CoilLazyGridSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/coil/CoilLazyGridSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.coil
 
 import android.os.Bundle

--- a/sample/src/main/java/com/google/accompanist/sample/glide/GlideBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/glide/GlideBasicSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.glide
 
 import android.os.Bundle

--- a/sample/src/main/java/com/google/accompanist/sample/glide/GlideLazyColumnSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/glide/GlideLazyColumnSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.glide
 
 import android.os.Bundle

--- a/sample/src/main/java/com/google/accompanist/sample/glide/GlideLazyGridSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/glide/GlideLazyGridSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.glide
 
 import android.os.Bundle

--- a/sample/src/main/java/com/google/accompanist/sample/insets/ListItems.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/insets/ListItems.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.glide.rememberGlidePainter
+import coil.compose.rememberImagePainter
 
 /**
  * Simple list item row which displays an image and text.
@@ -42,7 +42,7 @@ fun ListItem(
 ) {
     Row(modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
         Image(
-            painter = rememberGlidePainter(imageUrl),
+            painter = rememberImagePainter(imageUrl),
             contentDescription = null,
             modifier = Modifier
                 .size(64.dp)

--- a/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerTransitionSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerTransitionSample.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
-import com.google.accompanist.coil.rememberCoilPainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.calculateCurrentOffsetForPage
@@ -126,9 +126,8 @@ fun HorizontalPagerWithOffsetTransition() {
         ) {
             Box {
                 Image(
-                    painter = rememberCoilPainter(
-                        request = rememberRandomSampleImageUrl(width = 600),
-                        fadeIn = true,
+                    painter = rememberImagePainter(
+                        data = rememberRandomSampleImageUrl(width = 600),
                     ),
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
@@ -164,7 +163,7 @@ private fun ProfilePicture(modifier: Modifier = Modifier) {
         border = BorderStroke(4.dp, MaterialTheme.colors.surface)
     ) {
         Image(
-            painter = rememberCoilPainter(request = rememberRandomSampleImageUrl(), fadeIn = true),
+            painter = rememberImagePainter(rememberRandomSampleImageUrl()),
             contentDescription = null,
             modifier = Modifier.size(72.dp),
         )

--- a/sample/src/main/java/com/google/accompanist/sample/pager/PagerSampleItem.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/pager/PagerSampleItem.kt
@@ -29,7 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.coil.rememberCoilPainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.sample.rememberRandomSampleImageUrl
 
 /**
@@ -43,9 +43,8 @@ internal fun PagerSampleItem(
     Box(modifier) {
         // Our page content, displaying a random image
         Image(
-            painter = rememberCoilPainter(
-                request = rememberRandomSampleImageUrl(width = 600),
-                fadeIn = true,
+            painter = rememberImagePainter(
+                data = rememberRandomSampleImageUrl(width = 600),
             ),
             contentDescription = null,
             modifier = Modifier.matchParentSize()

--- a/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderBasicSample.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
-import com.google.accompanist.glide.rememberGlidePainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
@@ -93,7 +93,7 @@ private fun Sample() {
                 }
                 items(30) { index ->
                     ListItem(
-                        painter = rememberGlidePainter(randomSampleImageUrl(index)),
+                        painter = rememberImagePainter(randomSampleImageUrl(index)),
                         text = "Text",
                         // We're using the modifier provided by placeholder-material which
                         // uses good default values for the color

--- a/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderFadeSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderFadeSample.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
-import com.google.accompanist.glide.rememberGlidePainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material.fade
 import com.google.accompanist.placeholder.material.placeholder
@@ -95,7 +95,7 @@ private fun Sample() {
                 }
                 items(30) { index ->
                     ListItem(
-                        painter = rememberGlidePainter(randomSampleImageUrl(index)),
+                        painter = rememberImagePainter(randomSampleImageUrl(index)),
                         text = "Text",
                         // We're using the modifier provided by placeholder-material which
                         // uses good default values for the color

--- a/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderShimmerSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderShimmerSample.kt
@@ -36,7 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
-import com.google.accompanist.glide.rememberGlidePainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.placeholder.material.shimmer
@@ -95,7 +95,7 @@ private fun Sample() {
                 }
                 items(30) { index ->
                     ListItem(
-                        painter = rememberGlidePainter(randomSampleImageUrl(index)),
+                        painter = rememberImagePainter(randomSampleImageUrl(index)),
                         text = "Text",
                         // We're using the modifier provided by placeholder-material which
                         // uses good default values for the color

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.glide.rememberGlidePainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
@@ -90,7 +90,7 @@ private fun Sample() {
                 items(30) { index ->
                     Row(Modifier.padding(16.dp)) {
                         Image(
-                            painter = rememberGlidePainter(randomSampleImageUrl(index)),
+                            painter = rememberImagePainter(randomSampleImageUrl(index)),
                             contentDescription = null,
                             modifier = Modifier.size(64.dp),
                         )

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshTweakedIndicatorSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshTweakedIndicatorSample.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.glide.rememberGlidePainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
@@ -103,7 +103,7 @@ private fun Sample() {
                 items(30) { index ->
                     Row(Modifier.padding(16.dp)) {
                         Image(
-                            painter = rememberGlidePainter(randomSampleImageUrl(index)),
+                            painter = rememberImagePainter(randomSampleImageUrl(index)),
                             contentDescription = null,
                             modifier = Modifier.size(64.dp),
                         )

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshVerticalPagerSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshVerticalPagerSample.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.glide.rememberGlidePainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.VerticalPager
 import com.google.accompanist.pager.rememberPagerState
@@ -102,7 +102,7 @@ private fun Sample() {
                 Box {
                     // Our page content, displaying a random image
                     Image(
-                        painter = rememberGlidePainter(randomSampleImageUrl(width = 600)),
+                        painter = rememberImagePainter(randomSampleImageUrl(width = 600)),
                         contentDescription = null,
                         modifier = Modifier
                             .fillMaxWidth()

--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsColorSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsColorSample.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
-import com.google.accompanist.coil.rememberCoilPainter
+import coil.compose.rememberImagePainter
 import com.google.accompanist.insets.ProvideWindowInsets
 import com.google.accompanist.insets.systemBarsPadding
 import com.google.accompanist.sample.AccompanistSampleTheme
@@ -120,15 +120,14 @@ private fun Sample() {
     BoxWithConstraints(Modifier.fillMaxSize()) {
         // Displaying a random image
         Image(
-            painter = rememberCoilPainter(
-                request = with(LocalDensity.current) {
+            painter = rememberImagePainter(
+                data = with(LocalDensity.current) {
                     rememberRandomSampleImageUrl(
                         seed = 16,
                         width = maxWidth.roundToPx(),
                         height = maxHeight.roundToPx()
                     )
                 },
-                fadeIn = true,
             ),
             contentDescription = null,
             contentScale = ContentScale.Crop,


### PR DESCRIPTION
Following on from the release of [`coil-compose`](https://coil-kt.github.io/coil/compose/) in Coil 1.3.0, this PR deprecates Accompanist Coil. 

This left Accompanist Glide is a weird situation, where most of `imageloading-core` was there to only support Glide. Since Coil is better suited for use in Compose I've decided to deprecate everything: `accompanist-coil`, `accompanist-glide` and `accompanist-imageloading-core`. All of the libraries will be removed soon (likely v0.16.0)

I need to migrate `DrawablePainter` over to a new library, but that can wait for now.