### PR TITLE
Update PagerState.currentPage when it is changed in LazyListState

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -254,6 +254,13 @@ internal fun Pager(
             .drop(1)
             .collect { state.onScrollFinished() }
     }
+    LaunchedEffect(state) {
+        snapshotFlow { state.currentLayoutPageInfo }
+            // we want to react on the currentLayoutPageInfo changes happened not because of the
+            // scroll. for example the current page could change because the items were reordered.
+            .filter { !state.isScrollInProgress }
+            .collect { state.updateCurrentPageBasedOnLazyListState() }
+    }
 
     val pagerScope = remember(state) { PagerScopeImpl(state) }
 

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -78,7 +78,7 @@ class PagerState(
 
     private var _currentPage by mutableStateOf(currentPage)
 
-    private val currentLayoutPageInfo: LazyListItemInfo?
+    internal val currentLayoutPageInfo: LazyListItemInfo?
         get() = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull { it.offset <= 0 }
 
     private val currentLayoutPageOffset: Float
@@ -278,9 +278,13 @@ class PagerState(
         }
     }
 
-    internal fun onScrollFinished() {
+    internal fun updateCurrentPageBasedOnLazyListState() {
         // Then update the current page to our layout page
         currentPage = currentLayoutPageInfo?.index ?: 0
+    }
+
+    internal fun onScrollFinished() {
+        updateCurrentPageBasedOnLazyListState()
         // Clear the animation target page
         animationTargetPage = null
     }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
@@ -113,10 +113,12 @@ abstract class BaseHorizontalPagerTest(
     }
 
     @Composable
-    override fun PagerContent(
+    override fun AbstractPagerContent(
         count: () -> Int,
         pagerState: PagerState,
-        observeStateInContent: Boolean
+        observeStateInContent: Boolean,
+        pageToItem: (Int) -> String,
+        useKeys: Boolean,
     ) {
         CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
             applierScope = rememberCoroutineScope()
@@ -132,17 +134,24 @@ abstract class BaseHorizontalPagerTest(
                     itemSpacing = itemSpacingDp.dp,
                     reverseLayout = reverseLayout,
                     contentPadding = contentPadding,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
+                    key = if (useKeys) {
+                        { pageToItem(it) }
+                    } else {
+                        null
+                    }
                 ) { page ->
+                    val item = pageToItem(page)
+                    println("asdasd item=$item page=$page")
                     Box(
                         modifier = Modifier
                             .fillMaxWidth(itemWidthFraction)
                             .aspectRatio(1f)
                             .background(randomColor())
-                            .testTag(page.toString())
+                            .testTag(item)
                     ) {
                         BasicText(
-                            text = page.toString(),
+                            text = item,
                             modifier = Modifier.align(Alignment.Center)
                         )
                     }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
@@ -142,7 +142,6 @@ abstract class BaseHorizontalPagerTest(
                     }
                 ) { page ->
                     val item = pageToItem(page)
-                    println("asdasd item=$item page=$page")
                     Box(
                         modifier = Modifier
                             .fillMaxWidth(itemWidthFraction)

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
@@ -93,10 +93,12 @@ abstract class BaseVerticalPagerTest(
     }
 
     @Composable
-    override fun PagerContent(
+    override fun AbstractPagerContent(
         count: () -> Int,
         pagerState: PagerState,
-        observeStateInContent: Boolean
+        observeStateInContent: Boolean,
+        pageToItem: (Int) -> String,
+        useKeys: Boolean,
     ) {
         CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             applierScope = rememberCoroutineScope()
@@ -112,16 +114,22 @@ abstract class BaseVerticalPagerTest(
                     itemSpacing = itemSpacingDp.dp,
                     reverseLayout = reverseLayout,
                     contentPadding = contentPadding,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
+                    key = if (useKeys) {
+                        { pageToItem(it) }
+                    } else {
+                        null
+                    }
                 ) { page ->
+                    val item = pageToItem(page)
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
                             .background(randomColor())
-                            .testTag(page.toString())
+                            .testTag(item)
                     ) {
                         BasicText(
-                            text = page.toString(),
+                            text = item,
                             modifier = Modifier.align(Alignment.Center)
                         )
                     }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -418,11 +418,9 @@ abstract class PagerTest {
         composeTestRule.runOnIdle {
             assertThat(pagerState!!.currentPage).isEqualTo(0)
             list = listOf("1", "0", "2")
-            println("asdasd change list")
         }
 
         composeTestRule.runOnIdle {
-            println("asdasd assert page")
             assertThat(pagerState!!.currentPage).isEqualTo(1)
         }
     }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -18,7 +18,9 @@ package com.google.accompanist.pager
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MonotonicFrameClock
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -353,7 +355,6 @@ abstract class PagerTest {
             PagerContent(
                 count = { 10 },
                 pagerState = rememberPagerState().also { pagerState = it },
-                observeStateInContent = false
             )
         }
 
@@ -398,6 +399,32 @@ abstract class PagerTest {
             .swipeAcrossCenter(distancePercentage = MediumSwipeDistance)
         // ...and assert that we now laid out from page 0
         assertPagerLayout(0, pagerState.pageCount)
+    }
+
+    @Test
+    fun whenTheCurrentPageChangesInternallyOurStateIsUpdated() {
+        var list by mutableStateOf(listOf("0", "1", "2"))
+        var pagerState: PagerState? = null
+
+        composeTestRule.setContent {
+            PagerContent(
+                count = { list.size },
+                pagerState = rememberPagerState().also { pagerState = it },
+                pageToItem = { list[it] },
+                useKeys = true
+            )
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(pagerState!!.currentPage).isEqualTo(0)
+            list = listOf("1", "0", "2")
+            println("asdasd change list")
+        }
+
+        composeTestRule.runOnIdle {
+            println("asdasd assert page")
+            assertThat(pagerState!!.currentPage).isEqualTo(1)
+        }
     }
 
     /**
@@ -458,17 +485,37 @@ abstract class PagerTest {
             PagerContent(
                 count = count,
                 pagerState = state,
-                observeStateInContent = observeStateInContent
+                observeStateInContent = observeStateInContent,
             )
         }
         return state
     }
 
+    // we can't have default values on an abstract composable function params
     @Composable
-    protected abstract fun PagerContent(
+    private fun PagerContent(
+        count: () -> Int,
+        pagerState: PagerState,
+        observeStateInContent: Boolean = false,
+        pageToItem: (Int) -> String = { it.toString() },
+        useKeys: Boolean = false,
+    ) {
+        AbstractPagerContent(
+            count = count,
+            pagerState = pagerState,
+            observeStateInContent = observeStateInContent,
+            pageToItem = { pageToItem(it) },
+            useKeys = useKeys
+        )
+    }
+
+    @Composable
+    protected abstract fun AbstractPagerContent(
         count: () -> Int,
         pagerState: PagerState,
         observeStateInContent: Boolean,
+        pageToItem: (Int) -> String,
+        useKeys: Boolean
     )
 }
 


### PR DESCRIPTION
It could happen for example if the items were reordered.

Fixes #808