### PR TITLE
[SystemUiController] Add API 30 workaround for system bar appearance

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.1"
-androidx-core = "androidx.core:core-ktx:1.7.0"
+androidx-core = "androidx.core:core-ktx:1.8.0-alpha03"
 androidx-activity-compose = "androidx.activity:activity-compose:1.4.0"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.4.0"
 androidx-dynamicanimation = "androidx.dynamicanimation:dynamicanimation-ktx:1.0.0-alpha03"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -302,7 +302,8 @@
         <activity
             android:name=".systemuicontroller.SystemBarsColorSample"
             android:label="@string/system_ui_controller_title_color"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/SystemBarsColorSampleTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />

--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsColorSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsColorSample.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -87,6 +88,11 @@ private fun Sample() {
     var clickedColor by remember { mutableStateOf(Color.Unspecified) }
     var statusBarDarkIcons by remember { mutableStateOf(false) }
     var navigationBarDarkIcons by remember { mutableStateOf(false) }
+
+    SideEffect {
+        systemUiController.statusBarDarkContentEnabled = statusBarDarkIcons
+        systemUiController.navigationBarDarkContentEnabled = navigationBarDarkIcons
+    }
 
     @Composable
     fun Color(color: Color) {
@@ -213,7 +219,6 @@ private fun Sample() {
                     modifier = Modifier
                         .clickable {
                             statusBarDarkIcons = !statusBarDarkIcons
-                            systemUiController.statusBarDarkContentEnabled = statusBarDarkIcons
                         }
                         .padding(8.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -231,7 +236,6 @@ private fun Sample() {
                     modifier = Modifier
                         .clickable {
                             navigationBarDarkIcons = !navigationBarDarkIcons
-                            systemUiController.navigationBarDarkContentEnabled = navigationBarDarkIcons
                         }
                         .padding(8.dp),
                     verticalAlignment = Alignment.CenterVertically

--- a/sample/src/main/res/values/themes.xml
+++ b/sample/src/main/res/values/themes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2022 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+    <!-- A custom theme for the system bars color sample to verify overriding the system default -->
+    <!-- These values aren't used directly, but do make it more difficult to handle correctly -->
+    <style name="SystemBarsColorSampleTheme" parent="@android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:windowLightStatusBar" tools:targetApi="23">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
+    </style>
+</resources>

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 
 /**
  * A class which provides easy-to-use utilities for updating the System UI bar
@@ -174,10 +173,8 @@ fun rememberSystemUiController(): SystemUiController {
 internal class AndroidSystemUiController(
     private val view: View
 ) : SystemUiController {
-    private val window = requireNotNull(view.context.findWindow()) {
-        "The Compose View must be hosted in an Activity with a Window!"
-    }
-    private val windowInsetsController = WindowInsetsControllerCompat(window, view)
+    private val window = view.context.findWindow()
+    private val windowInsetsController = ViewCompat.getWindowInsetsController(view)
 
     override fun setStatusBarColor(
         color: Color,
@@ -186,8 +183,8 @@ internal class AndroidSystemUiController(
     ) {
         statusBarDarkContentEnabled = darkIcons
 
-        window.statusBarColor = when {
-            darkIcons && !windowInsetsController.isAppearanceLightStatusBars -> {
+        window?.statusBarColor = when {
+            darkIcons && windowInsetsController?.isAppearanceLightStatusBars != true -> {
                 // If we're set to use dark icons, but our windowInsetsController call didn't
                 // succeed (usually due to API level), we instead transform the color to maintain
                 // contrast
@@ -206,8 +203,8 @@ internal class AndroidSystemUiController(
         navigationBarDarkContentEnabled = darkIcons
         isNavigationBarContrastEnforced = navigationBarContrastEnforced
 
-        window.navigationBarColor = when {
-            darkIcons && !windowInsetsController.isAppearanceLightNavigationBars -> {
+        window?.navigationBarColor = when {
+            darkIcons && windowInsetsController?.isAppearanceLightNavigationBars != true -> {
                 // If we're set to use dark icons, but our windowInsetsController call didn't
                 // succeed (usually due to API level), we instead transform the color to maintain
                 // contrast
@@ -224,9 +221,9 @@ internal class AndroidSystemUiController(
         }
         set(value) {
             if (value) {
-                windowInsetsController.show(WindowInsetsCompat.Type.statusBars())
+                windowInsetsController?.show(WindowInsetsCompat.Type.statusBars())
             } else {
-                windowInsetsController.hide(WindowInsetsCompat.Type.statusBars())
+                windowInsetsController?.hide(WindowInsetsCompat.Type.statusBars())
             }
         }
 
@@ -237,29 +234,29 @@ internal class AndroidSystemUiController(
         }
         set(value) {
             if (value) {
-                windowInsetsController.show(WindowInsetsCompat.Type.navigationBars())
+                windowInsetsController?.show(WindowInsetsCompat.Type.navigationBars())
             } else {
-                windowInsetsController.hide(WindowInsetsCompat.Type.navigationBars())
+                windowInsetsController?.hide(WindowInsetsCompat.Type.navigationBars())
             }
         }
 
     override var statusBarDarkContentEnabled: Boolean
-        get() = windowInsetsController.isAppearanceLightStatusBars
+        get() = windowInsetsController?.isAppearanceLightStatusBars == true
         set(value) {
-            windowInsetsController.isAppearanceLightStatusBars = value
+            windowInsetsController?.isAppearanceLightStatusBars = value
         }
 
     override var navigationBarDarkContentEnabled: Boolean
-        get() = windowInsetsController.isAppearanceLightNavigationBars
+        get() = windowInsetsController?.isAppearanceLightNavigationBars == true
         set(value) {
-            windowInsetsController.isAppearanceLightNavigationBars = value
+            windowInsetsController?.isAppearanceLightNavigationBars = value
         }
 
     override var isNavigationBarContrastEnforced: Boolean
-        get() = Build.VERSION.SDK_INT >= 29 && window.isNavigationBarContrastEnforced
+        get() = Build.VERSION.SDK_INT >= 29 && window?.isNavigationBarContrastEnforced == true
         set(value) {
             if (Build.VERSION.SDK_INT >= 29) {
-                window.isNavigationBarContrastEnforced = value
+                window?.isNavigationBarContrastEnforced = value
             }
         }
 


### PR DESCRIPTION
This PR fixes #918 , where `@Preview` wasn't working with the `SystemUiController`.

The issues in this area (#881, #949) are fixed upstream in `androidx.core`, and should be available in the next release (and are available immediately in snapshot `8139767` and beyond). Those issues aren't directly fixed with this PR, so the `BEFORE` state will currently reproduce on API 30.

This PR just prepares for that update, where `ViewCompat.getWindowInsetsController` is the singular entry for `WindowInsetsControllerCompat` that will contain the workarounds.

BEFORE:

https://user-images.githubusercontent.com/4217560/151279075-a90b5dc7-0d8d-44fc-ab5a-47401fca5756.mp4


AFTER (with snapshot):

https://user-images.githubusercontent.com/4217560/151279079-54da2140-643a-45ba-a311-736d44a1a777.mp4


