### PR TITLE
[Pager] Fix precision loss in page offset calculation for large indexes

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -521,5 +521,5 @@ private class PagerScopeImpl(
  */
 @ExperimentalPagerApi
 fun PagerScope.calculateCurrentOffsetForPage(page: Int): Float {
-    return (currentPage + currentPageOffset) - page
+    return (currentPage - page) + currentPageOffset
 }


### PR DESCRIPTION
Fixes #945

Modified order of operands in `PagerScope.calculateCurrentOffsetForPage` to avoid precision loss when adding the page offset to a very large index, which results on this method always returning `0.0`. A typical scenario where this issue will occur is when recreating an infinite pager by setting a large number as pager count (which is the approach suggested in [this sample](https://github.com/google/accompanist/blob/main/sample/src/main/java/com/google/accompanist/sample/pager/HorizontalPagerLoopingSample.kt)).

