### PR TITLE
[Navigation Material] Animate Bottom Sheet Dismissal

### DIFF
--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/SheetContentHost.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/SheetContentHost.kt
@@ -108,7 +108,7 @@ internal fun SheetContentHost(
                 scope.launch {
                     hideCalled = true
                     try {
-                        sheetState.internalHide()
+                        sheetState.hide()
                     } finally {
                         hideCalled = false
                     }
@@ -133,10 +133,4 @@ private fun EmptySheet() {
     // If there are no destinations on the back stack, we need to add something to work
     // around this
     Box(Modifier.height(1.dp))
-}
-
-// We have the same issue when we are hiding the sheet, but snapTo works better
-@OptIn(ExperimentalMaterialApi::class)
-private suspend fun ModalBottomSheetState.internalHide() {
-    snapTo(ModalBottomSheetValue.Hidden)
 }


### PR DESCRIPTION
We're now using ModalBottomSheetState#hide instead of snapTo which will give us an animation when popping the back stack/dismissing the sheet!

Fixes: #724