### PR TITLE
Remove markdown filter from pull request builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
Removes the `**.md` filter for pull-request PRs.

PRs can't be merged until all required checks pass, but a change to only documentation won't cause any checks to run, leading to a fun catch-22.

The simplest solution seems to be just removing this filter from pull-request PRs.