### PR TITLE
[Webview] Make native webview fill parent WebView composable

### DIFF
--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -17,6 +17,7 @@
 package com.google.accompanist.web
 
 import android.graphics.Bitmap
+import android.view.ViewGroup
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -32,7 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
-import android.view.ViewGroup
 
 /**
  * A wrapper around the Android View WebView to provide a basic WebView composable.

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import android.view.ViewGroup
 
 /**
  * A wrapper around the Android View WebView to provide a basic WebView composable.
@@ -71,6 +72,11 @@ fun WebView(
         factory = { context ->
             WebView(context).apply {
                 onCreated(this)
+
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
 
                 webViewClient = object : WebViewClient() {
                     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {


### PR DESCRIPTION
I noticed that my web content does not fill the `WebView` composable completely. Instead, it wraps the content size. In my opinion the native webview should fill out the composable. So I simply added the `layoutParams`. What do you think?