### PR TITLE
Update to Navigation 2.4.0-beta01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ okhttp = "3.12.13"
 coil = "1.3.2"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.4.0-alpha10"
+androidxnavigation = "2.4.0-beta01"
 
 [libraries]
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }


### PR DESCRIPTION
Navigation changed its API surface between alpha10 and beta01 in an incompatible way. By moving to beta01, we can now use the new stable API surface.

Fixes #817