### PR TITLE
Fix set status bar icons on API 30

### DIFF
--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 /**
  * A class which provides easy-to-use utilities for updating the System UI bar
@@ -173,8 +174,10 @@ fun rememberSystemUiController(): SystemUiController {
 internal class AndroidSystemUiController(
     private val view: View
 ) : SystemUiController {
-    private val window = view.context.findWindow()
-    private val windowInsetsController = ViewCompat.getWindowInsetsController(view)!!
+    private val window = requireNotNull(view.context.findWindow()) {
+        "The Compose View must be hosted in an Activity with a Window!"
+    }
+    private val windowInsetsController = WindowInsetsControllerCompat(window, view)
 
     override fun setStatusBarColor(
         color: Color,
@@ -183,7 +186,7 @@ internal class AndroidSystemUiController(
     ) {
         statusBarDarkContentEnabled = darkIcons
 
-        window?.statusBarColor = when {
+        window.statusBarColor = when {
             darkIcons && !windowInsetsController.isAppearanceLightStatusBars -> {
                 // If we're set to use dark icons, but our windowInsetsController call didn't
                 // succeed (usually due to API level), we instead transform the color to maintain
@@ -203,7 +206,7 @@ internal class AndroidSystemUiController(
         navigationBarDarkContentEnabled = darkIcons
         isNavigationBarContrastEnforced = navigationBarContrastEnforced
 
-        window?.navigationBarColor = when {
+        window.navigationBarColor = when {
             darkIcons && !windowInsetsController.isAppearanceLightNavigationBars -> {
                 // If we're set to use dark icons, but our windowInsetsController call didn't
                 // succeed (usually due to API level), we instead transform the color to maintain
@@ -253,10 +256,10 @@ internal class AndroidSystemUiController(
         }
 
     override var isNavigationBarContrastEnforced: Boolean
-        get() = Build.VERSION.SDK_INT >= 29 && window?.isNavigationBarContrastEnforced == true
+        get() = Build.VERSION.SDK_INT >= 29 && window.isNavigationBarContrastEnforced
         set(value) {
             if (Build.VERSION.SDK_INT >= 29) {
-                window?.isNavigationBarContrastEnforced = value
+                window.isNavigationBarContrastEnforced = value
             }
         }
 


### PR DESCRIPTION
This fixes #881 

The issue occurs with the `Activity`'s theme contains `android:windowLightStatusBars="true"`. In other words, the status bars icons are dark by default.

There was a bug in `androidx.core` in this case that prevented showing the light icons on API 30: https://issuetracker.google.com/issues/180881870.

This was marked as fixed, and released with `1.7.0` (which `accompanist` is using), but there is a follow-up issue: Depending on how the `WindowInsetsControllerCompat` is acquired, the workaround fixing the issue on API 30 may or may not be used: https://issuetracker.google.com/issues/207401542

In our case, we were using a codepath that doesn't have the workaround, meaning that we are still encountering the "fixed" issue (#881). By switching from `ViewCompat. getWindowInsetsController` to the direct constructor of `WindowInsetsControllerCompat`, we will ensure we still get the workaround in the meantime while the upstream issue is fixed.