### PR TITLE
[Navigation Material] Fix Bottom Sheet Fully Expanding

### DIFF
--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
@@ -137,16 +137,19 @@ internal class SheetContentHostTest {
     @Test
     fun testOnSheetShownCalled_onBackStackEntryEnter() = runBlockingTest(testClock) {
         val sheetState = ModalBottomSheetState(ModalBottomSheetValue.Hidden)
-        val backStackEntry = createBackStackEntry(sheetState)
+        val backStackEntryState = mutableStateOf<NavBackStackEntry?>(null)
 
         val shownBackStackEntries = mutableListOf<NavBackStackEntry>()
 
         composeTestRule.setBottomSheetContent(
-            backStackEntry = mutableStateOf(backStackEntry),
+            backStackEntry = backStackEntryState,
             sheetState = sheetState,
             onSheetShown = { entry -> shownBackStackEntries.add(entry) },
             onSheetDismissed = { }
         )
+
+        val backStackEntry = createBackStackEntry(sheetState)
+        backStackEntryState.value = backStackEntry
 
         composeTestRule.runOnIdle {
             assertWithMessage("Sheet is visible")

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
@@ -17,12 +17,15 @@
 package com.google.accompanist.navigation.material
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
@@ -33,6 +36,7 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.testing.TestNavigatorState
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -41,6 +45,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
@@ -49,7 +54,11 @@ import org.junit.runner.RunWith
 
 @LargeTest
 @RunWith(AndroidJUnit4::class)
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalMaterialApi::class, ExperimentalMaterialNavigationApi::class)
+@OptIn(
+    ExperimentalCoroutinesApi::class,
+    ExperimentalMaterialApi::class,
+    ExperimentalMaterialNavigationApi::class
+)
 internal class SheetContentHostTest {
 
     private val testDispatcher = TestCoroutineDispatcher()
@@ -138,7 +147,6 @@ internal class SheetContentHostTest {
     fun testOnSheetShownCalled_onBackStackEntryEnter() = runBlockingTest(testClock) {
         val sheetState = ModalBottomSheetState(ModalBottomSheetValue.Hidden)
         val backStackEntryState = mutableStateOf<NavBackStackEntry?>(null)
-
         val shownBackStackEntries = mutableListOf<NavBackStackEntry>()
 
         composeTestRule.setBottomSheetContent(
@@ -148,12 +156,70 @@ internal class SheetContentHostTest {
             onSheetDismissed = { }
         )
 
-        val backStackEntry = createBackStackEntry(sheetState)
+        val backStackEntry = createBackStackEntry(sheetState) {
+            Box(Modifier.height(50.dp))
+        }
         backStackEntryState.value = backStackEntry
 
         composeTestRule.runOnIdle {
             assertWithMessage("Sheet is visible")
                 .that(sheetState.isVisible).isTrue()
+            assertWithMessage("Back stack entry should be in the shown entries list")
+                .that(shownBackStackEntries)
+                .containsExactly(backStackEntry)
+        }
+    }
+
+    @Test
+    fun testSheetHalfExpanded_onBackStackEntryEnter_shortSheet(): Unit = runBlocking {
+        val sheetState = ModalBottomSheetState(ModalBottomSheetValue.Hidden)
+        val backStackEntryState = mutableStateOf<NavBackStackEntry?>(null)
+        val shownBackStackEntries = mutableListOf<NavBackStackEntry>()
+
+        composeTestRule.setBottomSheetContent(
+            backStackEntry = backStackEntryState,
+            sheetState = sheetState,
+            onSheetShown = { entry -> shownBackStackEntries.add(entry) },
+            onSheetDismissed = { }
+        )
+
+        val backStackEntry = createBackStackEntry(sheetState) {
+            Box(Modifier.height(100.dp))
+        }
+        backStackEntryState.value = backStackEntry
+
+        composeTestRule.runOnIdle {
+            assertWithMessage("Sheet is fully expanded")
+                .that(sheetState.currentValue)
+                .isEqualTo(ModalBottomSheetValue.Expanded)
+            assertWithMessage("Back stack entry should be in the shown entries list")
+                .that(shownBackStackEntries)
+                .containsExactly(backStackEntry)
+        }
+    }
+
+    @Test
+    fun testSheetHalfExpanded_onBackStackEntryEnter_tallSheet(): Unit = runBlocking {
+        val sheetState = ModalBottomSheetState(ModalBottomSheetValue.Hidden)
+        val backStackEntryState = mutableStateOf<NavBackStackEntry?>(null)
+        val shownBackStackEntries = mutableListOf<NavBackStackEntry>()
+
+        composeTestRule.setBottomSheetContent(
+            backStackEntry = backStackEntryState,
+            sheetState = sheetState,
+            onSheetShown = { entry -> shownBackStackEntries.add(entry) },
+            onSheetDismissed = { }
+        )
+
+        val backStackEntry = createBackStackEntry(sheetState) {
+            Box(Modifier.fillMaxSize())
+        }
+        backStackEntryState.value = backStackEntry
+
+        composeTestRule.runOnIdle {
+            assertWithMessage("Tall sheet is half-expanded")
+                .that(sheetState.currentValue)
+                .isEqualTo(ModalBottomSheetValue.HalfExpanded)
             assertWithMessage("Back stack entry should be in the shown entries list")
                 .that(shownBackStackEntries)
                 .containsExactly(backStackEntry)
@@ -180,19 +246,26 @@ internal class SheetContentHostTest {
                     )
                 },
                 sheetState = sheetState,
-                content = { Box(Modifier.fillMaxSize().testTag(bodyContentTag)) }
+                content = {
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .testTag(bodyContentTag)
+                    )
+                }
             )
         }
     }
 
-    private fun createBackStackEntry(sheetState: ModalBottomSheetState): NavBackStackEntry {
+    private fun createBackStackEntry(
+        sheetState: ModalBottomSheetState,
+        sheetContent: @Composable ColumnScope.(NavBackStackEntry) -> Unit = { Text("Fake Sheet Content") }
+    ): NavBackStackEntry {
         val navigatorState = TestNavigatorState()
         val navigator = BottomSheetNavigator(sheetState)
         navigator.onAttach(navigatorState)
 
-        val destination = BottomSheetNavigator.Destination(navigator) {
-            Text("Fake Sheet Content")
-        }
+        val destination = BottomSheetNavigator.Destination(navigator, sheetContent)
         val backStackEntry = navigatorState.createBackStackEntry(destination, null)
         navigator.navigate(listOf(backStackEntry), null, null)
         return backStackEntry


### PR DESCRIPTION
Kinda similar to #741 - we were calling `show` too early. That meant that the `SwipeableState`/`ModalBottomSheetState`'s `anchors` wouldn't have been calculated properly yet. By default, a sheet will have two anchors: `Hidden` and `Expanded`. If `sheetHeight > containerHeight / 2`, the sheet should have a `HalfExpanded` state. For that, `ModalBottomSheetLayout` needs to know the sheet's height, making it two-pass. The effect we use to `show` the sheet got called on the first pass though, when the sheet content is composed to measure it, but the anchors didn't have the correct sheet height yet, causing the sheet to fully expand despite it being tall enough to have a `HalfExpanded` state.

This isn't a nice solution but in agreement with Matvei, it seems to be the most reasonable fix for the moment.