### PR TITLE
[Web] Expose progress as part of the loading state

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,3 +83,5 @@ android-tools-build-gradle = { module = "com.android.tools.build:gradle", versio
 android-tools-lint-lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 android-tools-lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 android-tools-lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
+
+squareup-mockwebserver = "com.squareup.okhttp3:mockwebserver:4.9.3"

--- a/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.sample.AccompanistSampleTheme
+import com.google.accompanist.web.LoadingState
 import com.google.accompanist.web.WebContent
 import com.google.accompanist.web.WebView
 import com.google.accompanist.web.rememberWebViewState
@@ -86,8 +87,12 @@ class BasicWebViewSample : ComponentActivity() {
                         }
                     }
 
-                    if (state.isLoading) {
-                        LinearProgressIndicator(Modifier.fillMaxWidth())
+                    val loadingState = state.loadingState
+                    if (loadingState is LoadingState.Loading) {
+                        LinearProgressIndicator(
+                            progress = loadingState.progress,
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
 
                     WebView(

--- a/web/api/current.api
+++ b/web/api/current.api
@@ -1,6 +1,21 @@
 // Signature format: 4.0
 package com.google.accompanist.web {
 
+  public abstract sealed class LoadingState {
+  }
+
+  public static final class LoadingState.Finished extends com.google.accompanist.web.LoadingState {
+    field public static final com.google.accompanist.web.LoadingState.Finished INSTANCE;
+  }
+
+  public static final class LoadingState.Loading extends com.google.accompanist.web.LoadingState {
+    ctor public LoadingState.Loading(float progress);
+    method public float component1();
+    method public com.google.accompanist.web.LoadingState.Loading copy(float progress);
+    method public float getProgress();
+    property public final float progress;
+  }
+
   public abstract sealed class WebContent {
     method public final String? getCurrentUrl();
   }
@@ -45,6 +60,7 @@ package com.google.accompanist.web {
     ctor public WebViewState(com.google.accompanist.web.WebContent webContent);
     method public com.google.accompanist.web.WebContent getContent();
     method public androidx.compose.runtime.snapshots.SnapshotStateList<com.google.accompanist.web.WebViewError> getErrorsForCurrentRequest();
+    method public com.google.accompanist.web.LoadingState getLoadingState();
     method public android.graphics.Bitmap? getPageIcon();
     method public String? getPageTitle();
     method public boolean isLoading();
@@ -52,6 +68,7 @@ package com.google.accompanist.web {
     property public final com.google.accompanist.web.WebContent content;
     property public final androidx.compose.runtime.snapshots.SnapshotStateList<com.google.accompanist.web.WebViewError> errorsForCurrentRequest;
     property public final boolean isLoading;
+    property public final com.google.accompanist.web.LoadingState loadingState;
     property public final android.graphics.Bitmap? pageIcon;
     property public final String? pageTitle;
   }

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -113,6 +113,8 @@ dependencies {
 
     testImplementation libs.androidx.test.espressoWeb
     androidTestImplementation libs.androidx.test.espressoWeb
+
+    androidTestImplementation libs.squareup.mockwebserver
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/web/src/androidTest/AndroidManifest.xml
+++ b/web/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2021 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.google.accompanist.web">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
+    <application android:usesCleartextTraffic="true" />
+
+</manifest>

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -47,6 +47,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 // Emulator image doesn't have a WebView until API 26
@@ -290,7 +291,8 @@ class WebTest {
         lateinit var state: WebViewState
 
         val mockServer = MockWebServer()
-        mockServer.enqueue(MockResponse().setBody("Test"))
+        // Simulate time spent loading
+        mockServer.enqueue(MockResponse().setBody("Test").setBodyDelay(1, TimeUnit.SECONDS))
         mockServer.start()
         val baseUrl = mockServer.url("/")
 
@@ -307,7 +309,7 @@ class WebTest {
             WebTestContent(webViewState = state, idlingResource = idleResource)
         }
 
-        rule.waitUntil { collectedLoadingStates.any { it is LoadingState.Loading } }
+        rule.waitUntil(3_000) { collectedLoadingStates.any { it is LoadingState.Loading } }
         rule.waitForIdle()
 
         assertThat(collectedLoadingStates.first()).isInstanceOf(LoadingState.Finished::class.java)

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -301,7 +301,7 @@ private fun WebTestContent(
     webViewState: WebViewState,
     idlingResource: WebViewIdlingResource
 ) {
-    idlingResource.webviewLoading = webViewState.isLoading
+    idlingResource.webviewLoading = webViewState.loadingState !is WebViewState.Finished
 
     MaterialTheme {
         WebView(


### PR DESCRIPTION
- Swap out the boolean for a `LoadingState` sealed class with a progress value
- Add test for loading state

MockWebServer was used to ensure an adequate turnaround time for the loading state to actually pass through the `Started` state. By using the same technique as other tests it never left `Finished`. I tried using HTML with meta tags to turn off any sort of caching but never saw the expected `Finished -> Started (*n) -> Finished` sequence.

Will likely conflict with https://github.com/google/accompanist/pull/1029 so I'll deal with that once things one or the other is merged.
