### PR TITLE
[Pager] Upgrade to Snapper 0.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ compose-material-material = { module = "androidx.compose.material:material", ver
 compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
 compose-animation-animation = { module = "androidx.compose.animation:animation", version.ref = "compose" }
 
-snapper = "dev.chrisbanes.snapper:snapper:0.1.2"
+snapper = "dev.chrisbanes.snapper:snapper:0.2.0"
 
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.17.0"

--- a/pager/api/current.api
+++ b/pager/api/current.api
@@ -11,9 +11,13 @@ package com.google.accompanist.pager {
   }
 
   @com.google.accompanist.pager.ExperimentalPagerApi public final class PagerDefaults {
-    method @androidx.compose.runtime.Composable @dev.chrisbanes.snapper.ExperimentalSnapperApi public androidx.compose.foundation.gestures.FlingBehavior flingBehavior(com.google.accompanist.pager.PagerState state, optional androidx.compose.animation.core.DecayAnimationSpec<java.lang.Float> decayAnimationSpec, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> snapAnimationSpec, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> maximumFlingDistance, optional float endContentPadding);
-    method public kotlin.jvm.functions.Function1<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> getSinglePageFlingDistance();
-    property public final kotlin.jvm.functions.Function1<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> singlePageFlingDistance;
+    method @Deprecated @androidx.compose.runtime.Composable @dev.chrisbanes.snapper.ExperimentalSnapperApi public androidx.compose.foundation.gestures.FlingBehavior flingBehavior(com.google.accompanist.pager.PagerState state, optional androidx.compose.animation.core.DecayAnimationSpec<java.lang.Float> decayAnimationSpec, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> snapAnimationSpec, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> maximumFlingDistance, optional float endContentPadding);
+    method @androidx.compose.runtime.Composable @dev.chrisbanes.snapper.ExperimentalSnapperApi public androidx.compose.foundation.gestures.FlingBehavior flingBehavior(com.google.accompanist.pager.PagerState state, optional androidx.compose.animation.core.DecayAnimationSpec<java.lang.Float> decayAnimationSpec, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> snapAnimationSpec, optional float endContentPadding, kotlin.jvm.functions.Function3<? super dev.chrisbanes.snapper.SnapperLayoutInfo,? super java.lang.Integer,? super java.lang.Integer,java.lang.Integer> snapIndex);
+    method @androidx.compose.runtime.Composable @dev.chrisbanes.snapper.ExperimentalSnapperApi public androidx.compose.foundation.gestures.FlingBehavior flingBehavior(com.google.accompanist.pager.PagerState state, optional androidx.compose.animation.core.DecayAnimationSpec<java.lang.Float> decayAnimationSpec, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> snapAnimationSpec, optional float endContentPadding);
+    method @Deprecated public kotlin.jvm.functions.Function1<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> getSinglePageFlingDistance();
+    method public kotlin.jvm.functions.Function3<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Integer,java.lang.Integer,java.lang.Integer> getSinglePageSnapIndex();
+    property @Deprecated public final kotlin.jvm.functions.Function1<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> singlePageFlingDistance;
+    property public final kotlin.jvm.functions.Function3<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Integer,java.lang.Integer,java.lang.Integer> singlePageSnapIndex;
     field public static final com.google.accompanist.pager.PagerDefaults INSTANCE;
   }
 

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -74,10 +74,23 @@ object PagerDefaults {
      */
     @ExperimentalSnapperApi
     @Suppress("MemberVisibilityCanBePrivate")
+    @Deprecated("MaximumFlingDistance has been deprecated in Snapper")
     val singlePageFlingDistance: (SnapperLayoutInfo) -> Float = { layoutInfo ->
         // We can scroll up to the scrollable size of the lazy layout
         layoutInfo.endScrollOffset - layoutInfo.startScrollOffset.toFloat()
     }
+
+    /**
+     * The default implementation for the `snapIndex` parameter of
+     * [flingBehavior] which limits the fling distance to a single page.
+     */
+    @ExperimentalSnapperApi
+    val singlePageSnapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int =
+        { layoutInfo, startIndex, targetIndex ->
+            targetIndex
+                .coerceIn(startIndex - 1, startIndex + 1)
+                .coerceIn(0, layoutInfo.totalItemsCount - 1)
+        }
 
     /**
      * Remember the default [FlingBehavior] that represents the scroll curve.
@@ -95,6 +108,8 @@ object PagerDefaults {
      */
     @Composable
     @ExperimentalSnapperApi
+    @Deprecated("MaximumFlingDistance has been deprecated in Snapper, replaced with snapIndex")
+    @Suppress("DEPRECATION")
     fun flingBehavior(
         state: PagerState,
         decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
@@ -109,6 +124,75 @@ object PagerDefaults {
         maximumFlingDistance = maximumFlingDistance,
         endContentPadding = endContentPadding,
     )
+
+    /**
+     * Remember the default [FlingBehavior] that represents the scroll curve.
+     *
+     * Please remember to provide the correct [endContentPadding] if supplying your own
+     * [FlingBehavior] to [VerticalPager] or [HorizontalPager]. See those functions for how they
+     * calculate the value.
+     *
+     * @param state The [PagerState] to update.
+     * @param decayAnimationSpec The decay animation spec to use for decayed flings.
+     * @param snapAnimationSpec The animation spec to use when snapping.
+     * @param endContentPadding The amount of content padding on the end edge of the lazy list
+     * in pixels (end/bottom depending on the scrolling direction).
+     * @param snapIndex Block which returns the index to snap to. The block is provided with the
+     * [SnapperLayoutInfo], the index where the fling started, and the index which Snapper has
+     * determined is the correct target index. Callers can override this value to any valid index
+     * for the layout. Some common use cases include limiting the fling distance, and rounding up/down
+     * to achieve snapping to groups of items.
+     */
+    @Composable
+    @ExperimentalSnapperApi
+    fun flingBehavior(
+        state: PagerState,
+        decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
+        snapAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+        endContentPadding: Dp = 0.dp,
+        snapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int,
+    ): FlingBehavior = rememberSnapperFlingBehavior(
+        lazyListState = state.lazyListState,
+        snapOffsetForItem = SnapOffsets.Start, // pages are full width, so we use the simplest
+        decayAnimationSpec = decayAnimationSpec,
+        springAnimationSpec = snapAnimationSpec,
+        endContentPadding = endContentPadding,
+        snapIndex = snapIndex,
+    )
+
+    /**
+     * Remember the default [FlingBehavior] that represents the scroll curve.
+     *
+     * Please remember to provide the correct [endContentPadding] if supplying your own
+     * [FlingBehavior] to [VerticalPager] or [HorizontalPager]. See those functions for how they
+     * calculate the value.
+     *
+     * @param state The [PagerState] to update.
+     * @param decayAnimationSpec The decay animation spec to use for decayed flings.
+     * @param snapAnimationSpec The animation spec to use when snapping.
+     * @param endContentPadding The amount of content padding on the end edge of the lazy list
+     * in pixels (end/bottom depending on the scrolling direction).
+     */
+    @Composable
+    @ExperimentalSnapperApi
+    fun flingBehavior(
+        state: PagerState,
+        decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
+        snapAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
+        endContentPadding: Dp = 0.dp,
+    ): FlingBehavior {
+        // You might be wondering this is function exists rather than a default value for snapIndex
+        // above. It was done to remove overload ambiguity with the maximumFlingDistance overload
+        // below. When that function is removed, we also remove this function and move to a default
+        // param value.
+        return flingBehavior(
+            state = state,
+            decayAnimationSpec = decayAnimationSpec,
+            snapAnimationSpec = snapAnimationSpec,
+            endContentPadding = endContentPadding,
+            snapIndex = singlePageSnapIndex,
+        )
+    }
 }
 
 /**


### PR DESCRIPTION
Required deprecating one of the `flingBehavior` functions which use the deprecated `maximumFlingDistance` param.