### PR TITLE
[SwipeRefresh] Fix overscroll behaviour on Android 12

### DIFF
--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefresh.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefresh.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
 
 private const val DragMultiplier = 0.5f
 
@@ -150,7 +151,11 @@ private class SwipeRefreshNestedScrollConnection(
     }
 
     private fun onScroll(available: Offset): Offset {
-        state.isSwipeInProgress = true
+        if (available.y > 0) {
+            state.isSwipeInProgress = true
+        } else if (state.indicatorOffset.roundToInt() == 0) {
+            state.isSwipeInProgress = false
+        }
 
         val newOffset = (available.y * DragMultiplier + state.indicatorOffset).coerceAtLeast(0f)
         val dragConsumed = newOffset - state.indicatorOffset


### PR DESCRIPTION
Fixes #1059

Bug is easy to reproduce in the old implementation on Android 12. Start swipe refresh but then scroll the other direction to scroll the list down. The indicator will often get stuck.

This fixes it thanks to a suggestion in the issue by cancelling the in progress swipe if the conditions aren't met.