### PR TITLE
[Pager Indicators] Add option to increase the size of the active page indicator

### DIFF
--- a/pager-indicators/api/current.api
+++ b/pager-indicators/api/current.api
@@ -2,8 +2,8 @@
 package com.google.accompanist.pager {
 
   public final class PagerIndicatorKt {
-    method @androidx.compose.runtime.Composable @com.google.accompanist.pager.ExperimentalPagerApi public static void HorizontalPagerIndicator(com.google.accompanist.pager.PagerState pagerState, optional androidx.compose.ui.Modifier modifier, optional long activeColor, optional long inactiveColor, optional float indicatorWidth, optional float indicatorHeight, optional float spacing, optional androidx.compose.ui.graphics.Shape indicatorShape);
-    method @androidx.compose.runtime.Composable @com.google.accompanist.pager.ExperimentalPagerApi public static void VerticalPagerIndicator(com.google.accompanist.pager.PagerState pagerState, optional androidx.compose.ui.Modifier modifier, optional long activeColor, optional long inactiveColor, optional float indicatorHeight, optional float indicatorWidth, optional float spacing, optional androidx.compose.ui.graphics.Shape indicatorShape);
+    method @androidx.compose.runtime.Composable @com.google.accompanist.pager.ExperimentalPagerApi public static void HorizontalPagerIndicator(com.google.accompanist.pager.PagerState pagerState, optional androidx.compose.ui.Modifier modifier, optional long activeColor, optional long inactiveColor, optional float indicatorWidth, optional float indicatorHeight, optional float spacing, optional androidx.compose.ui.graphics.Shape indicatorShape, optional @FloatRange(from=1.0) float activeIndicatorScale);
+    method @androidx.compose.runtime.Composable @com.google.accompanist.pager.ExperimentalPagerApi public static void VerticalPagerIndicator(com.google.accompanist.pager.PagerState pagerState, optional androidx.compose.ui.Modifier modifier, optional long activeColor, optional long inactiveColor, optional float indicatorHeight, optional float indicatorWidth, optional float spacing, optional androidx.compose.ui.graphics.Shape indicatorShape, optional @FloatRange(from=1.0) float activeIndicatorScale);
   }
 
   public final class PagerTabKt {

--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
@@ -16,6 +16,7 @@
 
 package com.google.accompanist.pager
 
+import androidx.annotation.FloatRange
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,6 +31,7 @@ import androidx.compose.material.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalDensity
@@ -55,6 +57,7 @@ import androidx.compose.ui.unit.dp
  * @param indicatorHeight the height of each indicator in [Dp]. Defaults to [indicatorWidth].
  * @param spacing the spacing between each indicator in [Dp].
  * @param indicatorShape the shape representing each indicator. This defaults to [CircleShape].
+ * @param activeIndicatorScale the scale to apply to the active page indicator.
  */
 @ExperimentalPagerApi
 @Composable
@@ -67,6 +70,7 @@ fun HorizontalPagerIndicator(
     indicatorHeight: Dp = indicatorWidth,
     spacing: Dp = indicatorWidth,
     indicatorShape: Shape = CircleShape,
+    @FloatRange(from = 1.0) activeIndicatorScale: Float = 1f,
 ) {
 
     val indicatorWidthPx = LocalDensity.current.run { indicatorWidth.roundToPx() }
@@ -100,6 +104,7 @@ fun HorizontalPagerIndicator(
                     )
                 }
                 .size(width = indicatorWidth, height = indicatorHeight)
+                .scale(activeIndicatorScale)
                 .background(
                     color = activeColor,
                     shape = indicatorShape,
@@ -126,6 +131,7 @@ fun HorizontalPagerIndicator(
  * @param indicatorWidth the width of each indicator in [Dp]. Defaults to [indicatorHeight].
  * @param spacing the spacing between each indicator in [Dp].
  * @param indicatorShape the shape representing each indicator. This defaults to [CircleShape].
+ * @param activeIndicatorScale the scale to apply to the active page indicator.
  */
 @ExperimentalPagerApi
 @Composable
@@ -138,6 +144,7 @@ fun VerticalPagerIndicator(
     indicatorWidth: Dp = indicatorHeight,
     spacing: Dp = indicatorHeight,
     indicatorShape: Shape = CircleShape,
+    @FloatRange(from = 1.0) activeIndicatorScale: Float = 1f,
 ) {
 
     val indicatorHeightPx = LocalDensity.current.run { indicatorHeight.roundToPx() }
@@ -171,6 +178,7 @@ fun VerticalPagerIndicator(
                     )
                 }
                 .size(width = indicatorWidth, height = indicatorHeight)
+                .scale(activeIndicatorScale)
                 .background(
                     color = activeColor,
                     shape = indicatorShape,


### PR DESCRIPTION
Adds an option to both the horizontal and vertical pager indicators to increase the scale of the active page indicator.

This is useful for accessibility enhancements to ensure that color is not the only indicator of page change (WCAG 2 SC 1.4.1)

Examples:

<img src="https://user-images.githubusercontent.com/98061948/158307222-8a247c27-46d3-46f6-9857-76d2453cb98b.png" width="200px">

<img src="https://user-images.githubusercontent.com/98061948/158307229-592701bd-ba94-418e-b6d1-c3420b4bb1f9.png" width="200px">