### PR TITLE
[Material-Navigation] Add navigator-level skip half expanded flag for BottomSheetNavigator.kt

### DIFF
--- a/docs/navigation-material.md
+++ b/docs/navigation-material.md
@@ -22,6 +22,9 @@ This features composable bottom sheet destinations.
         val navController = rememberNavController(bottomSheetNavigator)
     }
     ```
+   
+Passing the `skipHalfExpanded=true` flag to `rememberBottomSheetNavigator()` will fully expand bottom 
+sheets by default instead of limiting them to half of screen height.
 
 2. Wrap your `NavHost` in the `ModalBottomSheetLayout` composable that accepts a `BottomSheetNavigator`.
 

--- a/navigation-material/api/current.api
+++ b/navigation-material/api/current.api
@@ -19,7 +19,7 @@ package com.google.accompanist.navigation.material {
   }
 
   public final class BottomSheetNavigatorKt {
-    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec);
+    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec, optional boolean skipHalfExpanded);
   }
 
   @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public final class BottomSheetNavigatorSheetState {

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
@@ -24,11 +24,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import com.google.common.truth.Truth
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -73,13 +76,19 @@ class HalfExpandedTests {
                 ModalBottomSheetLayout(bottomSheetNavigator = bottomSheetNavigator) {
                     NavHost(
                         navController = navController,
-                        startDestination = "bottomSheet"
+                        startDestination = "start"
                     ) {
+                        composable("start") {
+                            Box(modifier = Modifier.fillMaxSize())
+                        }
                         bottomSheet("bottomSheet") {
                             Box(modifier = Modifier.fillMaxSize(screenPercent))
                         }
                     }
                 }
+            }
+            launch(Dispatchers.Main) {
+                navController.navigate("bottomSheet")
             }
             composeTestRule.awaitIdle()
             Truth.assertThat(bottomSheetNavigator.navigatorSheetState.currentValue)

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/HalfExpandedTests.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.material
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import com.google.common.truth.Truth
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterialNavigationApi::class)
+class HalfExpandedTests {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testSkipHalfExpandedWhenOverHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(true, 0.6f, ModalBottomSheetValue.Expanded)
+    }
+
+    @Test
+    fun testNoSkipHalfExpandedWhenOverHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(false, 0.6f, ModalBottomSheetValue.HalfExpanded)
+    }
+
+    @Test
+    fun testNoSkipHalfExpandedWhenUnderHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(false, 0.4f, ModalBottomSheetValue.Expanded)
+    }
+
+    @Test
+    fun testSkipHalfExpandedWhenUnderHalfScreenHeight(): Unit = runBlocking {
+        trySkipHalfExpanded(true, 0.4f, ModalBottomSheetValue.Expanded)
+    }
+
+    private suspend fun trySkipHalfExpanded(skipHalfExpanded: Boolean, screenPercent: Float, expectedSheetState: ModalBottomSheetValue) {
+        coroutineScope {
+            lateinit var navController: NavHostController
+            lateinit var bottomSheetNavigator: BottomSheetNavigator
+            composeTestRule.setContent {
+                bottomSheetNavigator = rememberBottomSheetNavigator(skipHalfExpanded = skipHalfExpanded)
+                navController = rememberNavController(bottomSheetNavigator)
+
+                ModalBottomSheetLayout(bottomSheetNavigator = bottomSheetNavigator) {
+                    NavHost(
+                        navController = navController,
+                        startDestination = "bottomSheet"
+                    ) {
+                        bottomSheet("bottomSheet") {
+                            Box(modifier = Modifier.fillMaxSize(screenPercent))
+                        }
+                    }
+                }
+            }
+            composeTestRule.awaitIdle()
+            Truth.assertThat(bottomSheetNavigator.navigatorSheetState.currentValue)
+                .isEqualTo(expectedSheetState)
+        }
+    }
+}

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -97,16 +97,22 @@ public class BottomSheetNavigatorSheetState(private val sheetState: ModalBottomS
 
 /**
  * Create and remember a [BottomSheetNavigator]
+ *
+ * @param animationSpec The [AnimationSpec] to use for swipes on the bottom sheet
+ * @param skipHalfExpanded Whether to skip the half expanded state and expand fully on open,
+ * defaulted to false
  */
 @ExperimentalMaterialNavigationApi
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 public fun rememberBottomSheetNavigator(
-    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    skipHalfExpanded: Boolean = false
 ): BottomSheetNavigator {
     val sheetState = rememberModalBottomSheetState(
         ModalBottomSheetValue.Hidden,
-        animationSpec
+        animationSpec,
+        skipHalfExpanded = skipHalfExpanded
     )
     return remember(sheetState) {
         BottomSheetNavigator(sheetState = sheetState)


### PR DESCRIPTION
This adds a skip half expanded flag to the rememberBottomSheetNavigator() function thereby fixing #657 for the navigator only.

Discussion on this PR before rebase: https://github.com/google/accompanist/pull/957