### PR TITLE
[Web] Fix baseUrl causing HTML data not to load

### DIFF
--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -81,6 +81,52 @@ class WebTest {
     }
 
     @Test
+    fun testDataLoadedWithBaseUrl() {
+        lateinit var state: WebViewState
+
+        rule.setContent {
+            state = rememberWebViewStateWithHTMLData(
+                data = TEST_DATA,
+                baseUrl = "file:///android_asset/"
+            )
+            WebTestContent(
+                state,
+                idleResource
+            )
+        }
+
+        onWebView()
+            .withElement(findElement(Locator.TAG_NAME, "a"))
+            .check(webMatches(getText(), containsString(LINK_TEXT)))
+    }
+
+    @Test
+    fun testCanNavigateFromDataToUrl() {
+        lateinit var state: WebViewState
+
+        rule.setContent {
+            state = rememberWebViewStateWithHTMLData(
+                data = TEST_DATA,
+                baseUrl = "file:///android_asset/"
+            )
+            WebTestContent(
+                state,
+                idleResource
+            )
+        }
+
+        onWebView()
+            .withElement(findElement(Locator.ID, "link"))
+            .perform(webClick())
+
+        // Wait for the webview to load and then perform the check
+        rule.waitForIdle()
+        onWebView().check(webMatches(getCurrentUrl(), containsString(LINK_URL)))
+        assertThat(state.content.getCurrentUrl())
+            .isEqualTo(LINK_URL)
+    }
+
+    @Test
     fun testUrlLoaded() {
         lateinit var state: WebViewState
 

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -165,8 +165,8 @@ sealed class WebContent {
 
     fun getCurrentUrl(): String? {
         return when (this) {
-            is Url -> { url }
-            is Data -> { baseUrl }
+            is Url -> url
+            is Data -> baseUrl
         }
     }
 }

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -164,7 +164,10 @@ sealed class WebContent {
     data class Data(val data: String, val baseUrl: String? = null) : WebContent()
 
     fun getCurrentUrl(): String? {
-        return (this as? Url)?.url
+        return when (this) {
+            is Url -> { url }
+            is Data -> { baseUrl }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1037 

When providing a baseUrl to load html content relative to, it was being overriden during the update history call. This was due to the check assuming html data didn't have a URL when in fact it should be checking the baseUrl.

Added a test for this case

This brought up the edge case of navigating from html content with a baseurl to some other content, added a test to make sure that still works.