### PR TITLE
Wrap the contents of the BottomSheet composable into a Column composable

### DIFF
--- a/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
@@ -101,11 +101,15 @@ private fun HomeScreen(showSheet: () -> Unit, showFeed: () -> Unit) {
 
 @Composable
 private fun BottomSheet(showFeed: () -> Unit, showAnotherSheet: () -> Unit, arg: String) {
-    Text("Sheet with arg: $arg")
-    Button(onClick = showFeed) {
-        Text("Click me to navigate!")
-    }
-    Button(onClick = showAnotherSheet) {
-        Text("Click me to show another sheet!")
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Sheet with arg: $arg")
+        Button(onClick = showFeed) {
+            Text("Click me to navigate!")
+        }
+        Button(onClick = showAnotherSheet) {
+            Text("Click me to show another sheet!")
+        }
     }
 }


### PR DESCRIPTION
Wrapped the contents of the `BottomSheet` composable into a `Column` composable. The lack of a parent composable like `Row` or `Column` causes the contents in the `BottomSheet` function to be stacked up on top of each other.