### PR TITLE
[Navigation-Material] Added skipHalfExpanded to rememberBottomSheetNavigator

### DIFF
--- a/navigation-material/api/current.api
+++ b/navigation-material/api/current.api
@@ -19,7 +19,7 @@ package com.google.accompanist.navigation.material {
   }
 
   public final class BottomSheetNavigatorKt {
-    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec);
+    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec, optional boolean skipHalfExpanded);
   }
 
   @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public final class BottomSheetNavigatorSheetState {

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -102,11 +102,13 @@ public class BottomSheetNavigatorSheetState(private val sheetState: ModalBottomS
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 public fun rememberBottomSheetNavigator(
-    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    skipHalfExpanded: Boolean = false
 ): BottomSheetNavigator {
     val sheetState = rememberModalBottomSheetState(
         ModalBottomSheetValue.Hidden,
-        animationSpec
+        animationSpec,
+        skipHalfExpanded
     )
     return remember(sheetState) {
         BottomSheetNavigator(sheetState = sheetState)


### PR DESCRIPTION
Adds the skipHalfExpanded flag as an optional argument to rememberBottomSheetNavigator, as mentioned in [this](https://github.com/google/accompanist/issues/1070) issue.