### PR TITLE
Fix rememberAnimatedNavController API

### DIFF
--- a/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/AnimatedNavHostTest.kt
+++ b/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/AnimatedNavHostTest.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navDeepLink
 import androidx.navigation.plusAssign
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/AnimatedNavHostTest.kt
+++ b/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/AnimatedNavHostTest.kt
@@ -50,8 +50,7 @@ class AnimatedNavHostTest {
         composeTestRule.mainClock.autoAdvance = false
 
         composeTestRule.setContent {
-            navController = rememberNavController()
-            navController.navigatorProvider += AnimatedComposeNavigator()
+            navController = rememberAnimatedNavController()
             AnimatedNavHost(navController, startDestination = first) {
                 composable(first) { BasicText(first) }
                 composable(second) { BasicText(second) }
@@ -144,8 +143,7 @@ class AnimatedNavHostTest {
             activity?.intent?.run {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
             }
-            navController = rememberNavController()
-            navController.navigatorProvider += AnimatedComposeNavigator()
+            navController = rememberAnimatedNavController()
             AnimatedNavHost(navController, startDestination = first) {
                 composable(first) { BasicText(first) }
                 composable(

--- a/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/NavHostControllerTest.kt
+++ b/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/NavHostControllerTest.kt
@@ -18,16 +18,12 @@ package com.google.accompanist.navigation.animation
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.get
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -53,7 +49,6 @@ class NavHostControllerTest {
                 composable(second) { BasicText(second) }
             }
         }
-
 
         val navigator = composeTestRule.runOnIdle {
             navController.navigatorProvider[AnimatedComposeNavigator::class]

--- a/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/NavHostControllerTest.kt
+++ b/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/NavHostControllerTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.animation
+
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.get
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalAnimationApi::class)
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class NavHostControllerTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testRememberAnimatedNavController() {
+        lateinit var navController: NavHostController
+
+        composeTestRule.setContent {
+            navController = rememberAnimatedNavController()
+            // get state to trigger recompose on navigate
+            navController.currentBackStackEntryAsState().value
+            AnimatedNavHost(navController, startDestination = first) {
+                composable(first) { BasicText(first) }
+                composable(second) { BasicText(second) }
+            }
+        }
+
+
+        val navigator = composeTestRule.runOnIdle {
+            navController.navigatorProvider[AnimatedComposeNavigator::class]
+        }
+
+        // trigger recompose
+        composeTestRule.runOnIdle {
+            navController.navigate(second)
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(navController.navigatorProvider[AnimatedComposeNavigator::class])
+                .isEqualTo(navigator)
+        }
+    }
+}
+
+private const val first = "first"
+private const val second = "second"

--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavHostController.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavHostController.kt
@@ -18,6 +18,7 @@ package com.google.accompanist.navigation.animation
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.plusAssign
@@ -33,6 +34,6 @@ import androidx.navigation.plusAssign
 @Composable
 public fun rememberAnimatedNavController(): NavHostController {
     return rememberNavController().apply {
-        navigatorProvider += AnimatedComposeNavigator()
+        navigatorProvider += remember(this) { AnimatedComposeNavigator() }
     }
 }


### PR DESCRIPTION
Making sure the `rememberAnimatedNavController` API only changes the `AnimatedComposeNavigator` if the underlying navController changes. 

Also switched to using the `rememberAnimatedNavController` function in our tests.

Fixes #610
