### PR TITLE
[Navigation Material] Added skipHalfExpanded option

### DIFF
--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -102,11 +102,13 @@ public class BottomSheetNavigatorSheetState(private val sheetState: ModalBottomS
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 public fun rememberBottomSheetNavigator(
-    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    skipHalfExpanded: Boolean = false
 ): BottomSheetNavigator {
     val sheetState = rememberModalBottomSheetState(
         ModalBottomSheetValue.Hidden,
-        animationSpec
+        animationSpec,
+        skipHalfExpanded
     )
     return remember(sheetState) {
         BottomSheetNavigator(sheetState = sheetState)


### PR DESCRIPTION
Just a simple update to allow a fully expanded BottomSheet by default.

Resolves #657 