### PR TITLE
[Pager] Do not scroll more than 3 items as an optimization

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import kotlin.math.abs
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
 
@@ -195,6 +196,13 @@ class PagerState(
         requireCurrentPageOffset(pageOffset, "pageOffset")
         try {
             animationTargetPage = page
+
+            // pre-jump to nearby item for long jumps as an optimization
+            // the same trick is done in ViewPager2
+            val oldPage = lazyListState.firstVisibleItemIndex
+            if (abs(page - oldPage) > 3) {
+                lazyListState.scrollToItem(if (page > oldPage) page - 3 else page + 3)
+            }
 
             if (pageOffset <= 0.005f) {
                 // If the offset is (close to) zero, just call animateScrollToItem and we're done

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
@@ -119,6 +119,7 @@ abstract class BaseHorizontalPagerTest(
         observeStateInContent: Boolean,
         pageToItem: (Int) -> String,
         useKeys: Boolean,
+        onPageComposed: (Int) -> Unit
     ) {
         CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
             applierScope = rememberCoroutineScope()
@@ -141,6 +142,7 @@ abstract class BaseHorizontalPagerTest(
                         null
                     }
                 ) { page ->
+                    onPageComposed(page)
                     val item = pageToItem(page)
                     Box(
                         modifier = Modifier

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
@@ -99,6 +99,7 @@ abstract class BaseVerticalPagerTest(
         observeStateInContent: Boolean,
         pageToItem: (Int) -> String,
         useKeys: Boolean,
+        onPageComposed: (Int) -> Unit
     ) {
         CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             applierScope = rememberCoroutineScope()
@@ -121,6 +122,7 @@ abstract class BaseVerticalPagerTest(
                         null
                     }
                 ) { page ->
+                    onPageComposed(page)
                     val item = pageToItem(page)
                     Box(
                         modifier = Modifier

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -425,6 +425,30 @@ abstract class PagerTest {
         }
     }
 
+    @Test
+    fun animatedScrollToIsNotComposingAllTheItemsInBetween() {
+        val pagerState = PagerState(0)
+        val composedPages = mutableSetOf<Int>()
+        composeTestRule.setContent {
+            PagerContent(
+                count = { 11 },
+                pagerState = pagerState,
+                onPageComposed = { composedPages.add(it) }
+            )
+        }
+
+        composeTestRule.runOnIdle {
+            runBlocking(AutoTestFrameClock()) {
+                pagerState.animateScrollToPage(10)
+            }
+        }
+
+        composeTestRule.runOnIdle {
+            assertThat(composedPages).doesNotContain(4)
+            assertThat(composedPages).doesNotContain(5)
+        }
+    }
+
     /**
      * Swipe across the center of the node. The major axis of the swipe is defined by the
      * overriding test.
@@ -497,13 +521,15 @@ abstract class PagerTest {
         observeStateInContent: Boolean = false,
         pageToItem: (Int) -> String = { it.toString() },
         useKeys: Boolean = false,
+        onPageComposed: (Int) -> Unit = {}
     ) {
         AbstractPagerContent(
             count = count,
             pagerState = pagerState,
             observeStateInContent = observeStateInContent,
             pageToItem = { pageToItem(it) },
-            useKeys = useKeys
+            useKeys = useKeys,
+            onPageComposed = onPageComposed
         )
     }
 
@@ -513,7 +539,8 @@ abstract class PagerTest {
         pagerState: PagerState,
         observeStateInContent: Boolean,
         pageToItem: (Int) -> String,
-        useKeys: Boolean
+        useKeys: Boolean,
+        onPageComposed: (Int) -> Unit
     )
 }
 


### PR DESCRIPTION
Ported the behavior from ViewPager2
It is a cherry pick of https://github.com/google/accompanist/pull/971 into compose-1.1 branch
Fixes #876