### PR TITLE
Fix pagerTabIndicatorOffset crashing

### DIFF
--- a/pager-indicators/build.gradle
+++ b/pager-indicators/build.gradle
@@ -68,11 +68,46 @@ android {
         }
         animationsDisabled true
     }
+
+    sourceSets {
+        test {
+            java.srcDirs += 'src/sharedTest/kotlin'
+            res.srcDirs += 'src/sharedTest/res'
+        }
+        androidTest {
+            java.srcDirs += 'src/sharedTest/kotlin'
+            res.srcDirs += 'src/sharedTest/res'
+        }
+    }
 }
 
 dependencies {
     api project(':pager')
     api libs.compose.material.material
+
+    // ======================
+    // Test dependencies
+    // ======================
+
+    androidTestImplementation project(':internal-testutils')
+    testImplementation project(':internal-testutils')
+
+    androidTestImplementation libs.junit
+    testImplementation libs.junit
+
+    androidTestImplementation libs.truth
+    testImplementation libs.truth
+
+    androidTestImplementation libs.compose.ui.test.junit4
+    testImplementation libs.compose.ui.test.junit4
+
+    androidTestImplementation libs.compose.ui.test.manifest
+    testImplementation libs.compose.ui.test.manifest
+
+    androidTestImplementation libs.androidx.test.runner
+    testImplementation libs.androidx.test.runner
+
+    testImplementation libs.robolectric
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
@@ -43,6 +43,9 @@ fun Modifier.pagerTabIndicatorOffset(
     pagerState: PagerState,
     tabPositions: List<TabPosition>,
 ): Modifier = composed {
+    // If there are no pages, nothing to show
+    if (pagerState.pageCount == 0) return@composed this
+
     val targetIndicatorOffset: Dp
     val indicatorWidth: Dp
 

--- a/pager-indicators/src/sharedTest/kotlin/com/google/accompanist/insets/DummyTests.kt
+++ b/pager-indicators/src/sharedTest/kotlin/com/google/accompanist/insets/DummyTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.insets
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/**
+ * Dummy tests to help with sharding: https://github.com/android/android-test/issues/973
+ */
+@RunWith(JUnit4::class)
+class DummyTests {
+    @Test
+    fun dummy1() = Unit
+
+    @Test
+    fun dummy2() = Unit
+
+    @Test
+    fun dummy3() = Unit
+
+    @Test
+    fun dummy4() = Unit
+
+    @Test
+    fun dummy5() = Unit
+
+    @Test
+    fun dummy6() = Unit
+
+    @Test
+    fun dummy7() = Unit
+
+    @Test
+    fun dummy8() = Unit
+
+    @Test
+    fun dummy9() = Unit
+
+    @Test
+    fun dummy10() = Unit
+}

--- a/pager-indicators/src/sharedTest/kotlin/com/google/accompanist/insets/TabIndicatorTest.kt
+++ b/pager-indicators/src/sharedTest/kotlin/com/google/accompanist/insets/TabIndicatorTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.insets
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRowDefaults
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.pagerTabIndicatorOffset
+import com.google.accompanist.pager.rememberPagerState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalPagerApi::class)
+@RunWith(AndroidJUnit4::class)
+class TabIndicatorTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun emptyPager() {
+        rule.setContent {
+            MaterialTheme {
+                val pagerState = rememberPagerState(pageCount = 0)
+                ScrollableTabRow(
+                    selectedTabIndex = pagerState.currentPage,
+                    indicator = { tabPositions ->
+                        TabRowDefaults.Indicator(
+                            Modifier.pagerTabIndicatorOffset(pagerState, tabPositions)
+                        )
+                    },
+                ) {
+                    // Add tabs for all of our pages
+                    (0 until pagerState.pageCount).forEach { index ->
+                        Tab(
+                            text = { Text("Tab $index") },
+                            selected = pagerState.currentPage == index,
+                            onClick = {}
+                        )
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Happens when the pager has 0 pages, which can happen during init.