### PR TITLE
Pin Android Emulator back on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 28, 29 ]
+        api-level: [ 22, 26, 29 ]
         shard: [ 0, 1 ] # Need to update shard-count below if this changes
 
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         run: release/signing-cleanup.sh
 
   test:
-    runs-on: macos-11.0
+    runs-on: macos-latest
     needs: build
     timeout-minutes: 50
 
@@ -137,6 +137,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ steps.determine-target.outputs.TARGET }}
           profile: Galaxy Nexus
+          emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160
           # We run all affected tests of the PR (or commit)
           script: ./scripts/run-tests.sh --log-file=logcat.txt --run-affected --affected-base-ref=$BASE_REF --shard-index=${{ matrix.shard }} --shard-count=2
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   android-test:
-    runs-on: macos-11.0
+    runs-on: macos-latest
     timeout-minutes: 60
 
     strategy:
@@ -66,6 +66,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ steps.determine-target.outputs.TARGET }}
           profile: Galaxy Nexus
+          emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/160
           # We run all tests, sharding them over 3 shards
           script: ./scripts/run-tests.sh --log-file=logcat.txt --shard-index=${{ matrix.shard }} --shard-count=3
 

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -19,7 +19,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 28, 29 ]
+        api-level: [ 22, 26, 29 ]
         shard: [ 0, 1, 2 ] # Need to update shard-count below if this changes
 
     steps:


### PR DESCRIPTION
To workaround https://github.com/ReactiveCircus/android-emulator-runner/issues/160. Also removed running tests on API 28 as they seem to be causing the emulator to fail.