### PR TITLE
[Web] Fix url in remember not causing recomposition

### DIFF
--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -21,6 +21,7 @@ import android.webkit.WebView
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -176,6 +177,53 @@ class WebTest {
 
         onWebView()
             .check(webMatches(getCurrentUrl(), containsString(LINK_URL)))
+    }
+
+    @Test
+    fun testUrlUpdatedWithRemember() {
+        val url = mutableStateOf("https://google.com")
+        rule.setContent {
+            @Composable
+            fun MyWebView(url: String) {
+                val webViewState = rememberWebViewState(url = url)
+                WebTestContent(webViewState = webViewState, idlingResource = idleResource)
+            }
+
+            MyWebView(url = url.value)
+        }
+
+        // Ensure the data is loaded first
+        onWebView()
+            .check(webMatches(getCurrentUrl(), containsString("google.com")))
+
+        url.value = "https://youtube.com"
+
+        onWebView()
+            .check(webMatches(getCurrentUrl(), containsString("youtube.com")))
+    }
+
+    @Test
+    fun testDataUpdatedWithRemember() {
+        val data = mutableStateOf(TEST_DATA)
+        rule.setContent {
+            @Composable
+            fun MyWebView(data: String) {
+                val webViewState = rememberWebViewStateWithHTMLData(data = data)
+                WebTestContent(webViewState = webViewState, idlingResource = idleResource)
+            }
+
+            MyWebView(data = data.value)
+        }
+
+        // Ensure the data is loaded first
+        onWebView()
+            .withElement(findElement(Locator.TAG_NAME, "a"))
+            .check(webMatches(getText(), containsString(LINK_TEXT)))
+
+        data.value = TEST_TITLE_DATA
+
+        onWebView()
+            .check(webMatches(getTitle(), containsString(TITLE_TEXT)))
     }
 
     @Test

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -410,12 +410,17 @@ data class WebViewError(
  */
 @Composable
 fun rememberWebViewState(url: String, additionalHttpHeaders: Map<String, String> = emptyMap()) =
-    remember(url, additionalHttpHeaders) {
+    remember {
         WebViewState(
             WebContent.Url(
                 url = url,
                 additionalHttpHeaders = additionalHttpHeaders
             )
+        )
+    }.apply {
+        this.content = WebContent.Url(
+            url = url,
+            additionalHttpHeaders = additionalHttpHeaders
         )
     }
 
@@ -426,4 +431,9 @@ fun rememberWebViewState(url: String, additionalHttpHeaders: Map<String, String>
  */
 @Composable
 fun rememberWebViewStateWithHTMLData(data: String, baseUrl: String? = null) =
-    remember(data, baseUrl) { WebViewState(WebContent.Data(data, baseUrl)) }
+    remember { WebViewState(WebContent.Data(data, baseUrl)) }.apply {
+        this.content = WebContent.Data(
+            data = data,
+            baseUrl = baseUrl
+        )
+    }


### PR DESCRIPTION
Fixes #1164 

The way the remember functions were written, their inputs could never be changed.

Switched to using `.apply {}` which the correct way to write these helper remember functions. See `rememberUpdatedSlingshot()` in this project for another example.

Added tests to cover this case for the future.