### PR TITLE
Fix active bullet offset

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
@@ -70,6 +70,7 @@ fun HorizontalPagerIndicator(
 ) {
 
     val indicatorWidthPx = LocalDensity.current.run { indicatorWidth.roundToPx() }
+    val spacingPx = LocalDensity.current.run { spacing.roundToPx() }
 
     Box(
         modifier = modifier,
@@ -94,7 +95,7 @@ fun HorizontalPagerIndicator(
                     val scrollPosition = (pagerState.currentPage + pagerState.currentPageOffset)
                         .coerceIn(0f, (pagerState.pageCount - 1).toFloat())
                     IntOffset(
-                        x = ((spacing.roundToPx() + indicatorWidthPx) * scrollPosition).toInt(),
+                        x = ((spacingPx + indicatorWidthPx) * scrollPosition).toInt(),
                         y = 0
                     )
                 }
@@ -140,6 +141,7 @@ fun VerticalPagerIndicator(
 ) {
 
     val indicatorHeightPx = LocalDensity.current.run { indicatorHeight.roundToPx() }
+    val spacingPx = LocalDensity.current.run { spacing.roundToPx() }
 
     Box(
         modifier = modifier,
@@ -165,7 +167,7 @@ fun VerticalPagerIndicator(
                         .coerceIn(0f, (pagerState.pageCount - 1).toFloat())
                     IntOffset(
                         x = 0,
-                        y = ((spacing.roundToPx() + indicatorHeightPx) * scrollPosition).toInt(),
+                        y = ((spacingPx + indicatorHeightPx) * scrollPosition).toInt(),
                     )
                 }
                 .size(width = indicatorWidth, height = indicatorHeight)

--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -67,6 +68,9 @@ fun HorizontalPagerIndicator(
     spacing: Dp = indicatorWidth,
     indicatorShape: Shape = CircleShape,
 ) {
+
+    val indicatorWidthPx = LocalDensity.current.run { indicatorWidth.roundToPx() }
+
     Box(
         modifier = modifier,
         contentAlignment = Alignment.CenterStart
@@ -90,7 +94,7 @@ fun HorizontalPagerIndicator(
                     val scrollPosition = (pagerState.currentPage + pagerState.currentPageOffset)
                         .coerceIn(0f, (pagerState.pageCount - 1).toFloat())
                     IntOffset(
-                        x = ((spacing + indicatorWidth) * scrollPosition).roundToPx(),
+                        x = ((spacing.roundToPx() + indicatorWidthPx) * scrollPosition).toInt(),
                         y = 0
                     )
                 }
@@ -134,6 +138,9 @@ fun VerticalPagerIndicator(
     spacing: Dp = indicatorHeight,
     indicatorShape: Shape = CircleShape,
 ) {
+
+    val indicatorHeightPx = LocalDensity.current.run { indicatorHeight.roundToPx() }
+
     Box(
         modifier = modifier,
         contentAlignment = Alignment.TopCenter
@@ -158,7 +165,7 @@ fun VerticalPagerIndicator(
                         .coerceIn(0f, (pagerState.pageCount - 1).toFloat())
                     IntOffset(
                         x = 0,
-                        y = ((spacing + indicatorHeight) * scrollPosition).roundToPx(),
+                        y = ((spacing.roundToPx() + indicatorHeightPx) * scrollPosition).toInt(),
                     )
                 }
                 .size(width = indicatorWidth, height = indicatorHeight)


### PR DESCRIPTION
#623 

Calculating indicatorWidth, indicatorHeight and spacing with LocalDensity seems to solve this issue.

VerticalPagerIndicator  | HorizontalPagerIndicator
------------- | -------------
![WhatsApp Image 2021-08-08 at 13 37 02](https://user-images.githubusercontent.com/13544246/128629184-71d4f2fc-35f5-44c3-8c23-0b009f876d58.jpeg) | ![WhatsApp Image 2021-08-08 at 13 36 06](https://user-images.githubusercontent.com/13544246/128629182-0243c5a7-703f-488b-b8e5-7ea3981713f7.jpeg)
