### PR TITLE
[Material-Navigation] Add skip half expanded navigator-level API

### DIFF
--- a/docs/navigation-material.md
+++ b/docs/navigation-material.md
@@ -18,7 +18,7 @@ This features composable bottom sheet destinations.
     ```kotlin
     @Composable
     fun MyApp() {
-        val bottomSheetNavigator = rememberBottomSheetNaviginator()
+        val bottomSheetNavigator = rememberBottomSheetNavigator()
         val navController = rememberNavController(bottomSheetNavigator)
     }
     ```

--- a/docs/navigation-material.md
+++ b/docs/navigation-material.md
@@ -18,10 +18,13 @@ This features composable bottom sheet destinations.
     ```kotlin
     @Composable
     fun MyApp() {
-        val bottomSheetNavigator = rememberBottomSheetNavigator()
+        val bottomSheetNavigator = rememberBottomSheetNaviginator()
         val navController = rememberNavController(bottomSheetNavigator)
     }
     ```
+   
+Passing the `skipHalfExpanded=true` flag to `rememberBottomSheetNavigator()` will fully expand bottom 
+sheets by default instead of limiting them to half of screen height.
 
 2. Wrap your `NavHost` in the `ModalBottomSheetLayout` composable that accepts a `BottomSheetNavigator`.
 

--- a/navigation-material/api/current.api
+++ b/navigation-material/api/current.api
@@ -19,7 +19,7 @@ package com.google.accompanist.navigation.material {
   }
 
   public final class BottomSheetNavigatorKt {
-    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec);
+    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec, optional boolean skipHalfExpanded);
   }
 
   @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public final class BottomSheetNavigatorSheetState {

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/BottomSheetNavigatorTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/BottomSheetNavigatorTest.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.plusAssign
 import androidx.navigation.testing.TestNavigatorState
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
@@ -126,10 +127,7 @@ internal class BottomSheetNavigatorTest {
                 secondDestinationCompositions++
                 onDispose { secondDestinationCompositions = 0 }
             }
-            Box(
-                Modifier
-                    .size(64.dp)
-                    .testTag(secondDestinationContentTag))
+            Box(Modifier.size(64.dp).testTag(secondDestinationContentTag))
         }
         val secondEntry = navigatorState.createBackStackEntry(secondDestination, null)
 
@@ -166,10 +164,7 @@ internal class BottomSheetNavigatorTest {
         composeTestRule.setContent {
             ModalBottomSheetLayout(
                 bottomSheetNavigator = navigator,
-                content = { Box(
-                    Modifier
-                        .fillMaxSize()
-                        .testTag(bodyContentTag)) }
+                content = { Box(Modifier.fillMaxSize().testTag(bodyContentTag)) }
             )
         }
 

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/BottomSheetNavigatorTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/BottomSheetNavigatorTest.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.plusAssign
 import androidx.navigation.testing.TestNavigatorState
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
@@ -127,7 +126,10 @@ internal class BottomSheetNavigatorTest {
                 secondDestinationCompositions++
                 onDispose { secondDestinationCompositions = 0 }
             }
-            Box(Modifier.size(64.dp).testTag(secondDestinationContentTag))
+            Box(
+                Modifier
+                    .size(64.dp)
+                    .testTag(secondDestinationContentTag))
         }
         val secondEntry = navigatorState.createBackStackEntry(secondDestination, null)
 
@@ -164,7 +166,10 @@ internal class BottomSheetNavigatorTest {
         composeTestRule.setContent {
             ModalBottomSheetLayout(
                 bottomSheetNavigator = navigator,
-                content = { Box(Modifier.fillMaxSize().testTag(bodyContentTag)) }
+                content = { Box(
+                    Modifier
+                        .fillMaxSize()
+                        .testTag(bodyContentTag)) }
             )
         }
 

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.material
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.plusAssign
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.google.common.truth.Truth
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterialNavigationApi::class)
+class HalfExpandedTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testSkipHalfExpandedWhenOverHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(true, 0.6f, ModalBottomSheetValue.Expanded)
+    }
+
+    @Test
+    fun testNoSkipHalfExpandedWhenOverHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(false, 0.6f, ModalBottomSheetValue.HalfExpanded)
+    }
+
+    @Test
+    fun testNoSkipHalfExpandedWhenUnderHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(false, 0.4f, ModalBottomSheetValue.Expanded)
+    }
+
+    @Test
+    fun testSkipHalfExpandedWhenUnderHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(true, 0.4f, ModalBottomSheetValue.Expanded)
+    }
+
+    private suspend fun trySkipHalfExpanded(skipHalfExpanded: Boolean, screenPercent: Float, expectedSheetState: ModalBottomSheetValue) {
+        coroutineScope {
+            lateinit var navController: NavHostController
+            lateinit var bottomSheetNavigator: BottomSheetNavigator
+            composeTestRule.setContent {
+                navController = rememberNavController()
+                bottomSheetNavigator = rememberBottomSheetNavigator(skipHalfExpanded = skipHalfExpanded)
+
+                navController.navigatorProvider += bottomSheetNavigator
+
+                NavHost(
+                    navController = navController,
+                    startDestination = "start"
+                ) {
+                    composable("start") {
+                        ModalBottomSheetLayout(
+                            bottomSheetNavigator = bottomSheetNavigator,
+                            content = { Box(Modifier.fillMaxSize()) }
+                        )
+                    }
+                    bottomSheet("bottomSheet") {
+                        Box(modifier = Modifier.fillMaxSize(screenPercent))
+                    }
+                }
+            }
+            launch(Dispatchers.Main) {
+                navController.navigate("bottomSheet")
+            }
+            composeTestRule.awaitIdle()
+            Truth.assertThat(bottomSheetNavigator.navigatorSheetState.currentValue)
+                .isEqualTo(expectedSheetState)
+        }
+    }
+}

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
@@ -24,15 +24,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.plusAssign
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.google.common.truth.Truth
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
@@ -71,28 +71,19 @@ class HalfExpandedTests {
             lateinit var navController: NavHostController
             lateinit var bottomSheetNavigator: BottomSheetNavigator
             composeTestRule.setContent {
-                navController = rememberNavController()
                 bottomSheetNavigator = rememberBottomSheetNavigator(skipHalfExpanded = skipHalfExpanded)
+                navController = rememberNavController(bottomSheetNavigator)
 
-                navController.navigatorProvider += bottomSheetNavigator
-
-                NavHost(
-                    navController = navController,
-                    startDestination = "start"
-                ) {
-                    composable("start") {
-                        ModalBottomSheetLayout(
-                            bottomSheetNavigator = bottomSheetNavigator,
-                            content = { Box(Modifier.fillMaxSize()) }
-                        )
-                    }
-                    bottomSheet("bottomSheet") {
-                        Box(modifier = Modifier.fillMaxSize(screenPercent))
+                ModalBottomSheetLayout(bottomSheetNavigator = bottomSheetNavigator) {
+                    NavHost(
+                        navController = navController,
+                        startDestination = "bottomSheet"
+                    ) {
+                        bottomSheet("bottomSheet") {
+                            Box(modifier = Modifier.fillMaxSize(screenPercent))
+                        }
                     }
                 }
-            }
-            launch(Dispatchers.Main) {
-                navController.navigate("bottomSheet")
             }
             composeTestRule.awaitIdle()
             Truth.assertThat(bottomSheetNavigator.navigatorSheetState.currentValue)

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -97,16 +97,22 @@ public class BottomSheetNavigatorSheetState(private val sheetState: ModalBottomS
 
 /**
  * Create and remember a [BottomSheetNavigator]
+ *
+ * @param animationSpec The [AnimationSpec] to use for swipes on the bottom sheet
+ * @param skipHalfExpanded Whether to skip the half expanded state and expand fully on open,
+ * defaulted to false
  */
 @ExperimentalMaterialNavigationApi
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 public fun rememberBottomSheetNavigator(
-    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    skipHalfExpanded: Boolean = false
 ): BottomSheetNavigator {
     val sheetState = rememberModalBottomSheetState(
         ModalBottomSheetValue.Hidden,
-        animationSpec
+        animationSpec,
+        skipHalfExpanded = skipHalfExpanded
     )
     return remember(sheetState) {
         BottomSheetNavigator(sheetState = sheetState)


### PR DESCRIPTION
This adds a skip half expanded flag to the `rememberBottomSheetNavigator()` function thereby fixing #657 for the navigator only.
