### PR TITLE
Remove default enter/exit transitions at the graph level

### DIFF
--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
@@ -19,9 +19,6 @@ package com.google.accompanist.navigation.animation
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDeepLink
@@ -100,10 +97,12 @@ public fun NavGraphBuilder.composable(
 public fun NavGraphBuilder.navigation(
     startDestination: String,
     route: String,
-    enterTransition: ((initial: NavBackStackEntry, target: NavBackStackEntry) -> EnterTransition)? =
-        { _, _ -> fadeIn(animationSpec = tween(700)) },
-    exitTransition: ((initial: NavBackStackEntry, target: NavBackStackEntry) -> ExitTransition)? =
-        { _, _ -> fadeOut(animationSpec = tween(700)) },
+    enterTransition: (
+        (initial: NavBackStackEntry, target: NavBackStackEntry) -> EnterTransition
+    )? = null,
+    exitTransition: (
+        (initial: NavBackStackEntry, target: NavBackStackEntry) -> ExitTransition
+    )? = null,
     popEnterTransition: (
         (initial: NavBackStackEntry, target: NavBackStackEntry) -> EnterTransition
     )? = enterTransition,


### PR DESCRIPTION
`AnimatedNavHost` determines the correct transition by walking up the hierarchy of the destination - the destination itself first gets a chance to provide a transition, then its parent graph, then its grandparent graph, etc. all the way up to the root of the entire graph. These global transitions at the root graph level are set by the parameters to `AnimatedNavHost`.

In the case of the intermediate navigation graphs that added via the `navigation` element, each nested graph should defer to their parent by default. This ensures that changing the transitions at the `AnimatedNavHost` level affects all destinations and all graphs that haven't specifically set their own transitions.