### PR TITLE
Fix the edge of Ripple in BottomNavigation

### DIFF
--- a/insets-ui/src/main/java/com/google/accompanist/insets/ui/BottomNavigation.kt
+++ b/insets-ui/src/main/java/com/google/accompanist/insets/ui/BottomNavigation.kt
@@ -63,8 +63,8 @@ fun BottomNavigation(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(BottomNavigationHeight + contentPadding.calculateBottomPadding())
                 .padding(contentPadding)
+                .height(BottomNavigationHeight)
                 .selectableGroup(),
             horizontalArrangement = Arrangement.SpaceBetween,
             content = content,

--- a/insets-ui/src/main/java/com/google/accompanist/insets/ui/BottomNavigation.kt
+++ b/insets-ui/src/main/java/com/google/accompanist/insets/ui/BottomNavigation.kt
@@ -16,9 +16,14 @@
 
 package com.google.accompanist.insets.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationDefaults
 import androidx.compose.material.MaterialTheme
@@ -47,19 +52,28 @@ fun BottomNavigation(
     backgroundColor: Color = MaterialTheme.colors.primarySurface,
     contentColor: Color = contentColorFor(backgroundColor),
     elevation: Dp = BottomNavigationDefaults.Elevation,
-    content: @Composable RowScope.() -> Unit
+    content: @Composable RowScope.() -> Unit,
 ) {
     Surface(
         color = backgroundColor,
+        contentColor = contentColor,
         elevation = elevation,
-        modifier = modifier
+        modifier = modifier,
     ) {
-        BottomNavigation(
-            backgroundColor = Color.Transparent,
-            contentColor = contentColor,
-            elevation = 0.dp,
-            modifier = Modifier.padding(contentPadding),
-            content = content
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(BottomNavigationHeight + contentPadding.calculateBottomPadding())
+                .padding(contentPadding)
+                .selectableGroup(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            content = content,
         )
     }
 }
+
+/**
+ * Copied from [androidx.compose.material.BottomNavigationHeight]
+ * Height of a [BottomNavigation] component
+ */
+private val BottomNavigationHeight = 56.dp


### PR DESCRIPTION
Let Ripple pass through the navigation bar in `Navigation Gestures (left and right)` mode.
This will be consistent with the effect of the status bar.

### Before and after

<img src="https://user-images.githubusercontent.com/14316223/139252729-c9160d63-ba7f-4d33-a27a-17b655cd458d.png" width=40% height=40%>   <img src="https://user-images.githubusercontent.com/14316223/139252714-1bde765e-c5f0-41cb-9921-1ffdde1e0cc1.png" width=40% height=40%>

