### PR TITLE
Re-enable API 28 emulators on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 29 ]
+        api-level: [ 22, 26, 28, 29 ]
         shard: [ 0, 1 ] # Need to update shard-count below if this changes
 
     env:

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -19,7 +19,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 29 ]
+        api-level: [ 22, 26, 28, 29 ]
         shard: [ 0, 1, 2 ] # Need to update shard-count below if this changes
 
     steps:


### PR DESCRIPTION
Related: https://github.com/ReactiveCircus/android-emulator-runner/issues/168