### PR TITLE
ADD: separate shimmer effect

### DIFF
--- a/placeholder/build.gradle
+++ b/placeholder/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     implementation libs.compose.foundation.foundation
     implementation libs.compose.ui.util
     implementation libs.napier
+    implementation libs.androidx.core
 
     // ======================
     // Test dependencies

--- a/placeholder/src/main/java/com/google/accompanist/placeholder/shimmer/Shimmer.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/shimmer/Shimmer.kt
@@ -1,0 +1,155 @@
+package com.google.accompanist.placeholder.shimmer
+
+import androidx.compose.animation.core.*
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.DrawModifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+import androidx.core.graphics.transform
+import kotlin.math.tan
+
+/**
+ * Skeleton screen effect similar to facebook open source project
+ * https://github.com/facebook/shimmer-android
+ *
+ * The skeleton screen is usually animated in a line rather than an element,
+ * so it is best to separate it from the placeholder
+ *
+ * @param visible whether the shimmer should be visible or not
+ * @param config shimmer effect config
+ */
+fun Modifier.shimmer(
+    visible: Boolean,
+    config: ShimmerConfig = ShimmerConfig()
+): Modifier = composed {
+    var progress: Float by remember { mutableStateOf(0f) }
+    if (visible) {
+        val infiniteTransition = rememberInfiniteTransition()
+        progress = infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                tween(
+                    durationMillis = config.duration.toInt(),
+                    delayMillis = config.delay.toInt(),
+                    easing = LinearEasing
+                ),
+                repeatMode = RepeatMode.Restart
+            ),
+        ).value
+    }
+    ShimmerModifier(visible = visible, progress = progress, config = config)
+}
+
+internal class ShimmerModifier(
+    private val visible: Boolean,
+    private val progress: Float,
+    private val config: ShimmerConfig
+) : DrawModifier, LayoutModifier {
+    private val cleanPaint = Paint()
+    private val paint = Paint().apply {
+        isAntiAlias = true
+        style = PaintingStyle.Fill
+        blendMode = BlendMode.SrcIn
+    }
+    private val angleTan = tan(Math.toRadians(config.angle.toDouble())).toFloat()
+    private var translateHeight = 0f
+    private var translateWidth = 0f
+    private val intensity = config.intensity
+    private val dropOff = config.dropOff
+    private val colors = listOf(
+        config.contentColor,
+        config.higLightColor,
+        config.higLightColor,
+        config.contentColor
+    )
+    private val colorStops: List<Float> = listOf(
+        ((1f - intensity - dropOff) / 2f).coerceIn(0f, 1f),
+        ((1f - intensity - 0.001f) / 2f).coerceIn(0f, 1f),
+        ((1f + intensity + 0.001f) / 2f).coerceIn(0f, 1f),
+        ((1f + intensity + dropOff) / 2f).coerceIn(0f, 1f)
+    )
+
+    override fun ContentDrawScope.draw() {
+        drawIntoCanvas {
+            it.withSaveLayer(Rect(0f, 0f, size.width, size.height), paint = cleanPaint) {
+                drawContent()
+                if (visible) {
+                    val (dx, dy) = when (config.direction) {
+                        ShimmerDirection.LeftToRight -> Pair(
+                            offset(-translateWidth, translateWidth, progress),
+                            0f
+                        )
+                        ShimmerDirection.RightToLeft -> Pair(
+                            offset(translateWidth, -translateWidth, progress),
+                            0f
+                        )
+
+                        ShimmerDirection.TopToBottom -> Pair(
+                            0f,
+                            offset(-translateHeight, translateHeight, progress)
+                        )
+
+
+                        ShimmerDirection.BottomToTop -> Pair(
+                            0f,
+                            offset(translateHeight, -translateHeight, progress)
+                        )
+
+                    }
+                    paint.shader?.transform {
+                        reset()
+                        postRotate(config.angle, size.width / 2f, size.height / 2f)
+                        postTranslate(dx, dy)
+                    }
+                    it.drawRect(Rect(0f, 0f, size.width, size.height), paint = paint)
+                }
+            }
+        }
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        val size = Size(width = placeable.width.toFloat(), height = placeable.height.toFloat())
+        updateSize(size)
+        return layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
+
+    private fun updateSize(size: Size) {
+        translateWidth = size.width + angleTan * size.height
+        translateHeight = size.height + angleTan * size.width
+        val toOffset = when (config.direction) {
+            ShimmerDirection.RightToLeft, ShimmerDirection.LeftToRight -> Offset(size.width, 0f)
+            else -> Offset(0f, size.height)
+        }
+        paint.shader = LinearGradientShader(
+            Offset(0f, 0f),
+            toOffset,
+            colors,
+            colorStops
+        )
+    }
+
+    private fun offset(start: Float, end: Float, progress: Float): Float {
+        return start + (end - start) * progress
+    }
+}

--- a/placeholder/src/main/java/com/google/accompanist/placeholder/shimmer/ShimmerConfig.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/shimmer/ShimmerConfig.kt
@@ -1,0 +1,41 @@
+package com.google.accompanist.placeholder.shimmer
+
+import androidx.annotation.FloatRange
+import androidx.compose.ui.graphics.Color
+
+data class ShimmerConfig(
+    /**
+     * indicate the base color for the shimmer
+     */
+    val contentColor: Color = Color.LightGray.copy(alpha = 0.3f),
+    /**
+     * indicate the highlight color for the shimmer
+     */
+    val higLightColor: Color = Color.LightGray.copy(alpha = 0.9f),
+    /**
+     * indicate how quickly the shimmer's gradient drops-off. A larger value causes a sharper drop-off.
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    val dropOff: Float = 0.5f,
+    /**
+     * indicate the intensity of the shimmer. A larger value causes the shimmer to be larger.
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    val intensity: Float = 0.2f,
+    /**
+     * indicate the direction of the shimmer's sweep
+     */
+    val direction: ShimmerDirection = ShimmerDirection.LeftToRight,
+    /**
+     * indicate the tilt angle of the shimmer in degrees
+     */
+    val angle: Float = 20f,
+    /**
+     * indicate how long the shimmering animation takes to do one full sweep.
+     */
+    val duration: Float = 1000f,
+    /**
+     * indicate how long to wait for starting the shimmering animation
+     */
+    val delay: Float = 200f
+)

--- a/placeholder/src/main/java/com/google/accompanist/placeholder/shimmer/ShimmerDirection.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/shimmer/ShimmerDirection.kt
@@ -1,0 +1,8 @@
+package com.google.accompanist.placeholder.shimmer
+
+enum class ShimmerDirection {
+    LeftToRight,
+    TopToBottom,
+    RightToLeft,
+    BottomToTop
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -358,6 +358,15 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".placeholder.PlaceholderSeparateShimmerSample"
+            android:label="@string/placeholder_title_separate_shimmer"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderSeparateShimmerSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderSeparateShimmerSample.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.sample.placeholder
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.res.stringResource
+import coil.compose.rememberImagePainter
+import com.google.accompanist.placeholder.material.placeholder
+import com.google.accompanist.placeholder.shimmer.shimmer
+import com.google.accompanist.sample.AccompanistSampleTheme
+import com.google.accompanist.sample.R
+import com.google.accompanist.sample.randomSampleImageUrl
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import kotlinx.coroutines.delay
+
+/**
+ * Example of skeletal screen animation in one line instead of one element
+ * Facebook-like style:https://github.com/facebook/shimmer-android
+ */
+class PlaceholderSeparateShimmerSample : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AccompanistSampleTheme {
+                Sample()
+            }
+        }
+    }
+}
+
+@Composable
+private fun Sample() {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.placeholder_title_shimmer)) },
+                backgroundColor = MaterialTheme.colors.surface,
+            )
+        },
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // Simulate a fake 2-second 'load'. Ideally this 'refreshing' value would
+        // come from a ViewModel or similar
+        var refreshing by remember { mutableStateOf(false) }
+        LaunchedEffect(refreshing) {
+            if (refreshing) {
+                delay(4000)
+                refreshing = false
+            }
+        }
+
+        SwipeRefresh(
+            state = rememberSwipeRefreshState(isRefreshing = refreshing),
+            onRefresh = { refreshing = true },
+        ) {
+            LazyColumn {
+                if (refreshing.not()) {
+                    item {
+                        ListItem(
+                            painter = rememberVectorPainter(Icons.Default.ArrowDownward),
+                            text = "Pull down"
+                        )
+                    }
+                }
+                items(30) { index ->
+                    ListItem(
+                        painter = rememberImagePainter(randomSampleImageUrl(index)),
+                        text = "Text",
+                        modifier = Modifier.shimmer(refreshing),
+                        childModifier = Modifier.placeholder(
+                            visible = refreshing
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -57,5 +57,5 @@
     <string name="placeholder_title_basics">Placeholder: Basic</string>
     <string name="placeholder_title_fade">Placeholder: Fade</string>
     <string name="placeholder_title_shimmer">Placeholder: Shimmer</string>
-
+    <string name="placeholder_title_separate_shimmer">Placeholder: Separate Shimmer</string>
 </resources>


### PR DESCRIPTION
Skeleton screen effect similar to [facebook open source project](https://github.com/facebook/shimmer-android)
The skeleton screen is usually animated in a line rather than an element,so it is best to separate it from the placeholder

The animation effect is as follows

https://user-images.githubusercontent.com/18047645/132097124-0d4dece6-6c90-4700-8fe0-1dbf4798c958.mp4


https://user-images.githubusercontent.com/18047645/132097129-7520ea64-cbc9-4764-85dd-e52bcc6b9f0d.mp4

