### PR TITLE
[Web] Add a method to expose WebViewClient and WebChromeClient

### DIFF
--- a/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
@@ -17,7 +17,10 @@
 package com.google.accompanist.sample.webview
 
 import android.annotation.SuppressLint
+import android.graphics.Bitmap
 import android.os.Bundle
+import android.util.Log
+import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
@@ -44,6 +47,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.sample.AccompanistSampleTheme
+import com.google.accompanist.web.AccompanistWebViewClient
 import com.google.accompanist.web.LoadingState
 import com.google.accompanist.web.WebContent
 import com.google.accompanist.web.WebView
@@ -115,13 +119,22 @@ class BasicWebViewSample : ComponentActivity() {
                         )
                     }
 
+                    // A custom WebViewClient and WebChromeClient can be provided via subclassing
+                    val webClient = object : AccompanistWebViewClient() {
+                        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                            super.onPageStarted(view, url, favicon)
+                            Log.d("Accompanist WebView", "Page started loading for $url")
+                        }
+                    }
+
                     WebView(
                         state = state,
                         modifier = Modifier.weight(1f),
                         navigator = navigator,
                         onCreated = { webView ->
                             webView.settings.javaScriptEnabled = true
-                        }
+                        },
+                        client = webClient
                     )
                 }
             }

--- a/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
@@ -120,10 +120,16 @@ class BasicWebViewSample : ComponentActivity() {
                     }
 
                     // A custom WebViewClient and WebChromeClient can be provided via subclassing
-                    val webClient = object : AccompanistWebViewClient() {
-                        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                            super.onPageStarted(view, url, favicon)
-                            Log.d("Accompanist WebView", "Page started loading for $url")
+                    val webClient = remember {
+                        object : AccompanistWebViewClient() {
+                            override fun onPageStarted(
+                                view: WebView?,
+                                url: String?,
+                                favicon: Bitmap?
+                            ) {
+                                super.onPageStarted(view, url, favicon)
+                                Log.d("Accompanist WebView", "Page started loading for $url")
+                            }
                         }
                     }
 

--- a/web/api/current.api
+++ b/web/api/current.api
@@ -1,6 +1,14 @@
 // Signature format: 4.0
 package com.google.accompanist.web {
 
+  public class AccompanistWebChromeClient extends android.webkit.WebChromeClient {
+    ctor public AccompanistWebChromeClient();
+  }
+
+  public class AccompanistWebViewClient extends android.webkit.WebViewClient {
+    ctor public AccompanistWebViewClient();
+  }
+
   public abstract sealed class LoadingState {
   }
 
@@ -51,7 +59,7 @@ package com.google.accompanist.web {
   }
 
   public final class WebViewKt {
-    method @androidx.compose.runtime.Composable public static void WebView(com.google.accompanist.web.WebViewState state, optional androidx.compose.ui.Modifier modifier, optional boolean captureBackPresses, optional com.google.accompanist.web.WebViewNavigator navigator, optional kotlin.jvm.functions.Function1<? super android.webkit.WebView,kotlin.Unit> onCreated, optional kotlin.jvm.functions.Function2<? super android.webkit.WebResourceRequest,? super android.webkit.WebResourceError,kotlin.Unit> onError);
+    method @androidx.compose.runtime.Composable public static void WebView(com.google.accompanist.web.WebViewState state, optional androidx.compose.ui.Modifier modifier, optional boolean captureBackPresses, optional com.google.accompanist.web.WebViewNavigator navigator, optional kotlin.jvm.functions.Function1<? super android.webkit.WebView,kotlin.Unit> onCreated, optional com.google.accompanist.web.AccompanistWebViewClient client, optional com.google.accompanist.web.AccompanistWebChromeClient chromeClient);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewNavigator rememberWebViewNavigator(optional kotlinx.coroutines.CoroutineScope coroutineScope);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewState(String url);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewStateWithHTMLData(String data, optional String? baseUrl);

--- a/web/api/current.api
+++ b/web/api/current.api
@@ -3,10 +3,19 @@ package com.google.accompanist.web {
 
   public class AccompanistWebChromeClient extends android.webkit.WebChromeClient {
     ctor public AccompanistWebChromeClient();
+    method public com.google.accompanist.web.WebViewState getState();
+    property public com.google.accompanist.web.WebViewState state;
+    field public com.google.accompanist.web.WebViewState state;
   }
 
   public class AccompanistWebViewClient extends android.webkit.WebViewClient {
     ctor public AccompanistWebViewClient();
+    method public com.google.accompanist.web.WebViewNavigator getNavigator();
+    method public com.google.accompanist.web.WebViewState getState();
+    property public com.google.accompanist.web.WebViewNavigator navigator;
+    property public com.google.accompanist.web.WebViewState state;
+    field public com.google.accompanist.web.WebViewNavigator navigator;
+    field public com.google.accompanist.web.WebViewState state;
   }
 
   public abstract sealed class LoadingState {

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -21,6 +21,7 @@ import android.webkit.WebView
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -529,8 +530,8 @@ private fun WebTestContent(
     webViewState: WebViewState,
     idlingResource: WebViewIdlingResource,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
-    client: AccompanistWebViewClient = AccompanistWebViewClient(),
-    chromeClient: AccompanistWebChromeClient = AccompanistWebChromeClient()
+    client: AccompanistWebViewClient = remember { AccompanistWebViewClient() },
+    chromeClient: AccompanistWebChromeClient = remember { AccompanistWebChromeClient() }
 ) {
     idlingResource.webviewLoading = webViewState.loadingState !is LoadingState.Finished
 

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -57,8 +57,8 @@ import kotlinx.coroutines.withContext
  * @param onCreated Called when the WebView is first created, this can be used to set additional
  * settings on the WebView. WebChromeClient and WebViewClient should not be set here as they will be
  * subsequently overwritten after this lambda is called.
- * @param onError Called when the WebView encounters an error. Forwarded event from the
- * WebViewClient
+ * @param client Provides access to WebViewClient via subclassing
+ * @param chromeClient Provides access to WebChromeClient via subclassing
  * @sample com.google.accompanist.sample.webview.BasicWebViewSample
  */
 @Composable
@@ -68,7 +68,8 @@ fun WebView(
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
     onCreated: (WebView) -> Unit = {},
-    onError: (request: WebResourceRequest?, error: WebResourceError?) -> Unit = { _, _ -> }
+    client: AccompanistWebViewClient = AccompanistWebViewClient(),
+    chromeClient: AccompanistWebChromeClient = AccompanistWebChromeClient()
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
 
@@ -90,87 +91,15 @@ fun WebView(
                     ViewGroup.LayoutParams.MATCH_PARENT
                 )
 
-                webChromeClient = object : WebChromeClient() {
-                    override fun onReceivedTitle(view: WebView?, title: String?) {
-                        super.onReceivedTitle(view, title)
-                        state.pageTitle = title
-                    }
+                // Set the state of the client and chrome client
+                // This is done internally to ensure they always are the same instance as the
+                // parent Web composable
+                client.state = state
+                client.navigator = navigator
+                chromeClient.state = state
 
-                    override fun onReceivedIcon(view: WebView?, icon: Bitmap?) {
-                        super.onReceivedIcon(view, icon)
-                        state.pageIcon = icon
-                    }
-
-                    override fun onProgressChanged(view: WebView?, newProgress: Int) {
-                        super.onProgressChanged(view, newProgress)
-                        if (state.loadingState is LoadingState.Finished) return
-                        state.loadingState = LoadingState.Loading(newProgress / 100.0f)
-                    }
-                }
-
-                webViewClient = object : WebViewClient() {
-                    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                        super.onPageStarted(view, url, favicon)
-                        state.loadingState = LoadingState.Loading(0.0f)
-                        state.errorsForCurrentRequest.clear()
-                        state.pageTitle = null
-                        state.pageIcon = null
-                    }
-
-                    override fun onPageFinished(view: WebView?, url: String?) {
-                        super.onPageFinished(view, url)
-                        state.loadingState = LoadingState.Finished
-                        navigator.canGoBack = view?.canGoBack() ?: false
-                        navigator.canGoForward = view?.canGoForward() ?: false
-                    }
-
-                    override fun doUpdateVisitedHistory(
-                        view: WebView?,
-                        url: String?,
-                        isReload: Boolean
-                    ) {
-                        super.doUpdateVisitedHistory(view, url, isReload)
-                        // WebView will often update the current url itself.
-                        // This happens in situations like redirects and navigating through
-                        // history. We capture this change and update our state holder url.
-                        // On older APIs (28 and lower), this method is called when loading
-                        // html data. We don't want to update the state in this case as that will
-                        // overwrite the html being loaded.
-                        if (url != null &&
-                            !url.startsWith("data:text/html") &&
-                            state.content.getCurrentUrl() != url
-                        ) {
-                            state.content = WebContent.Url(url)
-                        }
-                    }
-
-                    override fun onReceivedError(
-                        view: WebView?,
-                        request: WebResourceRequest?,
-                        error: WebResourceError?
-                    ) {
-                        super.onReceivedError(view, request, error)
-
-                        if (error != null) {
-                            state.errorsForCurrentRequest.add(WebViewError(request, error))
-                        }
-
-                        onError(request, error)
-                    }
-
-                    override fun shouldOverrideUrlLoading(
-                        view: WebView?,
-                        request: WebResourceRequest?
-                    ): Boolean {
-                        // Override all url loads to make the single source of truth
-                        // of the URL the state holder Url
-                        request?.let {
-                            val content = WebContent.Url(it.url.toString())
-                            state.content = content
-                        }
-                        return true
-                    }
-                }
+                webChromeClient = chromeClient
+                webViewClient = client
             }.also { webView = it }
         },
         modifier = modifier
@@ -190,6 +119,107 @@ fun WebView(
 
         navigator.canGoBack = view.canGoBack()
         navigator.canGoForward = view.canGoForward()
+    }
+}
+
+/**
+ * AccompanistWebViewClient
+ *
+ * A parent class implementation of WebViewClient that can be subclassed to add custom behaviour.
+ *
+ * As Accompanist Web needs to set its own web client to function, it provides this intermediary
+ * class that can be overriden if further custom behaviour is required.
+ */
+open class AccompanistWebViewClient : WebViewClient() {
+    internal lateinit var state: WebViewState
+    internal lateinit var navigator: WebViewNavigator
+
+    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+        super.onPageStarted(view, url, favicon)
+        state.loadingState = LoadingState.Loading(0.0f)
+        state.errorsForCurrentRequest.clear()
+        state.pageTitle = null
+        state.pageIcon = null
+    }
+
+    override fun onPageFinished(view: WebView?, url: String?) {
+        super.onPageFinished(view, url)
+        state.loadingState = LoadingState.Finished
+        navigator.canGoBack = view?.canGoBack() ?: false
+        navigator.canGoForward = view?.canGoForward() ?: false
+    }
+
+    override fun doUpdateVisitedHistory(
+        view: WebView?,
+        url: String?,
+        isReload: Boolean
+    ) {
+        super.doUpdateVisitedHistory(view, url, isReload)
+        // WebView will often update the current url itself.
+        // This happens in situations like redirects and navigating through
+        // history. We capture this change and update our state holder url.
+        // On older APIs (28 and lower), this method is called when loading
+        // html data. We don't want to update the state in this case as that will
+        // overwrite the html being loaded.
+        if (url != null &&
+            !url.startsWith("data:text/html") &&
+            state.content.getCurrentUrl() != url
+        ) {
+            state.content = WebContent.Url(url)
+        }
+    }
+
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError?
+    ) {
+        super.onReceivedError(view, request, error)
+
+        if (error != null) {
+            state.errorsForCurrentRequest.add(WebViewError(request, error))
+        }
+    }
+
+    override fun shouldOverrideUrlLoading(
+        view: WebView?,
+        request: WebResourceRequest?
+    ): Boolean {
+        // Override all url loads to make the single source of truth
+        // of the URL the state holder Url
+        request?.let {
+            val content = WebContent.Url(it.url.toString())
+            state.content = content
+        }
+        return true
+    }
+}
+
+/**
+ * AccompanistWebChromeClient
+ *
+ * A parent class implementation of WebChromeClient that can be subclassed to add custom behaviour.
+ *
+ * As Accompanist Web needs to set its own web client to function, it provides this intermediary
+ * class that can be overriden if further custom behaviour is required.
+ */
+open class AccompanistWebChromeClient : WebChromeClient() {
+    internal lateinit var state: WebViewState
+
+    override fun onReceivedTitle(view: WebView?, title: String?) {
+        super.onReceivedTitle(view, title)
+        state.pageTitle = title
+    }
+
+    override fun onReceivedIcon(view: WebView?, icon: Bitmap?) {
+        super.onReceivedIcon(view, icon)
+        state.pageIcon = icon
+    }
+
+    override fun onProgressChanged(view: WebView?, newProgress: Int) {
+        super.onProgressChanged(view, newProgress)
+        if (state.loadingState is LoadingState.Finished) return
+        state.loadingState = LoadingState.Loading(newProgress / 100.0f)
     }
 }
 
@@ -277,6 +307,7 @@ class WebViewState(webContent: WebContent) {
 class WebViewNavigator(private val coroutineScope: CoroutineScope) {
 
     private enum class NavigationEvent { BACK, FORWARD, RELOAD, STOP_LOADING }
+
     private val navigationEvents: MutableSharedFlow<NavigationEvent> = MutableSharedFlow()
 
     // Use Dispatchers.Main to ensure that the webview methods are called on UI thread

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -68,8 +68,8 @@ fun WebView(
     captureBackPresses: Boolean = true,
     navigator: WebViewNavigator = rememberWebViewNavigator(),
     onCreated: (WebView) -> Unit = {},
-    client: AccompanistWebViewClient = AccompanistWebViewClient(),
-    chromeClient: AccompanistWebChromeClient = AccompanistWebChromeClient()
+    client: AccompanistWebViewClient = remember { AccompanistWebViewClient() },
+    chromeClient: AccompanistWebChromeClient = remember { AccompanistWebChromeClient() }
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
 

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -131,8 +131,10 @@ fun WebView(
  * class that can be overriden if further custom behaviour is required.
  */
 open class AccompanistWebViewClient : WebViewClient() {
-    internal lateinit var state: WebViewState
-    internal lateinit var navigator: WebViewNavigator
+    open lateinit var state: WebViewState
+        internal set
+    open lateinit var navigator: WebViewNavigator
+        internal set
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
@@ -204,7 +206,8 @@ open class AccompanistWebViewClient : WebViewClient() {
  * class that can be overriden if further custom behaviour is required.
  */
 open class AccompanistWebChromeClient : WebChromeClient() {
-    internal lateinit var state: WebViewState
+    open lateinit var state: WebViewState
+        internal set
 
     override fun onReceivedTitle(view: WebView?, title: String?) {
         super.onReceivedTitle(view, title)


### PR DESCRIPTION
Fixes #1095 
Fixes #1071 

Currently Accompanist Web sets it's own clients and doesn't provide a way to customise them. This limits the functionality and has created some obvious missing features. This is an attempt to expose the clients whilst maintaining the existing functionality. I did this via subclassing as I couldn't think of another way to do it, the clients themselves are classes not interfaces which limited the possibilities.

Open to other suggestions.

The other thing is I removed the `onError` callback as it was now duplicating functionality. I decided not to mark it as deprecated because this library was never released in a non-alpha version but I can create a deprecated version of it if needed.