### PR TITLE
Pager Indicator Bug

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
@@ -50,7 +50,7 @@ fun Modifier.pagerTabIndicatorOffset(
     val indicatorWidth: Dp
 
     val currentTab = tabPositions[minOf(tabPositions.lastIndex, pagerState.currentPage)]
-    val targetPage = pagerState.targetPage
+    val targetPage = pagerState.pendingPage
     val targetTab = tabPositions.getOrNull(targetPage)
 
     if (targetTab != null) {

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -162,6 +162,27 @@ class PagerState(
                 else -> (currentPage + 1).coerceAtMost(pageCount - 1)
             }
 
+    /**
+     * The pending target page for any on-going animations or scrolls by the user.
+     * The difference between [pendingPage] and [targetPage] is that [targetPage] detect the
+     * page change when the offset is more than 50%, on the other hand [pendingPage] detect the
+     * page change when the offset is different than zero.
+     * Returns the current page if a scroll or animation is not currently in progress.
+     */
+    val pendingPage: Int
+        get() = animationTargetPage
+            ?: flingAnimationTarget?.invoke()
+            ?: when {
+                // If a scroll isn't in progress, return the current page
+                !isScrollInProgress -> currentPage
+                // If the offset is lower than zero, guess the previous page
+                currentPageOffset < 0f -> (currentPage - 1).coerceAtLeast(0)
+                // If the offset is higher than zero, guess the next page
+                currentPageOffset > 0f -> (currentPage + 1).coerceAtMost(pageCount - 1)
+                // If the offset is 0f (or very close), return the current page
+                else -> currentPage
+            }
+
     @Deprecated(
         "Replaced with animateScrollToPage(page, pageOffset)",
         ReplaceWith("animateScrollToPage(page = page, pageOffset = pageOffset)")


### PR DESCRIPTION
## [pager] Adding "pendingPage" attribute.

### Description

The pending target page for any on-going animations or scrolls by the user.
The difference between [pendingPage] and [targetPage] is that [targetPage] detect the
page change when the offset is more than 50%, on the other hand [pendingPage] detect the
page change when the offset is different than zero.
Returns the current page if a scroll or animation is not currently in progress.
    
## [pager-indicators] "targetPage" was replaced by "pendingPage"

### Description

In somes configurations, targetPage dont has the expected value. This cause some bugs in tab indicator.

| BUG | FIX |
| :---: | :---: |
![bug](https://user-images.githubusercontent.com/50251532/148661156-2d5fa675-4aef-4ae5-b187-db23d0d60da9.gif) | ![fix](https://user-images.githubusercontent.com/50251532/148661155-6c3c5096-3647-4cd3-a1e0-1ff277ba571a.gif) |  

