### PR TITLE
[WebView] Add additionalHttpHeaders to WebContent.Url

### DIFF
--- a/web/api/current.api
+++ b/web/api/current.api
@@ -49,10 +49,13 @@ package com.google.accompanist.web {
   }
 
   public static final class WebContent.Url extends com.google.accompanist.web.WebContent {
-    ctor public WebContent.Url(String url);
+    ctor public WebContent.Url(String url, optional java.util.Map<java.lang.String,java.lang.String> additionalHttpHeaders);
     method public String component1();
-    method public com.google.accompanist.web.WebContent.Url copy(String url);
+    method public java.util.Map<java.lang.String,java.lang.String> component2();
+    method public com.google.accompanist.web.WebContent.Url copy(String url, java.util.Map<java.lang.String,java.lang.String> additionalHttpHeaders);
+    method public java.util.Map<java.lang.String,java.lang.String> getAdditionalHttpHeaders();
     method public String getUrl();
+    property public final java.util.Map<java.lang.String,java.lang.String> additionalHttpHeaders;
     property public final String url;
   }
 
@@ -70,7 +73,7 @@ package com.google.accompanist.web {
   public final class WebViewKt {
     method @androidx.compose.runtime.Composable public static void WebView(com.google.accompanist.web.WebViewState state, optional androidx.compose.ui.Modifier modifier, optional boolean captureBackPresses, optional com.google.accompanist.web.WebViewNavigator navigator, optional kotlin.jvm.functions.Function1<? super android.webkit.WebView,kotlin.Unit> onCreated, optional com.google.accompanist.web.AccompanistWebViewClient client, optional com.google.accompanist.web.AccompanistWebChromeClient chromeClient);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewNavigator rememberWebViewNavigator(optional kotlinx.coroutines.CoroutineScope coroutineScope);
-    method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewState(String url);
+    method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewState(String url, optional java.util.Map<java.lang.String,java.lang.String> additionalHttpHeaders);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewStateWithHTMLData(String data, optional String? baseUrl);
   }
 

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -537,7 +537,7 @@ class WebTest {
             )
         }
 
-        rule.waitUntil(3_000) { collectedLoadingStates.any { it is LoadingState.Finished } }
+        rule.waitUntil(5_000) { collectedLoadingStates.any { it is LoadingState.Finished } }
         rule.waitForIdle()
 
         val request = mockServer.takeRequest()

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -509,13 +509,12 @@ class WebTest {
         assertThat(navigator.canGoForward).isTrue()
     }
 
+    @FlakyTest
     @Test
     fun testAdditionalHttpHeaders() {
         val mockServer = MockWebServer()
         mockServer.start()
         val baseUrl = mockServer.url("/")
-
-        val collectedLoadingStates = mutableListOf<LoadingState>()
 
         rule.setContent {
             val state = rememberWebViewState(
@@ -526,18 +525,12 @@ class WebTest {
                 )
             )
 
-            LaunchedEffect(state) {
-                snapshotFlow { state.loadingState }
-                    .toCollection(collectedLoadingStates)
-            }
-
             WebTestContent(
                 webViewState = state,
                 idlingResource = idleResource,
             )
         }
 
-        rule.waitUntil(5_000) { collectedLoadingStates.any { it is LoadingState.Finished } }
         rule.waitForIdle()
 
         val request = mockServer.takeRequest()

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -509,11 +509,14 @@ class WebTest {
         assertThat(navigator.canGoForward).isTrue()
     }
 
+    @FlakyTest(detail = "https://github.com/google/accompanist/issues/1085")
     @Test
     fun testAdditionalHttpHeaders() {
         val mockServer = MockWebServer()
         mockServer.start()
         val baseUrl = mockServer.url("/")
+
+        val collectedLoadingStates = mutableListOf<LoadingState>()
 
         rule.setContent {
             val state = rememberWebViewState(
@@ -524,12 +527,18 @@ class WebTest {
                 )
             )
 
+            LaunchedEffect(state) {
+                snapshotFlow { state.loadingState }
+                    .toCollection(collectedLoadingStates)
+            }
+
             WebTestContent(
                 webViewState = state,
                 idlingResource = idleResource,
             )
         }
 
+        rule.waitUntil(3_000) { collectedLoadingStates.any { it is LoadingState.Finished } }
         rule.waitForIdle()
 
         val request = mockServer.takeRequest()

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -509,7 +509,6 @@ class WebTest {
         assertThat(navigator.canGoForward).isTrue()
     }
 
-    @FlakyTest(detail = "https://github.com/google/accompanist/issues/1085")
     @Test
     fun testAdditionalHttpHeaders() {
         val mockServer = MockWebServer()

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -509,6 +509,37 @@ class WebTest {
         assertThat(navigator.canGoForward).isTrue()
     }
 
+    @Test
+    fun testAdditionalHttpHeaders() {
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val baseUrl = mockServer.url("/")
+
+        rule.setContent {
+            val state = rememberWebViewState(
+                url = baseUrl.toString(),
+                additionalHttpHeaders = mapOf(
+                    "first-additional-header" to "first",
+                    "second-additional-header" to "second",
+                )
+            )
+
+            WebTestContent(
+                webViewState = state,
+                idlingResource = idleResource,
+            )
+        }
+
+        rule.waitForIdle()
+
+        val request = mockServer.takeRequest()
+
+        assertThat(request.getHeader("first-additional-header")).isEqualTo("first")
+        assertThat(request.getHeader("second-additional-header")).isEqualTo("second")
+
+        mockServer.shutdown()
+    }
+
     private val webNode: SemanticsNodeInteraction
         get() = rule.onNodeWithTag(WebViewTag)
 }

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -110,7 +110,7 @@ fun WebView(
 
                 if (url.isNotEmpty() && url != view.url) {
                     if (content.additionalHttpHeaders != null) {
-                        view.loadUrl(url, content.additionalHttpHeaders)
+                        view.loadUrl(url, content.additionalHttpHeaders.toMutableMap())
                     } else {
                         view.loadUrl(url)
                     }

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -109,11 +108,7 @@ fun WebView(
                 val url = content.url
 
                 if (url.isNotEmpty() && url != view.url) {
-                    if (content.additionalHttpHeaders != null) {
-                        view.loadUrl(url, content.additionalHttpHeaders.toMutableMap())
-                    } else {
-                        view.loadUrl(url)
-                    }
+                    view.loadUrl(url, content.additionalHttpHeaders.toMutableMap())
                 }
             }
             is WebContent.Data -> {
@@ -232,7 +227,7 @@ open class AccompanistWebChromeClient : WebChromeClient() {
 sealed class WebContent {
     data class Url(
         val url: String,
-        val additionalHttpHeaders: Map<String, String>? = null,
+        val additionalHttpHeaders: Map<String, String> = emptyMap(),
     ) : WebContent()
 
     data class Data(val data: String, val baseUrl: String? = null) : WebContent()
@@ -408,7 +403,7 @@ data class WebViewError(
  * @param url The url to load in the WebView
  */
 @Composable
-fun rememberWebViewState(url: String, additionalHttpHeaders: Map<String, String>? = null) =
+fun rememberWebViewState(url: String, additionalHttpHeaders: Map<String, String> = emptyMap()) =
     remember(url, additionalHttpHeaders) {
         WebViewState(
             WebContent.Url(

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -171,7 +171,7 @@ open class AccompanistWebViewClient : WebViewClient() {
             !url.startsWith("data:text/html") &&
             state.content.getCurrentUrl() != url
         ) {
-            state.content = WebContent.Url(url)
+            state.content = state.content.withUrl(url)
         }
     }
 
@@ -194,8 +194,7 @@ open class AccompanistWebViewClient : WebViewClient() {
         // Override all url loads to make the single source of truth
         // of the URL the state holder Url
         request?.let {
-            val content = WebContent.Url(it.url.toString())
-            state.content = content
+            state.content = state.content.withUrl(it.url.toString())
         }
         return true
     }
@@ -244,6 +243,11 @@ sealed class WebContent {
             is Data -> baseUrl
         }
     }
+}
+
+internal fun WebContent.withUrl(url: String) = when (this) {
+    is WebContent.Url -> copy(url = url)
+    else -> WebContent.Url(url)
 }
 
 /**

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -109,7 +109,11 @@ fun WebView(
                 val url = content.url
 
                 if (url.isNotEmpty() && url != view.url) {
-                    view.loadUrl(url)
+                    if (content.additionalHttpHeaders != null) {
+                        view.loadUrl(url, content.additionalHttpHeaders)
+                    } else {
+                        view.loadUrl(url)
+                    }
                 }
             }
             is WebContent.Data -> {
@@ -227,7 +231,11 @@ open class AccompanistWebChromeClient : WebChromeClient() {
 }
 
 sealed class WebContent {
-    data class Url(val url: String) : WebContent()
+    data class Url(
+        val url: String,
+        val additionalHttpHeaders: Map<String, String>? = null,
+    ) : WebContent()
+
     data class Data(val data: String, val baseUrl: String? = null) : WebContent()
 
     fun getCurrentUrl(): String? {
@@ -396,8 +404,15 @@ data class WebViewError(
  * @param url The url to load in the WebView
  */
 @Composable
-fun rememberWebViewState(url: String) =
-    remember(url) { WebViewState(WebContent.Url(url)) }
+fun rememberWebViewState(url: String, additionalHttpHeaders: Map<String, String>? = null) =
+    remember(url, additionalHttpHeaders) {
+        WebViewState(
+            WebContent.Url(
+                url = url,
+                additionalHttpHeaders = additionalHttpHeaders
+            )
+        )
+    }
 
 /**
  * Creates a WebView state that is remembered across Compositions.

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -401,6 +401,8 @@ data class WebViewError(
  * Creates a WebView state that is remembered across Compositions.
  *
  * @param url The url to load in the WebView
+ * @param additionalHttpHeaders Optional, additional HTTP headers that are passed to [WebView.loadUrl].
+ *                              Note that these headers are used for all subsequent requests of the WebView.
  */
 @Composable
 fun rememberWebViewState(url: String, additionalHttpHeaders: Map<String, String> = emptyMap()) =


### PR DESCRIPTION
I have a use case where I need to pass additional HTTP headers to `WebView.loadUrl()`.

While extending `WebContent.Url` I noticed that `state.content` is reassigned in several callback methods of `WebViewClient`, for example in `shouldOverrideUrlLoading()`. While `additionalHttpHeaders` are used for the initial `loadUrl()` call, this means that the state property `additionalHttpHeaders` is lost on reassignment. I'm not sure if this poses an issue and if so how to handle this situation.