### PR TITLE
[Web] Navigation Controls

### DIFF
--- a/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
@@ -27,10 +27,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,6 +47,7 @@ import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.web.LoadingState
 import com.google.accompanist.web.WebContent
 import com.google.accompanist.web.WebView
+import com.google.accompanist.web.rememberWebViewNavigator
 import com.google.accompanist.web.rememberWebViewState
 
 class BasicWebViewSample : ComponentActivity() {
@@ -52,11 +57,26 @@ class BasicWebViewSample : ComponentActivity() {
         setContent {
             AccompanistSampleTheme {
                 val state = rememberWebViewState(url = "https://google.com")
+                val navigator = rememberWebViewNavigator()
                 val (textFieldValue, setTextFieldValue) = remember(state.content) {
                     mutableStateOf(state.content.getCurrentUrl() ?: "")
                 }
 
                 Column {
+                    TopAppBar(
+                        title = { Text(text = "WebView Sample") },
+                        navigationIcon = {
+                            if (navigator.canGoBack) {
+                                IconButton(onClick = { navigator.navigateBack() }) {
+                                    Icon(
+                                        imageVector = Icons.Default.ArrowBack,
+                                        contentDescription = "Back"
+                                    )
+                                }
+                            }
+                        }
+                    )
+
                     Row {
                         Box(modifier = Modifier.weight(1f)) {
                             if (state.errorsForCurrentRequest.isNotEmpty()) {
@@ -98,6 +118,7 @@ class BasicWebViewSample : ComponentActivity() {
                     WebView(
                         state = state,
                         modifier = Modifier.weight(1f),
+                        navigator = navigator,
                         onCreated = { webView ->
                             webView.settings.javaScriptEnabled = true
                         }

--- a/web/api/current.api
+++ b/web/api/current.api
@@ -51,9 +51,22 @@ package com.google.accompanist.web {
   }
 
   public final class WebViewKt {
-    method @androidx.compose.runtime.Composable public static void WebView(com.google.accompanist.web.WebViewState state, optional androidx.compose.ui.Modifier modifier, optional boolean captureBackPresses, optional kotlin.jvm.functions.Function1<? super android.webkit.WebView,kotlin.Unit> onCreated, optional kotlin.jvm.functions.Function2<? super android.webkit.WebResourceRequest,? super android.webkit.WebResourceError,kotlin.Unit> onError);
+    method @androidx.compose.runtime.Composable public static void WebView(com.google.accompanist.web.WebViewState state, optional androidx.compose.ui.Modifier modifier, optional boolean captureBackPresses, optional com.google.accompanist.web.WebViewNavigator navigator, optional kotlin.jvm.functions.Function1<? super android.webkit.WebView,kotlin.Unit> onCreated, optional kotlin.jvm.functions.Function2<? super android.webkit.WebResourceRequest,? super android.webkit.WebResourceError,kotlin.Unit> onError);
+    method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewNavigator rememberWebViewNavigator(optional kotlinx.coroutines.CoroutineScope coroutineScope);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewState(String url);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewStateWithHTMLData(String data, optional String? baseUrl);
+  }
+
+  @androidx.compose.runtime.Stable public final class WebViewNavigator {
+    ctor public WebViewNavigator(kotlinx.coroutines.CoroutineScope coroutineScope);
+    method public boolean getCanGoBack();
+    method public boolean getCanGoForward();
+    method public void navigateBack();
+    method public void navigateForward();
+    method public void reload();
+    method public void stopLoading();
+    property public final boolean canGoBack;
+    property public final boolean canGoForward;
   }
 
   @androidx.compose.runtime.Stable public final class WebViewState {


### PR DESCRIPTION
Currently this is just an early proof of concept, implementing the ability to control web view navigation from outside the composable (e.g. for wiring up a `TopAppBar` "up" button to the WebView's `goBack()` method).

I figured it would be good to get some general feedback on this implementation in an early stage before going ahead with docs, tests, etc.

I figured that this stuff made more sense as its own class outside of `WebViewState` as it's a case that not everyone will have to override, and because it's more "action" oriented than "state" oriented. This implementation also seems a bit more along the lines of similar constructs elsewhere in Compose like `InteractionSource`