### PR TITLE
Accept a lamda to run after requesting permissions

### DIFF
--- a/permissions/src/main/java/com/google/accompanist/permissions/MultiplePermissionsState.kt
+++ b/permissions/src/main/java/com/google/accompanist/permissions/MultiplePermissionsState.kt
@@ -26,13 +26,16 @@ import androidx.compose.runtime.Stable
  * [documentation](https://developer.android.com/training/permissions/requesting#workflow_for_requesting_permissions).
  *
  * @param permissions the permissions to control and observe.
+ * @param onResult an action to run with the results of the permission request after calling
+ *      [MultiplePermissionsState.launchMultiplePermissionRequest].
  */
 @ExperimentalPermissionsApi
 @Composable
 fun rememberMultiplePermissionsState(
-    permissions: List<String>
+    permissions: List<String>,
+    onResult: (Map<String, Boolean>) -> Unit = {}
 ): MultiplePermissionsState {
-    return rememberMutableMultiplePermissionsState(permissions)
+    return rememberMutableMultiplePermissionsState(permissions, onResult)
 }
 
 /**

--- a/permissions/src/main/java/com/google/accompanist/permissions/MutableMultiplePermissionsState.kt
+++ b/permissions/src/main/java/com/google/accompanist/permissions/MutableMultiplePermissionsState.kt
@@ -37,11 +37,14 @@ import androidx.compose.ui.platform.LocalContext
  * [documentation](https://developer.android.com/training/permissions/requesting#workflow_for_requesting_permissions).
  *
  * @param permissions the permissions to control and observe.
+ * @param onResult an action to run with the results of the permission request after calling
+ *      [MultiplePermissionsState.launchMultiplePermissionRequest].
  */
 @ExperimentalPermissionsApi
 @Composable
 internal fun rememberMutableMultiplePermissionsState(
-    permissions: List<String>
+    permissions: List<String>,
+    onResult: (Map<String, Boolean>) -> Unit = {}
 ): MultiplePermissionsState {
     // Create mutable permissions that can be requested individually
     val mutablePermissions = rememberMutablePermissionsState(permissions)
@@ -58,6 +61,7 @@ internal fun rememberMutableMultiplePermissionsState(
     ) { permissionsResult ->
         multiplePermissionsState.updatePermissionsStatus(permissionsResult)
         multiplePermissionsState.permissionRequested = true
+        onResult(permissionsResult)
     }
     DisposableEffect(multiplePermissionsState, launcher) {
         multiplePermissionsState.launcher = launcher

--- a/permissions/src/main/java/com/google/accompanist/permissions/MutablePermissionState.kt
+++ b/permissions/src/main/java/com/google/accompanist/permissions/MutablePermissionState.kt
@@ -37,11 +37,14 @@ import androidx.compose.ui.platform.LocalContext
  * [documentation](https://developer.android.com/training/permissions/requesting#workflow_for_requesting_permissions).
  *
  * @param permission the permission to control and observe.
+ * @param onResult an action to run with the result of the permission request after calling
+ *      [PermissionState.launchPermissionRequest].
  */
 @ExperimentalPermissionsApi
 @Composable
 internal fun rememberMutablePermissionState(
-    permission: String
+    permission: String,
+    onResult: (Boolean) -> Unit = {}
 ): MutablePermissionState {
     val context = LocalContext.current
     val permissionState = remember(permission) {
@@ -55,6 +58,7 @@ internal fun rememberMutablePermissionState(
     val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
         permissionState.hasPermission = it
         permissionState.permissionRequested = true
+        onResult(it)
     }
     DisposableEffect(permissionState, launcher) {
         permissionState.launcher = launcher

--- a/permissions/src/main/java/com/google/accompanist/permissions/PermissionState.kt
+++ b/permissions/src/main/java/com/google/accompanist/permissions/PermissionState.kt
@@ -26,13 +26,16 @@ import androidx.compose.runtime.Stable
  * [documentation](https://developer.android.com/training/permissions/requesting#workflow_for_requesting_permissions).
  *
  * @param permission the permission to control and observe.
+ * @param onResult an action to run with the result of the permission request after calling
+ *      [PermissionState.launchPermissionRequest].
  */
 @ExperimentalPermissionsApi
 @Composable
 fun rememberPermissionState(
-    permission: String
+    permission: String,
+    onResult: (Boolean) -> Unit = {}
 ): PermissionState {
-    return rememberMutablePermissionState(permission)
+    return rememberMutablePermissionState(permission, onResult)
 }
 
 /**


### PR DESCRIPTION
Callers of rememberPermissionState can provide a lamda to run with the
result after using launchPermissionRequest. Similar addition for
rememberMultiplePermissionsState and launchMultiplePermissionsRequest.