### PR TITLE
[Placeholder] Fix outline cache in placeholder

### DIFF
--- a/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
+++ b/placeholder/src/main/java/com/google/accompanist/placeholder/Placeholder.kt
@@ -178,7 +178,7 @@ fun Modifier.placeholder(
                 // the alpha applied
                 paint.alpha = placeholderAlpha
                 withLayer(paint) {
-                    drawPlaceholder(
+                    lastOutline.value = drawPlaceholder(
                         shape = shape,
                         color = color,
                         highlight = highlight,
@@ -190,7 +190,7 @@ fun Modifier.placeholder(
                 }
             } else if (placeholderAlpha >= 0.99f) {
                 // If the placeholder alpha is > 99%, draw it with no alpha
-                drawPlaceholder(
+                lastOutline.value = drawPlaceholder(
                     shape = shape,
                     color = color,
                     highlight = highlight,


### PR DESCRIPTION
In the original implementation of the placeholder modifier a `lastOutline` ref was used to cache the `Outline` returned by the `drawPlaceholder` method. An update was made that removed the assignment of the outline to the ref in this commit:

https://github.com/google/accompanist/commit/350f4b99fe9c04a074c9e39e25cf0eb7786ef2d7#r62458837

This change restores the ref assignment to make the outline cache function correctly.
