### PR TITLE
Remove swiperefresh's dependency on ui-tooling

### DIFF
--- a/swiperefresh/build.gradle
+++ b/swiperefresh/build.gradle
@@ -83,7 +83,6 @@ android {
 
 dependencies {
     implementation libs.compose.material.material
-    implementation libs.compose.ui.tooling
     implementation libs.compose.ui.util
 
     // ======================


### PR DESCRIPTION
As it is not used and will pull in unnecessary dependencies for consumers.