### PR TITLE
Add instructions for migration to nav animation docs

### DIFF
--- a/docs/navigation-animation.md
+++ b/docs/navigation-animation.md
@@ -100,7 +100,18 @@ dependencies {
 }
 ```
 
+## Migration
+
+To migrate from using the Navigation Compose APIs do the following:
+
+* Replace `rememberNavController()` with `rememberAnimatedNavController()`
+* Replace `NavHost` with `AnimatedNavHost`
+* Replace `import androidx.navigation.compose.navigation` with `import com.google.accompanist.navigation.animation.navigation`
+* Replace `import androidx.navigation.compose.composable` with `import com.google.accompanist.navigation.animation.composable`
+
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap]. These are updated on every commit.
 
 [compose]: https://developer.android.com/jetpack/compose
 [snap]: https://oss.sonatype.org/content/repositories/snapshots/com/google/accompanist/accompanist-navigation-animation/
+
+For more details see [Animations in Navigation Compose](https://medium.com/androiddevelopers/animations-in-navigation-compose-36d48870776b)

--- a/docs/navigation-animation.md
+++ b/docs/navigation-animation.md
@@ -100,7 +100,7 @@ dependencies {
 }
 ```
 
-## Migration
+## Migrating to Accompanist Navigation Animation
 
 To migrate from using the Navigation Compose APIs do the following:
 


### PR DESCRIPTION
Add instructions for how users can migrate from the jetpack Navigation
Compose APIs to Navigation Accompanist to make it clear to developers.

Also added a link to the Navigation Accompanist blog post.