### PR TITLE
Add links to documentation on modules where it was missing

### DIFF
--- a/navigation-animation/README.md
+++ b/navigation-animation/README.md
@@ -2,6 +2,8 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-navigation-animation)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+For more information, visit the documentation: https://google.github.io/accompanist/navigation-animation
+
 ## Download
 
 ```groovy

--- a/navigation-material/README.md
+++ b/navigation-material/README.md
@@ -2,6 +2,8 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-navigation-material)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+For more information, visit the documentation: https://google.github.io/accompanist/navigation-material
+
 ## Download
 
 ```groovy

--- a/permissions/README.md
+++ b/permissions/README.md
@@ -2,6 +2,8 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-permissions)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+For more information, visit the documentation: https://google.github.io/accompanist/permissions
+
 ## Download
 
 ```groovy

--- a/placeholder-material/README.md
+++ b/placeholder-material/README.md
@@ -2,6 +2,8 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-placeholder)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+For more information, visit the documentation: https://google.github.io/accompanist/placeholder
+
 ## Download
 
 ```groovy

--- a/placeholder/README.md
+++ b/placeholder/README.md
@@ -2,6 +2,8 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-placeholder)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+For more information, visit the documentation: https://google.github.io/accompanist/placeholder
+
 ## Download
 
 ```groovy


### PR DESCRIPTION
Some modules were lacking the easy to find link inside their README files to the appropriate documentation that I found very neat in other modules. This commit adds the links in those modules too.