### PR TITLE
[Pager] PagerState's lazyListState public

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -74,8 +74,7 @@ fun rememberPagerState(
 class PagerState(
     @IntRange(from = 0) currentPage: Int = 0,
 ) : ScrollableState {
-    // Should this be public?
-    internal val lazyListState = LazyListState(firstVisibleItemIndex = currentPage)
+    val lazyListState = LazyListState(firstVisibleItemIndex = currentPage)
 
     private var _currentPage by mutableStateOf(currentPage)
 


### PR DESCRIPTION
Make PagerState's lazyListState public.

I'd like to propose having the lazyListState of the PagerState to become public. A use case that I am needing the lazyListState is to check the `layoutInfo.visibleItemsInfo` of the lazyListState to check if an item is currently visible. I also saw the question as the comment, and my answer is Yes.
