### PR TITLE
[SystemUiController] Add API 30 workaround for system bar appearance

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.1"
-androidx-core = "androidx.core:core-ktx:1.7.0"
+androidx-core = "androidx.core:core-ktx:1.8.0-alpha03"
 androidx-activity-compose = "androidx.activity:activity-compose:1.4.0"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.4.0"
 androidx-dynamicanimation = "androidx.dynamicanimation:dynamicanimation-ktx:1.0.0-alpha03"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 compose = "1.2.0-alpha01"
-composesnapshot = "-" # a single character = no snapshot
+composesnapshot = "8139767" # a single character = no snapshot
 
 # gradlePlugin and lint need to be updated together
 gradlePlugin = "7.1.0-rc01"
@@ -54,7 +54,7 @@ coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.1"
-androidx-core = "androidx.core:core-ktx:1.8.0-alpha03"
+androidx-core = "androidx.core:core-ktx:1.8.0-SNAPSHOT"
 androidx-activity-compose = "androidx.activity:activity-compose:1.4.0"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.4.0"
 androidx-dynamicanimation = "androidx.dynamicanimation:dynamicanimation-ktx:1.0.0-alpha03"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -302,7 +302,8 @@
         <activity
             android:name=".systemuicontroller.SystemBarsColorSample"
             android:label="@string/system_ui_controller_title_color"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/SystemBarsColorSampleTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />

--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsColorSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsColorSample.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -87,6 +88,11 @@ private fun Sample() {
     var clickedColor by remember { mutableStateOf(Color.Unspecified) }
     var statusBarDarkIcons by remember { mutableStateOf(false) }
     var navigationBarDarkIcons by remember { mutableStateOf(false) }
+
+    SideEffect {
+        systemUiController.statusBarDarkContentEnabled = statusBarDarkIcons
+        systemUiController.navigationBarDarkContentEnabled = navigationBarDarkIcons
+    }
 
     @Composable
     fun Color(color: Color) {
@@ -213,7 +219,6 @@ private fun Sample() {
                     modifier = Modifier
                         .clickable {
                             statusBarDarkIcons = !statusBarDarkIcons
-                            systemUiController.statusBarDarkContentEnabled = statusBarDarkIcons
                         }
                         .padding(8.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -231,7 +236,6 @@ private fun Sample() {
                     modifier = Modifier
                         .clickable {
                             navigationBarDarkIcons = !navigationBarDarkIcons
-                            systemUiController.navigationBarDarkContentEnabled = navigationBarDarkIcons
                         }
                         .padding(8.dp),
                     verticalAlignment = Alignment.CenterVertically

--- a/sample/src/main/res/values/themes.xml
+++ b/sample/src/main/res/values/themes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+    <!-- A custom theme for the system bars color sample to verify overriding the system default -->
+    <!-- These values aren't used directly, but do make it more difficult to handle correctly -->
+    <style name="SystemBarsColorSampleTheme" parent="@android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
+    </style>
+</resources>

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -243,36 +243,12 @@ internal class AndroidSystemUiController(
     override var statusBarDarkContentEnabled: Boolean
         get() = windowInsetsController?.isAppearanceLightStatusBars == true
         set(value) {
-            // This is an API 30 specific workaround, to set the corresponding flags even
-            // though they shouldn't matter.
-            @Suppress("DEPRECATION")
-            if (Build.VERSION.SDK_INT == 30 && window != null) {
-                window.decorView.systemUiVisibility = if (value) {
-                    window.decorView.systemUiVisibility or
-                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                } else {
-                    window.decorView.systemUiVisibility and
-                        View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-                }
-            }
             windowInsetsController?.isAppearanceLightStatusBars = value
         }
 
     override var navigationBarDarkContentEnabled: Boolean
         get() = windowInsetsController?.isAppearanceLightNavigationBars == true
         set(value) {
-            // This is an API 30 specific workaround, to set the corresponding flags even
-            // though they shouldn't matter.
-            @Suppress("DEPRECATION")
-            if (Build.VERSION.SDK_INT == 30 && window != null) {
-                window.decorView.systemUiVisibility = if (value) {
-                    window.decorView.systemUiVisibility or
-                        View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-                } else {
-                    window.decorView.systemUiVisibility and
-                        View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv()
-                }
-            }
             windowInsetsController?.isAppearanceLightNavigationBars = value
         }
 


### PR DESCRIPTION
This should actually fix #881 fully and #949, for the case where the theme has `android:windowLightStatusBar=true` and trying to set it to `false` (via `statusBarDarkContentEnabled = false` or `darkIcons = false`).

There was also a somewhat similar issue for the navigation bars, where the scrim wouldn't be updated while toggling the navigation bar dark icons on API 30, which I believe is https://issuetracker.google.com/issues/215832843 but hasn't been reported here yet as an issue.

The fix for both of these seems to be setting the corresponding `systemUiVisibility` flags anyway, in addition to calling the normal flags. I'm planning to upstream these changes as well, so that we don't have to use these workarounds with a future version of `androidx.core`.

This fix also made the `systemUiController` optional again, so that it will work when using it in a `@Preview` (and fixes #918)

BEFORE:

https://user-images.githubusercontent.com/4217560/151279075-a90b5dc7-0d8d-44fc-ab5a-47401fca5756.mp4


AFTER:

https://user-images.githubusercontent.com/4217560/151279079-54da2140-643a-45ba-a311-736d44a1a777.mp4




 