### PR TITLE
Update to Navigation 2.4.0-beta01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ okhttp = "3.12.13"
 coil = "1.3.2"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.4.0-alpha10"
+androidxnavigation = "2.4.0-beta01"
 
 [libraries]
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }


### PR DESCRIPTION
Update the version of Navigation specifically in the compose-1.0 branch to ensure it remains compatible with future versions of Navigation.

Fixes #817