### PR TITLE
[SwipeRefresh] Fix zero elevation when the indicator is bouncing back

### DIFF
--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
@@ -115,11 +115,6 @@ fun SwipeRefreshIndicator(
     largeIndication: Boolean = false,
     elevation: Dp = 6.dp,
 ) {
-    val adjustedElevation = when {
-        state.isRefreshing -> elevation
-        state.indicatorOffset > 0.5f -> elevation
-        else -> 0.dp
-    }
     val sizes = if (largeIndication) LargeSizes else DefaultSizes
 
     val indicatorRefreshTrigger = with(LocalDensity.current) { refreshTriggerDistance.toPx() }
@@ -135,14 +130,12 @@ fun SwipeRefreshIndicator(
 
     var offset by remember { mutableStateOf(0f) }
 
-    // If the user is currently swiping, we use the 'slingshot' offset directly
     if (state.isSwipeInProgress) {
+        // If the user is currently swiping, we use the 'slingshot' offset directly
         offset = slingshot.offset.toFloat()
-    }
-
-    LaunchedEffect(state.isSwipeInProgress, state.isRefreshing) {
+    } else {
         // If there's no swipe currently in progress, animate to the correct resting position
-        if (!state.isSwipeInProgress) {
+        LaunchedEffect(state.isRefreshing) {
             animate(
                 initialValue = offset,
                 targetValue = when {
@@ -153,6 +146,12 @@ fun SwipeRefreshIndicator(
                 offset = value
             }
         }
+    }
+
+    val adjustedElevation = when {
+        state.isRefreshing -> elevation
+        offset > 0.5f -> elevation
+        else -> 0.dp
     }
 
     Surface(


### PR DESCRIPTION
Fix the bug that the indicator's elevation is set to 0 when bouncing back after swipe or refresh.
Also slightly simplify the logic in `SwipeRefreshIndicator`.