### PR TITLE
Update to depend on Navigation 2.4.0-alpha07

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ okhttp = "3.12.13"
 coil = "1.3.0"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.4.0-alpha06"
+androidxnavigation = "2.4.0-alpha07"
 
 [libraries]
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }


### PR DESCRIPTION
Depend on [Navigation `2.4.0-alpha07`](https://developer.android.com/jetpack/androidx/releases/navigation#2.4.0-alpha07) to pull in the fixes from that release.