### PR TITLE
[SystemUiController] Update androidx-core to 1.8.0-alpha06

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ coil-gif = { module = "io.coil-kt:coil-gif", version.ref = "coil" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.1"
-androidx-core = "androidx.core:core-ktx:1.8.0-alpha04"
+androidx-core = "androidx.core:core-ktx:1.8.0-alpha06"
 androidx-activity-compose = "androidx.activity:activity-compose:1.4.0"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.4.0"
 androidx-dynamicanimation = "androidx.dynamicanimation:dynamicanimation-ktx:1.0.0-alpha03"

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 
 /**
@@ -174,7 +175,9 @@ internal class AndroidSystemUiController(
     private val view: View
 ) : SystemUiController {
     private val window = view.context.findWindow()
-    private val windowInsetsController = ViewCompat.getWindowInsetsController(view)
+    private val windowInsetsController = window?.let {
+        WindowCompat.getInsetsController(it, view)
+    }
 
     override fun setStatusBarColor(
         color: Color,

--- a/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/SystemUiControllerTest.kt
+++ b/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/SystemUiControllerTest.kt
@@ -23,6 +23,7 @@ import android.view.Window
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.graphics.Color
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -120,7 +121,7 @@ class SystemUiControllerTest {
 
         // Assert that the system couldn't apply the native light icons
         rule.scenario.onActivity {
-            val windowInsetsController = ViewCompat.getWindowInsetsController(it.contentView)!!
+            val windowInsetsController = WindowCompat.getInsetsController(window, it.contentView)
             assertThat(windowInsetsController.isAppearanceLightStatusBars).isFalse()
         }
     }
@@ -145,7 +146,7 @@ class SystemUiControllerTest {
 
         // Assert that the system applied the native light icons
         rule.scenario.onActivity {
-            val windowInsetsController = ViewCompat.getWindowInsetsController(it.contentView)!!
+            val windowInsetsController = WindowCompat.getInsetsController(window, it.contentView)
             assertThat(windowInsetsController.isAppearanceLightStatusBars).isTrue()
         }
     }
@@ -171,7 +172,7 @@ class SystemUiControllerTest {
 
         // Assert that the system couldn't apply the native light icons
         rule.scenario.onActivity {
-            val windowInsetsController = ViewCompat.getWindowInsetsController(it.contentView)!!
+            val windowInsetsController = WindowCompat.getInsetsController(window, it.contentView)
             assertThat(windowInsetsController.isAppearanceLightNavigationBars).isFalse()
         }
     }
@@ -196,7 +197,7 @@ class SystemUiControllerTest {
 
         // Assert that the system applied the native light icons
         rule.scenario.onActivity {
-            val windowInsetsController = ViewCompat.getWindowInsetsController(it.contentView)!!
+            val windowInsetsController = WindowCompat.getInsetsController(window, it.contentView)
             assertThat(windowInsetsController.isAppearanceLightNavigationBars).isTrue()
         }
     }


### PR DESCRIPTION
Small version bump to `androidx.core`, which undeprecated the `WindowCompat.getInsetsController` method (which was previously deprecated).

This is a minor change on our side to use the non-deprecated version (and this won't break preview either!)

Upstream, the approach that promised to allow `ViewCompat.getWindowInsetsController` everywhere didn't work, as for some API versions direct access to the `Window` was required.

Therefore, `ViewCompat.getWindowInsetsController` was reverted to its original behavior but deprecated, since it would find the `Activity`'s `Window`. This wouldn't work when used from a `Dialog`, so `WindowCompat.getInsetsController` is the undeprecated version that requires explicitly passing the correct `Window`.

A related issue here is that `SystemUiController` wouldn't work in a `Dialog`, since it performs the similar logic of finding the `Activity`'s `Window` instead of the correct `Dialog` `Window`.

I filed https://issuetracker.google.com/issues/221889664 as a feature request for a `Window` `CompositionLocal` which could be overwritten in a `Dialog`.