### PR TITLE
[Pager] Don't set selected semantic property

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.semantics.ScrollAxisRange
 import androidx.compose.ui.semantics.horizontalScrollAxisRange
 import androidx.compose.ui.semantics.scrollBy
 import androidx.compose.ui.semantics.selectableGroup
-import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -288,12 +287,9 @@ internal fun Pager(
             for (_page in pages) {
                 val page = state.pageOf(_page)
                 key(page) {
-                    val itemSemantics = Modifier.semantics {
-                        this.selected = page == state.currentPage
-                    }
                     Box(
                         contentAlignment = Alignment.Center,
-                        modifier = itemSemantics.then(PageData(_page))
+                        modifier = PageData(_page)
                     ) {
                         val scope = remember(this, state) {
                             PagerScopeImpl(this, state)

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -17,12 +17,8 @@
 package com.google.accompanist.pager
 
 import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.assertIsNotSelected
-import androidx.compose.ui.test.assertIsSelectable
-import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.performScrollTo
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
@@ -340,10 +336,6 @@ abstract class PagerTest {
                 composeTestRule.onNodeWithTag(page.toString())
                     .assertExists()
                     .assertLaidOutItemPosition(page, currentPage)
-                    .onParent()
-                    .assertIsSelectable()
-                    .assertWhen(page == currentPage) { assertIsSelected() }
-                    .assertWhen(page != currentPage) { assertIsNotSelected() }
             } else {
                 // If this page is not expected to be laid out, assert that it doesn't exist
                 composeTestRule.onNodeWithTag(_page.toString()).assertDoesNotExist()


### PR DESCRIPTION
Selected is designed to be used by controls such as radio buttons, which doesn't match our use case. Remove this for now to allow developers to set their own semantic meaning.

Fixes #599