### PR TITLE
[Pager] Fix recomposition affecting scrolling

### DIFF
--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
@@ -18,6 +18,7 @@ package com.google.accompanist.pager
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -111,6 +112,7 @@ abstract class BaseHorizontalPagerTest(
 
     override fun setPagerContent(
         pageCount: Int,
+        observeStateInContent: Boolean,
     ): PagerState {
         val pagerState = PagerState(
             pageCount = pageCount,
@@ -120,24 +122,30 @@ abstract class BaseHorizontalPagerTest(
         composeTestRule.setContent(layoutDirection) {
             applierScope = rememberCoroutineScope()
 
-            HorizontalPager(
-                state = pagerState,
-                itemSpacing = itemSpacingDp.dp,
-                reverseLayout = reverseLayout,
-                horizontalAlignment = horizontalAlignment,
-                modifier = Modifier.fillMaxSize()
-            ) { page ->
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(itemWidthFraction)
-                        .aspectRatio(1f)
-                        .background(randomColor())
-                        .testTag(page.toString())
-                ) {
-                    BasicText(
-                        text = page.toString(),
-                        modifier = Modifier.align(Alignment.Center)
-                    )
+            Column {
+                if (observeStateInContent) {
+                    BasicText(text = "${pagerState.isScrollInProgress}")
+                }
+
+                HorizontalPager(
+                    state = pagerState,
+                    itemSpacing = itemSpacingDp.dp,
+                    reverseLayout = reverseLayout,
+                    horizontalAlignment = horizontalAlignment,
+                    modifier = Modifier.fillMaxSize()
+                ) { page ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(itemWidthFraction)
+                            .aspectRatio(1f)
+                            .background(randomColor())
+                            .testTag(page.toString())
+                    ) {
+                        BasicText(
+                            text = page.toString(),
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    }
                 }
             }
         }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
@@ -18,7 +18,6 @@ package com.google.accompanist.pager
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -122,7 +121,7 @@ abstract class BaseHorizontalPagerTest(
         composeTestRule.setContent(layoutDirection) {
             applierScope = rememberCoroutineScope()
 
-            Column {
+            Box {
                 if (observeStateInContent) {
                     BasicText(text = "${pagerState.isScrollInProgress}")
                 }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
@@ -18,7 +18,6 @@ package com.google.accompanist.pager
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -114,7 +113,7 @@ abstract class BaseVerticalPagerTest(
         composeTestRule.setContent(LayoutDirection.Ltr) {
             applierScope = rememberCoroutineScope()
 
-            Column {
+            Box {
                 if (observeStateInContent) {
                     BasicText(text = "${pagerState.isScrollInProgress}")
                 }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
@@ -18,6 +18,7 @@ package com.google.accompanist.pager
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -100,7 +101,10 @@ abstract class BaseVerticalPagerTest(
             }
     }
 
-    override fun setPagerContent(pageCount: Int): PagerState {
+    override fun setPagerContent(
+        pageCount: Int,
+        observeStateInContent: Boolean,
+    ): PagerState {
         val pagerState = PagerState(
             pageCount = pageCount,
             offscreenLimit = offscreenLimit,
@@ -110,24 +114,30 @@ abstract class BaseVerticalPagerTest(
         composeTestRule.setContent(LayoutDirection.Ltr) {
             applierScope = rememberCoroutineScope()
 
-            VerticalPager(
-                state = pagerState,
-                itemSpacing = itemSpacingDp.dp,
-                reverseLayout = reverseLayout,
-                verticalAlignment = verticalAlignment,
-                modifier = Modifier.fillMaxSize()
-            ) { page ->
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f)
-                        .background(randomColor())
-                        .testTag(page.toString())
-                ) {
-                    BasicText(
-                        text = page.toString(),
-                        modifier = Modifier.align(Alignment.Center)
-                    )
+            Column {
+                if (observeStateInContent) {
+                    BasicText(text = "${pagerState.isScrollInProgress}")
+                }
+
+                VerticalPager(
+                    state = pagerState,
+                    itemSpacing = itemSpacingDp.dp,
+                    reverseLayout = reverseLayout,
+                    verticalAlignment = verticalAlignment,
+                    modifier = Modifier.fillMaxSize()
+                ) { page ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(1f)
+                            .background(randomColor())
+                            .testTag(page.toString())
+                    ) {
+                        BasicText(
+                            text = page.toString(),
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    }
                 }
             }
         }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -290,7 +290,6 @@ abstract class PagerTest {
     }
 
     @Test
-    @Ignore("https://github.com/google/accompanist/issues/590")
     fun scrollWhenStateObserved() {
         val pagerState = setPagerContent(pageCount = 4, observeStateInContent = true)
 

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -289,6 +289,23 @@ abstract class PagerTest {
         assertPagerLayout(1, pagerState.pageCount)
     }
 
+    @Test
+    fun scrollWhenStateObserved() {
+        val pagerState = setPagerContent(pageCount = 4, observeStateInContent = true)
+
+        // Now swipe towards start, from page 0 to page 1
+        composeTestRule.onNodeWithTag("0")
+            .swipeAcrossCenter(distancePercentage = -MediumSwipeDistance)
+        // ...and assert that we now laid out from page 1
+        assertPagerLayout(1, pagerState.pageCount)
+
+        // Now swipe towards the end, from page 1 to page 0
+        composeTestRule.onNodeWithTag("1")
+            .swipeAcrossCenter(distancePercentage = MediumSwipeDistance)
+        // ...and assert that we now laid out from page 0
+        assertPagerLayout(0, pagerState.pageCount)
+    }
+
     /**
      * Swipe across the center of the node. The major axis of the swipe is defined by the
      * overriding test.
@@ -339,5 +356,8 @@ abstract class PagerTest {
         currentPage: Int,
     ): SemanticsNodeInteraction
 
-    protected abstract fun setPagerContent(pageCount: Int): PagerState
+    protected abstract fun setPagerContent(
+        pageCount: Int,
+        observeStateInContent: Boolean = false,
+    ): PagerState
 }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -290,6 +290,7 @@ abstract class PagerTest {
     }
 
     @Test
+    @Ignore("https://github.com/google/accompanist/issues/590")
     fun scrollWhenStateObserved() {
         val pagerState = setPagerContent(pageCount = 4, observeStateInContent = true)
 


### PR DESCRIPTION
If the Pager composable is recomposed during a scroll it currently resets back to the original page. This is because the recomposition will call `rememberPagerState()`, which updates the `PagerState.pageCount` count value, which triggers a page layout update.

There's no real need to update the layout when this happens, as the updated `currentPage` will do it as necessary. Fixed by removing that call.

Fixes #585