### PR TITLE
[material-navigation] Backdrop Navigation

### DIFF
--- a/docs/navigation-material.md
+++ b/docs/navigation-material.md
@@ -58,6 +58,53 @@ This features composable bottom sheet destinations.
     }
     ```
 
+### Backdrop Destinations
+
+1. Create a `BackdropNavigator` and add it to the `NavController`:
+
+    ```kotlin
+    @Composable
+    fun MyApp() {
+        val backdropNavigator= rememberBackdropNavigator()
+        val navController = rememberNavController(backdropNavigator)
+    }
+    ```
+
+2. Wrap your `NavHost` in the `BackdropScaffold` composable that accepts a `BackdropScaffoldNavigator`.
+
+    ```kotlin
+    @Composable
+    fun MyApp() {
+        val backdropNavigator= rememberBackdropNavigator()
+        val navController = rememberNavController(backdropNavigator)
+        BackdropScaffold(bottomSheetNavigator) {
+            NavHost(navController, Destinations.Home) {
+               // We'll define our graph here in a bit!
+            }
+        }
+    }
+    ```
+
+3. Register a bottom sheet destination
+
+    ```kotlin
+    @Composable
+    fun MyApp() {
+        val bottomSheetNavigator = rememberBottomSheetNavigator()
+        val navController = rememberNavController(bottomSheetNavigator)
+        ModalBottomSheetLayout(bottomSheetNavigator) {
+            NavHost(navController, Destinations.Home) {
+               composable(route = "home") {
+                   ...
+               }
+               backdrop(route = "backdrop") {
+                   Text("This is a cool backdrop back layer!")
+               }
+            }
+        }
+    }
+    ```
+
 For more examples, refer to the [samples](https://github.com/google/accompanist/tree/main/sample/src/main/java/com/google/accompanist/sample/navigation/material).
 
 ## Download

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/Backdrop.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/Backdrop.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.material
+
+import androidx.compose.material.BackdropScaffoldDefaults
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.SnackbarHost
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+
+
+
+@ExperimentalMaterialNavigationApi
+@OptIn(ExperimentalMaterialApi::class)
+@Composable public fun BackdropScaffold(
+    backdropNavigator: BackdropNavigator,
+    appBar: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    gesturesEnabled: Boolean = true,
+    peekHeight: Dp = BackdropScaffoldDefaults.PeekHeight,
+    headerHeight: Dp = BackdropScaffoldDefaults.HeaderHeight,
+    persistentAppBar: Boolean = true,
+    stickyFrontLayer: Boolean = true,
+    backLayerBackgroundColor: Color = MaterialTheme.colors.primary,
+    backLayerContentColor: Color = contentColorFor(backLayerBackgroundColor),
+    frontLayerShape: Shape = BackdropScaffoldDefaults.frontLayerShape,
+    frontLayerElevation: Dp = BackdropScaffoldDefaults.FrontLayerElevation,
+    frontLayerBackgroundColor: Color = MaterialTheme.colors.surface,
+    frontLayerContentColor: Color = contentColorFor(frontLayerBackgroundColor),
+    frontLayerScrimColor: Color = BackdropScaffoldDefaults.frontLayerScrimColor,
+    snackbarHost: @Composable (SnackbarHostState) -> Unit = { SnackbarHost(it) },
+    frontLayerContent: @Composable () -> Unit,
+) {
+    androidx.compose.material.BackdropScaffold(
+        appBar,
+        backdropNavigator.backLayerContent,
+        frontLayerContent,
+        modifier,
+        backdropNavigator.backdropScaffoldState,
+        gesturesEnabled,
+        peekHeight,
+        headerHeight,
+        persistentAppBar,
+        stickyFrontLayer,
+        backLayerBackgroundColor,
+        backLayerContentColor,
+        frontLayerShape,
+        frontLayerElevation,
+        frontLayerBackgroundColor,
+        frontLayerContentColor,
+        frontLayerScrimColor,
+        snackbarHost,
+    )
+}
+

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/Backdrop.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/Backdrop.kt
@@ -16,6 +16,7 @@
 
 package com.google.accompanist.navigation.material
 
+import androidx.compose.material.BackdropScaffold
 import androidx.compose.material.BackdropScaffoldDefaults
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
@@ -29,10 +30,16 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
 
 
-
+/**
+ * Helper function to create a [BackdropScaffold] from a [BackdropNavigator].
+ *
+ * @see [BackdropScaffold]
+ *
+ */
 @ExperimentalMaterialNavigationApi
 @OptIn(ExperimentalMaterialApi::class)
-@Composable public fun BackdropScaffold(
+@Composable
+public fun BackdropScaffold(
     backdropNavigator: BackdropNavigator,
     appBar: @Composable () -> Unit,
     modifier: Modifier = Modifier,
@@ -51,7 +58,7 @@ import androidx.compose.ui.unit.Dp
     snackbarHost: @Composable (SnackbarHostState) -> Unit = { SnackbarHost(it) },
     frontLayerContent: @Composable () -> Unit,
 ) {
-    androidx.compose.material.BackdropScaffold(
+    BackdropScaffold(
         appBar,
         backdropNavigator.backLayerContent,
         frontLayerContent,

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BackdropContentHost.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BackdropContentHost.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.material
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.BackdropScaffoldState
+import androidx.compose.material.BackdropValue
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.compose.LocalOwnersProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Hosts a [BottomSheetNavigator.Destination]'s [NavBackStackEntry] and its
+ * [BottomSheetNavigator.Destination.content] and provides a [onSheetDismissed] callback. It also
+ * shows and hides the [ModalBottomSheetLayout] through the [sheetState] when the sheet content
+ * enters or leaves the composition.
+ *
+ * @param columnHost The [ColumnScope] the sheet content is hosted in, typically the instance
+ * that is provided by [ModalBottomSheetLayout]
+ * @param backStackEntry The [NavBackStackEntry] holding the [BottomSheetNavigator.Destination],
+ * or null if there is no [NavBackStackEntry]
+ * @param sheetState The [ModalBottomSheetState] used to observe and control the sheet visibility
+ * @param onSheetDismissed Callback when the sheet has been dismissed. Typically, you'll want to
+ * pop the back stack here.
+ */
+@ExperimentalMaterialNavigationApi
+@OptIn(ExperimentalMaterialApi::class, ExperimentalCoroutinesApi::class)
+@Composable
+internal fun BackdropContentHost(
+    backStackEntry: NavBackStackEntry?,
+    backdropScaffoldState: BackdropScaffoldState,
+    saveableStateHolder: SaveableStateHolder,
+    onSheetShown: (entry: NavBackStackEntry) -> Unit,
+    onSheetDismissed: (entry: NavBackStackEntry) -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    if (backStackEntry != null) {
+        val currentOnSheetShown by rememberUpdatedState(onSheetShown)
+        val currentOnSheetDismissed by rememberUpdatedState(onSheetDismissed)
+        var hideCalled by remember(backStackEntry) { mutableStateOf(false) }
+        LaunchedEffect(backStackEntry, hideCalled) {
+            val sheetVisibility = snapshotFlow { backdropScaffoldState.isRevealed }
+            sheetVisibility
+                // We are only interested in changes in the sheet's visibility
+                .distinctUntilChanged()
+                // distinctUntilChanged emits the initial value which we don't need
+                .drop(1)
+                // We want to know when the back layer was visible but is not anymore
+                .filter { isRevealed -> !isRevealed }
+                // Finally, pop the back stack when the sheet has been hidden
+                .collect { if (!hideCalled) currentOnSheetDismissed(backStackEntry) }
+        }
+
+        // We use this signal to know when its (almost) safe to `show` the bottom sheet
+        // It will be set after the sheet's content has been `onGloballyPositioned`
+        val contentPositionedSignal = remember(backStackEntry) {
+            CompletableDeferred<Unit?>()
+        }
+
+        // Whenever the composable associated with the backStackEntry enters the composition, we
+        // want to show the sheet, and hide it when this composable leaves the composition
+        DisposableEffect(backStackEntry) {
+            scope.launch {
+                contentPositionedSignal.await()
+                try {
+                    // If we don't wait for a few frames before calling `show`, we will be too early
+                    // and the sheet content won't have been laid out yet (even with our content
+                    // positioned signal). If a sheet is tall enough to have a HALF_EXPANDED state,
+                    // we might be here before the SwipeableState's anchors have been properly
+                    // calculated, resulting in the sheet animating to the EXPANDED state when
+                    // calling `show`. As a workaround, we wait for a magic number of frames.
+                    // https://issuetracker.google.com/issues/200980998
+                    repeat(AWAIT_FRAMES_BEFORE_SHOW) { awaitFrame() }
+                    backdropScaffoldState.reveal()
+                } catch (sheetShowCancelled: CancellationException) {
+                    // There is a race condition in ModalBottomSheetLayout that happens when the
+                    // sheet content changes due to the anchors being re-calculated. This causes an
+                    // animation to run for a short time, cancelling any currently running animation
+                    // such as the one triggered by our `show` call.
+                    // The sheet will still snap to the EXPANDED or HALF_EXPANDED state.
+                    // In that case we want to wait until the sheet is visible. For safety, we only
+                    // wait for 800 milliseconds - if the sheet is not visible until then, something
+                    // has gone horribly wrong.
+                    // https://issuetracker.google.com/issues/200980998
+                    withTimeout(800) {
+                        while (!backdropScaffoldState.isRevealed) {
+                            awaitFrame()
+                        }
+                    }
+                } finally {
+                    // If, for some reason, the sheet is in a state where the animation is still
+                    // running, there is a chance that it is already targeting the EXPANDED or
+                    // HALF_EXPANDED state and will snap to that. In that case we can be fairly
+                    // certain that the sheet will actually end up in that state.
+                    if (backdropScaffoldState.isRevealed || backdropScaffoldState.willBeVisible) {
+                        currentOnSheetShown(backStackEntry)
+                    }
+                }
+            }
+            onDispose {
+                scope.launch {
+                    hideCalled = true
+                    try {
+                        backdropScaffoldState.internalHide()
+                    } finally {
+                        hideCalled = false
+                    }
+                }
+            }
+        }
+
+        val content = (backStackEntry.destination as BackdropNavigator.Destination).content
+        backStackEntry.LocalOwnersProvider(saveableStateHolder) {
+            Box(Modifier.onGloballyPositioned { contentPositionedSignal.complete(Unit) }) {
+                content(backStackEntry)
+            }
+        }
+    } else {
+        EmptySheet()
+    }
+}
+
+@Composable
+private fun EmptySheet() {
+    // The swipeable modifier has a bug where it doesn't support having something with
+    // height = 0
+    // b/178529942
+    // If there are no destinations on the back stack, we need to add something to work
+    // around this
+    Box(Modifier.height(1.dp))
+}
+
+private suspend fun awaitFrame() = withFrameNanos(onFrame = {})
+
+/**
+ * This magic number has been chosen through painful experiments.
+ * - Waiting for 1 frame still results in the sheet fully expanding, which we don't want
+ * - Waiting for 2 frames results in the `show` call getting cancelled
+ * - Waiting for 3+ frames results in the sheet expanding to the correct state. Success!
+ * We wait for a few frames more just to be sure.
+ */
+private const val AWAIT_FRAMES_BEFORE_SHOW = 3
+
+// We have the same issue when we are hiding the sheet, but snapTo works better
+@OptIn(ExperimentalMaterialApi::class)
+private suspend fun BackdropScaffoldState.internalHide() {
+    snapTo(BackdropValue.Concealed)
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+private val BackdropScaffoldState.willBeVisible: Boolean
+    get() = targetValue == BackdropValue.Revealed

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BackdropNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BackdropNavigator.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.material
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.material.BackdropScaffoldState
+import androidx.compose.material.BackdropValue
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.SwipeProgress
+import androidx.compose.material.SwipeableDefaults
+import androidx.compose.material.rememberBackdropScaffoldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.navigation.FloatingWindow
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavDestination
+import androidx.navigation.NavOptions
+import androidx.navigation.Navigator
+import androidx.navigation.NavigatorState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The state of a [ModalBottomSheetLayout] that the [BottomSheetNavigator] drives
+ *
+ * @param sheetState The sheet state that is driven by the [BottomSheetNavigator]
+ */
+@ExperimentalMaterialNavigationApi
+@OptIn(ExperimentalMaterialApi::class)
+public class BackdropNavigatorState(private val backdropState: BackdropScaffoldState) {
+    /**
+     * @see BackdropScaffoldState.isRevealed
+     */
+    public val isRevealed: Boolean
+        get() = backdropState.isRevealed
+    /**
+     * @see BackdropScaffoldState.isConcealed
+     */
+    public val isConcealed: Boolean
+        get() = backdropState.isConcealed
+    /**
+     * @see BackdropScaffoldState.snackbarHostState
+     */
+    public val snackbarHostState: SnackbarHostState
+        get() = backdropState.snackbarHostState
+
+    /**
+     * @see BackdropScaffoldState.currentValue
+     */
+    public val currentValue: BackdropValue
+        get() = backdropState.currentValue
+
+    /**
+     * @see BackdropScaffoldState.targetValue
+     */
+    public val targetValue: BackdropValue
+        get() = backdropState.targetValue
+
+    /**
+     * @see BackdropScaffoldState.offset
+     */
+    public val offset: State<Float>
+        get() = backdropState.offset
+
+    /**
+     * @see BackdropScaffoldState.overflow
+     */
+    public val overflow: State<Float>
+        get() = backdropState.overflow
+
+    /**
+     * @see BackdropScaffoldState.direction
+     */
+    public val direction: Float
+        get() = backdropState.direction
+
+    /**
+     * @see BackdropScaffoldState.progress
+     */
+    public val progress: SwipeProgress<BackdropValue>
+        get() = backdropState.progress
+
+    /**
+     * @see BackdropScaffoldState.isAnimationRunning
+     */
+    public val isAnimationRunning: Boolean
+        get() = backdropState.isAnimationRunning
+}
+
+/**
+ * Create and remember a [BottomSheetNavigator]
+ */
+@ExperimentalMaterialNavigationApi
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+public fun rememberBackdropNavigator(
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    confirmStateChange: (BackdropValue) -> Boolean = { true },
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
+): BackdropNavigator {
+    val sheetState = rememberBackdropScaffoldState(
+        BackdropValue.Concealed,
+        animationSpec,
+        confirmStateChange,
+        snackbarHostState
+    )
+    return remember(sheetState) {
+        BackdropNavigator(backdropScaffoldState = sheetState)
+    }
+}
+
+/**
+ * Navigator that drives a [ModalBottomSheetState] for use of [ModalBottomSheetLayout]s
+ * with the navigation library. Every destination using this Navigator must set a valid
+ * [Composable] by setting it directly on an instantiated [Destination] or calling
+ * [androidx.navigation.compose.material.bottomSheet].
+ *
+ * <b>The [sheetContent] [Composable] will always host the latest entry of the back stack. When
+ * navigating from a [BottomSheetNavigator.Destination] to another
+ * [BottomSheetNavigator.Destination], the content of the sheet will be replaced instead of a
+ * new bottom sheet being shown.</b>
+ *
+ * When the sheet is dismissed by the user, the [state]'s [NavigatorState.backStack] will be popped.
+ *
+ * @param backdropScaffoldState The [ModalBottomSheetState] that the [BottomSheetNavigator] will use to
+ * drive the sheet state
+ */
+@ExperimentalMaterialNavigationApi
+@OptIn(ExperimentalMaterialApi::class)
+@Navigator.Name("BackdropNavigator")
+public class BackdropNavigator(
+    internal val backdropScaffoldState: BackdropScaffoldState
+) : Navigator<BackdropNavigator.Destination>() {
+
+    private var attached by mutableStateOf(false)
+
+    /**
+     * Get the back stack from the [state]. In some cases, the [sheetContent] might be composed
+     * before the Navigator is attached, so we specifically return an empty flow if we aren't
+     * attached yet.
+     */
+    private val backStack: StateFlow<List<NavBackStackEntry>>
+        get() = if (attached) {
+            state.backStack
+        } else {
+            MutableStateFlow(emptyList())
+        }
+
+    /**
+     * Access properties of the [ModalBottomSheetLayout]'s [ModalBottomSheetState]
+     */
+    public val navigatorState = BackdropNavigatorState(backdropScaffoldState)
+
+    /**
+     * A [Composable] function that hosts the current sheet content. This should be set as
+     * sheetContent of your [ModalBottomSheetLayout].
+     */
+    public val backLayerContent: @Composable () -> Unit = @Composable {
+        val saveableStateHolder = rememberSaveableStateHolder()
+        val backStackEntries by backStack.collectAsState()
+
+        // We always replace the sheet's content instead of overlaying and nesting floating
+        // window destinations. That means that only *one* concurrent destination is supported by
+        // this navigator.
+        val latestEntry = backStackEntries.lastOrNull { entry ->
+            // We might have entries in the back stack that aren't started currently, so filter
+            // these
+            entry.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+        }
+
+        // Mark all of the entries' transitions as complete, except for the entry we are
+        // currently displaying because it will have its transition completed when the sheet's
+        // animation has completed
+        DisposableEffect(backStackEntries) {
+            backStackEntries.forEach {
+                if (it != latestEntry) state.markTransitionComplete(it)
+            }
+            onDispose { }
+        }
+
+        BackdropContentHost(
+            backStackEntry = latestEntry,
+            backdropScaffoldState = backdropScaffoldState,
+            saveableStateHolder = saveableStateHolder,
+            onSheetShown = { backStackEntry ->
+                state.markTransitionComplete(backStackEntry)
+            },
+            onSheetDismissed = { backStackEntry ->
+                // Sheet dismissal can be started through popBackStack in which case we have a
+                // transition that we'll want to complete
+                if (state.transitionsInProgress.value.contains(backStackEntry)) {
+                    state.markTransitionComplete(backStackEntry)
+                } else {
+                    state.pop(popUpTo = backStackEntry, saveState = false)
+                }
+            }
+        )
+    }
+
+    override fun onAttach(state: NavigatorState) {
+        super.onAttach(state)
+        attached = true
+    }
+
+    override fun createDestination(): Destination = Destination(navigator = this, content = {})
+
+    override fun navigate(
+        entries: List<NavBackStackEntry>,
+        navOptions: NavOptions?,
+        navigatorExtras: Extras?
+    ) {
+        entries.forEach { entry ->
+            state.pushWithTransition(entry)
+        }
+    }
+
+    override fun popBackStack(popUpTo: NavBackStackEntry, savedState: Boolean) {
+        state.popWithTransition(popUpTo, savedState)
+    }
+
+    /**
+     * [NavDestination] specific to [BottomSheetNavigator]
+     */
+    @NavDestination.ClassType(Composable::class)
+    public class Destination(
+        navigator: BackdropNavigator,
+        internal val content: @Composable (NavBackStackEntry) -> Unit
+    ) : NavDestination(navigator), FloatingWindow
+}

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/NavGraphBuilder.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/NavGraphBuilder.kt
@@ -55,6 +55,15 @@ public fun NavGraphBuilder.bottomSheet(
     )
 }
 
+
+/**
+ * Add the [content] [Composable] as a Backdrop's back layer content to the [NavGraphBuilder]
+ *
+ * @param route route for the destination
+ * @param arguments list of arguments to associate with destination
+ * @param deepLinks list of deep links to associate with the destinations
+ * @param content the back layer content at the given destination
+ */
 @ExperimentalMaterialNavigationApi
 public fun NavGraphBuilder.backdrop(
     route: String,

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/NavGraphBuilder.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/NavGraphBuilder.kt
@@ -54,3 +54,26 @@ public fun NavGraphBuilder.bottomSheet(
         }
     )
 }
+
+@ExperimentalMaterialNavigationApi
+public fun NavGraphBuilder.backdrop(
+    route: String,
+    arguments: List<NamedNavArgument> = emptyList(),
+    deepLinks: List<NavDeepLink> = emptyList(),
+    content: @Composable (backstackEntry: NavBackStackEntry) -> Unit
+) {
+    addDestination(
+        BackdropNavigator.Destination(
+            provider[BackdropNavigator::class],
+            content
+        ).apply {
+            this.route = route
+            arguments.forEach { (argumentName, argument) ->
+                addArgument(argumentName, argument)
+            }
+            deepLinks.forEach { deepLink ->
+                addDeepLink(deepLink)
+            }
+        }
+    )
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -208,6 +208,16 @@
         </activity>
 
         <activity
+            android:name=".navigation.material.BackdropNavSample"
+            android:label="@string/navigation_title_backdrop"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".permissions.RequestPermissionSample"
             android:label="@string/permissions_title_one"
             android:exported="false">

--- a/sample/src/main/java/com/google/accompanist/sample/navigation/material/BackdropNavSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/navigation/material/BackdropNavSample.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.sample.navigation.material
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.google.accompanist.navigation.material.BackdropScaffold
+import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
+import com.google.accompanist.navigation.material.backdrop
+import com.google.accompanist.navigation.material.rememberBackdropNavigator
+import com.google.accompanist.sample.AccompanistSampleTheme
+import java.util.UUID
+
+@ExperimentalMaterialApi
+class BackdropNavSample : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AccompanistSampleTheme {
+                BackdropNavDemo()
+            }
+        }
+    }
+}
+
+private object BackdropDestinations {
+    const val Home = "HOME"
+    const val Feed = "FEED"
+    const val Sheet = "SHEET"
+}
+
+@ExperimentalMaterialApi
+@OptIn(ExperimentalMaterialNavigationApi::class)
+@Composable
+fun BackdropNavDemo() {
+    val bottomSheetNavigator = rememberBackdropNavigator()
+    val navController = rememberNavController(bottomSheetNavigator)
+
+    BackdropScaffold(
+        bottomSheetNavigator,
+        appBar = { }
+    ) {
+        NavHost(navController, BackdropDestinations.Home) {
+            composable(BackdropDestinations.Home) {
+                HomeScreen(
+                    showSheet = {
+                        navController.navigate(BackdropDestinations.Sheet + "?arg=From Home Screen")
+                    },
+                    showFeed = { navController.navigate(BackdropDestinations.Feed) }
+                )
+            }
+            composable(BackdropDestinations.Feed) { Text("Feed!") }
+            backdrop(BackdropDestinations.Sheet + "?arg={arg}") { backstackEntry ->
+                val arg = backstackEntry.arguments?.getString("arg") ?: "Missing argument :("
+                Backdrop(
+                    showFeed = { navController.navigate(BackdropDestinations.Feed) },
+                    showAnotherSheet = {
+                        navController.navigate(BackdropDestinations.Sheet + "?arg=${UUID.randomUUID()}")
+                    },
+                    arg = arg
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeScreen(showSheet: () -> Unit, showFeed: () -> Unit) {
+    Column(Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+        Text("Body")
+        Button(onClick = showSheet) {
+            Text("Show sheet!")
+        }
+        Button(onClick = showFeed) {
+            Text("Navigate to Feed")
+        }
+    }
+}
+
+@Composable
+private fun Backdrop(showFeed: () -> Unit, showAnotherSheet: () -> Unit, arg: String) = Column {
+    Text("Sheet with arg: $arg")
+    Button(onClick = showFeed) {
+        Text("Click me to navigate!")
+    }
+    Button(onClick = showAnotherSheet) {
+        Text("Click me to show another sheet!")
+    }
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
 
     <string name="navigation_title_animated">Navigation: Transitions</string>
     <string name="navigation_title_bottom_sheet">Navigation: Bottom Sheets</string>
+    <string name="navigation_title_backdrop">Navigation: Backdrop</string>
 
     <string name="permissions_title_one">Permissions: Request permission</string>
     <string name="permissions_title_multiple">Permissions: Request multiple permissions</string>


### PR DESCRIPTION
# Description
Modified the existing implementation for ModelBottomSheetLayout to implement the same functionality for BackdropScaffold. Allowing the user to add destinations for the back layer in the nav host.
To allow someone to do the following:

``` kotlin

@Composable fun Example() {
    val backdropNavigator = rememberBackdropNavigator()
    val navController = rememberNavHostController(backdropNavigator)

    BackdropScaffold(backdropNavigator) {
        NavHost(navController) {
            composable("main") {  Text("Front Layer Content") }
            backdrop("backlayer")  {  Text("Back Layer Content") }
        }
    }
}

```