### PR TITLE
[Pager] Do not scroll more than 3 items as an optimization

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import kotlin.math.abs
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
@@ -195,6 +196,13 @@ class PagerState(
         requireCurrentPageOffset(pageOffset, "pageOffset")
         try {
             animationTargetPage = page
+
+            // pre-jump to nearby item for long jumps as an optimization
+            // the same trick is done in ViewPager2
+            val oldPage = lazyListState.firstVisibleItemIndex
+            if (abs(page - oldPage) > 3) {
+                lazyListState.scrollToItem(if (page > oldPage) page - 3 else page + 3)
+            }
 
             if (pageOffset <= 0.005f) {
                 // If the offset is (close to) zero, just call animateScrollToItem and we're done

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
@@ -120,6 +120,7 @@ abstract class BaseHorizontalPagerTest(
         pageToItem: (Int) -> String,
         useKeys: Boolean,
         userScrollEnabled: Boolean,
+        onPageComposed: (Int) -> Unit
     ) {
         CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
             applierScope = rememberCoroutineScope()
@@ -143,6 +144,7 @@ abstract class BaseHorizontalPagerTest(
                     },
                     userScrollEnabled = userScrollEnabled,
                 ) { page ->
+                    onPageComposed(page)
                     val item = pageToItem(page)
                     Box(
                         modifier = Modifier

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
@@ -100,6 +100,7 @@ abstract class BaseVerticalPagerTest(
         pageToItem: (Int) -> String,
         useKeys: Boolean,
         userScrollEnabled: Boolean,
+        onPageComposed: (Int) -> Unit
     ) {
         CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             applierScope = rememberCoroutineScope()
@@ -123,6 +124,7 @@ abstract class BaseVerticalPagerTest(
                     },
                     userScrollEnabled = userScrollEnabled,
                 ) { page ->
+                    onPageComposed(page)
                     val item = pageToItem(page)
                     Box(
                         modifier = Modifier

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -490,7 +490,6 @@ abstract class PagerTest {
         composeTestRule.runOnIdle {
             assertThat(composedPages).doesNotContain(4)
             assertThat(composedPages).doesNotContain(5)
-            assertThat(composedPages).doesNotContain(6)
         }
     }
 

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -469,6 +469,31 @@ abstract class PagerTest {
         }
     }
 
+    @Test
+    fun animatedScrollToIsNotComposingAllTheItemsInBetween() {
+        val pagerState = PagerState(0)
+        val composedPages = mutableSetOf<Int>()
+        composeTestRule.setContent {
+            PagerContent(
+                count = { 11 },
+                pagerState = pagerState,
+                onPageComposed = { composedPages.add(it) }
+            )
+        }
+
+        composeTestRule.runOnIdle {
+            runBlocking(AutoTestFrameClock()) {
+                pagerState.animateScrollToPage(10)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(composedPages).doesNotContain(4)
+            assertThat(composedPages).doesNotContain(5)
+            assertThat(composedPages).doesNotContain(6)
+        }
+    }
+
     /**
      * Swipe across the center of the node. The major axis of the swipe is defined by the
      * overriding test.
@@ -542,6 +567,7 @@ abstract class PagerTest {
         pageToItem: (Int) -> String = { it.toString() },
         userScrollEnabled: Boolean = true,
         useKeys: Boolean = false,
+        onPageComposed: (Int) -> Unit = {}
     ) {
         AbstractPagerContent(
             count = count,
@@ -549,7 +575,8 @@ abstract class PagerTest {
             observeStateInContent = observeStateInContent,
             pageToItem = { pageToItem(it) },
             useKeys = useKeys,
-            userScrollEnabled = userScrollEnabled
+            userScrollEnabled = userScrollEnabled,
+            onPageComposed = onPageComposed
         )
     }
 
@@ -561,6 +588,7 @@ abstract class PagerTest {
         pageToItem: (Int) -> String,
         useKeys: Boolean,
         userScrollEnabled: Boolean,
+        onPageComposed: (Int) -> Unit
     )
 }
 


### PR DESCRIPTION
Ported the behavior from ViewPager2
Fixes https://github.com/google/accompanist/issues/876