### PR TITLE
Fix destination animations being ignored

### DIFF
--- a/navigation-animation/api/current.api
+++ b/navigation-animation/api/current.api
@@ -7,7 +7,7 @@ package com.google.accompanist.navigation.animation {
   }
 
   @androidx.compose.animation.ExperimentalAnimationApi @androidx.navigation.NavDestination.ClassType(Composable::class) public static final class AnimatedComposeNavigator.Destination extends androidx.navigation.NavDestination {
-    ctor public AnimatedComposeNavigator.Destination(com.google.accompanist.navigation.animation.AnimatedComposeNavigator navigator, kotlin.jvm.functions.Function2<? super androidx.compose.animation.AnimatedVisibilityScope,? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.AnimatedContentScope<androidx.navigation.NavBackStackEntry>,? extends androidx.compose.animation.EnterTransition>? enterTransition, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.AnimatedContentScope<androidx.navigation.NavBackStackEntry>,? extends androidx.compose.animation.ExitTransition>? exitTransition, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.AnimatedContentScope<androidx.navigation.NavBackStackEntry>,? extends androidx.compose.animation.EnterTransition>? popEnterTransition, optional kotlin.jvm.functions.Function1<? super androidx.compose.animation.AnimatedContentScope<androidx.navigation.NavBackStackEntry>,? extends androidx.compose.animation.ExitTransition>? popExitTransition);
+    ctor public AnimatedComposeNavigator.Destination(com.google.accompanist.navigation.animation.AnimatedComposeNavigator navigator, kotlin.jvm.functions.Function2<? super androidx.compose.animation.AnimatedVisibilityScope,? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
   }
 
   public final class AnimatedNavHostKt {

--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedComposeNavigator.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedComposeNavigator.kt
@@ -16,10 +16,7 @@
 
 package com.google.accompanist.navigation.animation
 
-import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -73,15 +70,7 @@ public class AnimatedComposeNavigator : Navigator<AnimatedComposeNavigator.Desti
     @NavDestination.ClassType(Composable::class)
     public class Destination(
         navigator: AnimatedComposeNavigator,
-        internal val content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit,
-        internal var enterTransition:
-            (AnimatedContentScope<NavBackStackEntry>.() -> EnterTransition?)? = null,
-        internal var exitTransition:
-            (AnimatedContentScope<NavBackStackEntry>.() -> ExitTransition?)? = null,
-        internal var popEnterTransition:
-            (AnimatedContentScope<NavBackStackEntry>.() -> EnterTransition?)? = enterTransition,
-        internal var popExitTransition:
-            (AnimatedContentScope<NavBackStackEntry>.() -> ExitTransition?)? = exitTransition
+        internal val content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
     ) : NavDestination(navigator)
 
     internal companion object {

--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
@@ -60,11 +60,7 @@ public fun NavGraphBuilder.composable(
     addDestination(
         AnimatedComposeNavigator.Destination(
             provider[AnimatedComposeNavigator::class],
-            content,
-            enterTransition,
-            exitTransition,
-            popEnterTransition,
-            popExitTransition
+            content
         ).apply {
             this.route = route
             arguments.forEach { (argumentName, argument) ->

--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
@@ -73,6 +73,10 @@ public fun NavGraphBuilder.composable(
             deepLinks.forEach { deepLink ->
                 addDeepLink(deepLink)
             }
+            enterTransition?.let { enterTransitions[route] = enterTransition }
+            exitTransition?.let { exitTransitions[route] = exitTransition }
+            popEnterTransition?.let { popEnterTransitions[route] = popEnterTransition }
+            popExitTransition?.let { popExitTransitions[route] = popExitTransition }
         }
     )
 }


### PR DESCRIPTION
Adding destination custom animations to the animation maps to ensure
they are considered when selecting the final animation.

Fixes #882