### PR TITLE
[Permissions] Fix typo

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -36,7 +36,7 @@ private fun FeatureThatRequiresCameraPermission() {
         android.Manifest.permission.CAMERA
     )
 
-    when (state.status) {
+    when (cameraPermissionState.status) {
         // If the camera permission is granted, then show screen with the feature enabled
         PermissionStatus.Granted -> {
             Text("Camera permission Granted")

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -30,16 +30,33 @@ The following code exercises the [permission request workflow](https://developer
 ```kotlin
 @Composable
 private fun FeatureThatRequiresCameraPermission() {
-    val externalStoragePermissionState = rememberPermissionState(
-        android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+    // Camera permission state
+    val cameraPermissionState = rememberPermissionState(
+        android.Manifest.permission.CAMERA
     )
-
-    if (externalStoragePermissionState.hasPermission) {
-        /*Do stuff with the permission*/
-    } else {
-        /*Request permission with a [SideEffect]*/
-        SideEffect {
-            externalStoragePermissionState.launchPermissionRequest()
+    when (cameraPermissionState.status) {
+        // If the camera permission is granted, then show screen with the feature enabled
+        PermissionStatus.Granted -> {
+            Text("Camera permission Granted")
+        }
+        is PermissionStatus.Denied -> {
+            Column {
+                val textToShow = if (state.status.shouldShowRationale) {
+                    // If the user has denied the permission but the rationale can be shown,
+                    // then gently explain why the app requires this permission
+                    "The camera is important for this app. Please grant the permission."
+                } else {
+                    // If it's the first time the user lands on this feature, or the user
+                    // doesn't want to be asked again for this permission, explain that the
+                    // permission is required
+                    "Camera permission required for this feature to be available. " +
+                        "Please grant the permission"
+                }
+                Text(textToShow)
+                Button(onClick = { state.launchPermissionRequest() }) {
+                    Text("Request permission")
+                }
+            }
         }
     }
 }

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -55,7 +55,7 @@ private fun FeatureThatRequiresCameraPermission() {
                         "Please grant the permission"
                 }
                 Text(textToShow)
-                Button(onClick = { state.launchPermissionRequest() }) {
+                Button(onClick = { cameraPermissionState.launchPermissionRequest() }) {
                     Text("Request permission")
                 }
             }

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -35,7 +35,7 @@ private fun FeatureThatRequiresCameraPermission() {
     val cameraPermissionState = rememberPermissionState(
         android.Manifest.permission.CAMERA
     )
-    
+
     when (cameraPermissionState.status) {
         // If the camera permission is granted, then show screen with the feature enabled
         PermissionStatus.Granted -> {

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -30,36 +30,16 @@ The following code exercises the [permission request workflow](https://developer
 ```kotlin
 @Composable
 private fun FeatureThatRequiresCameraPermission() {
-
-    // Camera permission state
-    val cameraPermissionState = rememberPermissionState(
-        android.Manifest.permission.CAMERA
+    val externalStoragePermissionState = rememberPermissionState(
+        android.Manifest.permission.WRITE_EXTERNAL_STORAGE
     )
 
-    when (cameraPermissionState.status) {
-        // If the camera permission is granted, then show screen with the feature enabled
-        PermissionStatus.Granted -> {
-            Text("Camera permission Granted")
-        }
-        is PermissionStatus.Denied -> {
-            Column {
-                val textToShow = if (state.status.shouldShowRationale) {
-                    // If the user has denied the permission but the rationale can be shown,
-                    // then gently explain why the app requires this permission
-                    "The camera is important for this app. Please grant the permission."
-                } else {
-                    // If it's the first time the user lands on this feature, or the user
-                    // doesn't want to be asked again for this permission, explain that the
-                    // permission is required
-                    "Camera permission required for this feature to be available. " +
-                        "Please grant the permission"
-                }
-
-                Text(textToShow)
-                Button(onClick = { state.launchPermissionRequest() }) {
-                    Text("Request permission")
-                }
-            }
+    if (externalStoragePermissionState.hasPermission) {
+        /*Do stuff with the permission*/
+    } else {
+        /*Request permission with a [SideEffect]*/
+        SideEffect {
+            externalStoragePermissionState.launchPermissionRequest()
         }
     }
 }

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -43,7 +43,7 @@ private fun FeatureThatRequiresCameraPermission() {
         }
         is PermissionStatus.Denied -> {
             Column {
-                val textToShow = if (state.status.shouldShowRationale) {
+                val textToShow = if (cameraPermissionState.status.shouldShowRationale) {
                     // If the user has denied the permission but the rationale can be shown,
                     // then gently explain why the app requires this permission
                     "The camera is important for this app. Please grant the permission."

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -30,10 +30,12 @@ The following code exercises the [permission request workflow](https://developer
 ```kotlin
 @Composable
 private fun FeatureThatRequiresCameraPermission() {
+
     // Camera permission state
     val cameraPermissionState = rememberPermissionState(
         android.Manifest.permission.CAMERA
     )
+    
     when (cameraPermissionState.status) {
         // If the camera permission is granted, then show screen with the feature enabled
         PermissionStatus.Granted -> {


### PR DESCRIPTION
The `state` variable does not exist and might be confusing for the newcomers, thus it might be better to use `cameraPermissionState` in `when` statement.