### PR TITLE
[Pager] Tweaks to PagerState.targetPage

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
@@ -51,7 +51,7 @@ fun Modifier.pagerTabIndicatorOffset(
 
     val currentTab = tabPositions[pagerState.currentPage]
     val targetPage = pagerState.targetPage
-    val targetTab = targetPage?.let { tabPositions.getOrNull(it) }
+    val targetTab = tabPositions.getOrNull(targetPage)
 
     if (targetTab != null) {
         // The distance between the target and current page. If the pager is animating over many

--- a/pager/api/current.api
+++ b/pager/api/current.api
@@ -32,7 +32,7 @@ package com.google.accompanist.pager {
     method @IntRange(from=0) public int getCurrentPage();
     method public float getCurrentPageOffset();
     method @IntRange(from=0) public int getPageCount();
-    method public Integer? getTargetPage();
+    method public int getTargetPage();
     method public boolean isScrollInProgress();
     method public suspend Object? scroll(androidx.compose.foundation.MutatePriority scrollPriority, kotlin.jvm.functions.Function2<? super androidx.compose.foundation.gestures.ScrollScope,? super kotlin.coroutines.Continuation<? super kotlin.Unit>,?> block, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
     method public suspend Object? scrollToPage(@IntRange(from=0) int page, optional @FloatRange(from=0.0, to=1.0) float pageOffset, optional kotlin.coroutines.Continuation<? super kotlin.Unit> p);
@@ -41,7 +41,7 @@ package com.google.accompanist.pager {
     property public final float currentPageOffset;
     property public boolean isScrollInProgress;
     property @IntRange(from=0) public final int pageCount;
-    property public final Integer? targetPage;
+    property public final int targetPage;
     field public static final com.google.accompanist.pager.PagerState.Companion Companion;
   }
 

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -246,12 +246,14 @@ class PagerState(
 
     /**
      * The target page for any on-going animations or scrolls by the user.
-     * Returns null if a scroll or animation is not currently in progress.
+     * Returns the current page if a scroll or animation is not currently in progress.
      */
-    val targetPage: Int?
+    val targetPage: Int
         get() = _animationTargetPage ?: when {
-            // If a scroll isn't in progress, return null
-            !isScrollInProgress -> null
+            // If a scroll isn't in progress, return the current page
+            !isScrollInProgress -> currentPage
+            // If the offset is 0f (or very close), return the current page
+            currentPageOffset < 0.001f -> currentPage
             // If we're offset towards the start, guess the previous page
             currentPageOffset < 0 -> (currentPage - 1).coerceAtLeast(0)
             // If we're offset towards the end, guess the next page

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -195,7 +195,12 @@ abstract class PagerTest {
 
     @Test
     fun mediumDistance_fastSwipe_toFling() {
+        composeTestRule.mainClock.autoAdvance = false
+
         val pagerState = setPagerContent(pageCount = 10)
+
+        assertThat(pagerState.isScrollInProgress).isFalse()
+        assertThat(pagerState.targetPage).isEqualTo(0)
 
         // Now swipe towards start, from page 0 to page 1, over a medium distance of the item width.
         // This should trigger a fling()
@@ -204,13 +209,24 @@ abstract class PagerTest {
                 distancePercentage = -MediumSwipeDistance,
                 velocity = FastVelocity,
             )
+
+        assertThat(pagerState.isScrollInProgress).isTrue()
+        assertThat(pagerState.targetPage).isEqualTo(1)
+
+        // Now re-enable the clock advancement and let the fling animation run
+        composeTestRule.mainClock.autoAdvance = true
         // ...and assert that we now laid out from page 1
         assertPagerLayout(1, pagerState.pageCount)
     }
 
     @Test
     fun mediumDistance_slowSwipe_toSnapForward() {
+        composeTestRule.mainClock.autoAdvance = false
+
         val pagerState = setPagerContent(pageCount = 10)
+
+        assertThat(pagerState.isScrollInProgress).isFalse()
+        assertThat(pagerState.targetPage).isEqualTo(0)
 
         // Now swipe towards start, from page 0 to page 1, over a medium distance of the item width.
         // This should trigger a spring to position 1
@@ -219,13 +235,24 @@ abstract class PagerTest {
                 distancePercentage = -MediumSwipeDistance,
                 velocity = SlowVelocity,
             )
+
+        assertThat(pagerState.isScrollInProgress).isTrue()
+        assertThat(pagerState.targetPage).isEqualTo(1)
+
+        // Now re-enable the clock advancement and let the snap animation run
+        composeTestRule.mainClock.autoAdvance = true
         // ...and assert that we now laid out from page 1
         assertPagerLayout(1, pagerState.pageCount)
     }
 
     @Test
     fun shortDistance_fastSwipe_toFling() {
+        composeTestRule.mainClock.autoAdvance = false
+
         val pagerState = setPagerContent(pageCount = 10)
+
+        assertThat(pagerState.isScrollInProgress).isFalse()
+        assertThat(pagerState.targetPage).isEqualTo(0)
 
         // Now swipe towards start, from page 0 to page 1, over a short distance of the item width.
         // This should trigger a fling to page 1
@@ -234,13 +261,24 @@ abstract class PagerTest {
                 distancePercentage = -ShortSwipeDistance,
                 velocity = FastVelocity,
             )
+
+        assertThat(pagerState.isScrollInProgress).isTrue()
+        assertThat(pagerState.targetPage).isEqualTo(1)
+
+        // Now re-enable the clock advancement and let the fling animation run
+        composeTestRule.mainClock.autoAdvance = true
         // ...and assert that we now laid out from page 1
         assertPagerLayout(1, pagerState.pageCount)
     }
 
     @Test
     fun shortDistance_slowSwipe_toSnapBack() {
+        composeTestRule.mainClock.autoAdvance = false
+
         val pagerState = setPagerContent(pageCount = 10)
+
+        assertThat(pagerState.isScrollInProgress).isFalse()
+        assertThat(pagerState.targetPage).isEqualTo(0)
 
         // Now swipe towards start, from page 0 to page 1, over a short distance of the item width.
         // This should trigger a spring back to the original position
@@ -249,6 +287,12 @@ abstract class PagerTest {
                 distancePercentage = -ShortSwipeDistance,
                 velocity = SlowVelocity,
             )
+
+        assertThat(pagerState.isScrollInProgress).isTrue()
+        assertThat(pagerState.targetPage).isEqualTo(0)
+
+        // Now re-enable the clock advancement and let the snap animation run
+        composeTestRule.mainClock.autoAdvance = true
         // ...and assert that we 'sprang back' to page 0
         assertPagerLayout(0, pagerState.pageCount)
     }


### PR DESCRIPTION
- Make it non-null. If an animation isn't in progress we now return the current page.
- We now also return the current page if the offset is currently 0f.

Fixes #652
Fixes #654