### PR TITLE
Compose 1.2.0-beta03

### DIFF
--- a/appcompat-theme/build.gradle
+++ b/appcompat-theme/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -102,6 +102,9 @@ dependencies {
 
     androidTestImplementation libs.androidx.test.runner
     testImplementation libs.androidx.test.runner
+
+    androidTestImplementation libs.androidx.test.espressoCore
+    testImplementation libs.androidx.test.espressoCore
 
     testImplementation libs.robolectric
 }

--- a/drawablepainter/build.gradle
+++ b/drawablepainter/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/flowlayout/build.gradle
+++ b/flowlayout/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.accompanist
 # !! No longer need to update this manually when using a Compose SNAPSHOT
-VERSION_NAME=0.24.10-SNAPSHOT
+VERSION_NAME=0.24.10-beta
 
 POM_DESCRIPTION=Utilities for Jetpack Compose
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 compose = "1.2.0-beta03"
-composebeta2 = "1.2.0-beta02"
 composesnapshot = "-" # a single character = no snapshot
 
 # gradlePlugin and lint need to be updated together

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,10 @@
 [versions]
-compose = "1.2.0-beta02"
+compose = "1.2.0-beta03"
+composebeta2 = "1.2.0-beta02"
 composesnapshot = "-" # a single character = no snapshot
 
 # gradlePlugin and lint need to be updated together
-gradlePlugin = "7.1.3"
+gradlePlugin = "7.3.0-beta01"
 lintMinCompose = "30.0.0"
 
 ktlint = "0.42.1"
@@ -13,7 +14,7 @@ okhttp = "3.12.13"
 coil = "1.3.2"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.5.0-alpha04"
+androidxnavigation = "2.5.0-rc01"
 
 [libraries]
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
@@ -55,7 +56,7 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.1"
 androidx-core = "androidx.core:core-ktx:1.8.0-alpha06"
-androidx-activity-compose = "androidx.activity:activity-compose:1.4.0"
+androidx-activity-compose = "androidx.activity:activity-compose:1.5.0-rc01"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.4.0"
 androidx-dynamicanimation = "androidx.dynamicanimation:dynamicanimation-ktx:1.0.0-alpha03"
 androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
@@ -71,11 +72,14 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxtest" }
 androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.ref = "androidxtest" }
 androidx-test-uiAutomator = "androidx.test.uiautomator:uiautomator:2.2.0"
-androidx-test-espressoWeb = "androidx.test.espresso:espresso-web:3.4.0"
 
-junit = "junit:junit:4.13"
+# alpha for robolectric x compose fix
+androidx-test-espressoCore = "androidx.test.espresso:espresso-core:3.5.0-alpha06"
+androidx-test-espressoWeb = "androidx.test.espresso:espresso-web:3.5.0-alpha06"
+
+junit = "junit:junit:4.13.2"
 truth = "com.google.truth:truth:1.1.2"
-robolectric = "org.robolectric:robolectric:4.5.1"
+robolectric = "org.robolectric:robolectric:4.8"
 
 affectedmoduledetector = "com.dropbox.affectedmoduledetector:affectedmoduledetector:0.1.2"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/insets-ui/build.gradle
+++ b/insets-ui/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/insets/build.gradle
+++ b/insets/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/internal-testutils/build.gradle
+++ b/internal-testutils/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21

--- a/navigation-animation/build.gradle
+++ b/navigation-animation/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/navigation-material/build.gradle
+++ b/navigation-material/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -74,11 +74,6 @@ dependencies {
     api libs.androidx.navigation.compose
     implementation libs.compose.foundation.foundation
     implementation libs.compose.material.material
-
-    // FIXME: Needed because navigation-compose 2.4.0-SNAPSHOT forces activity-compose 1.3.0-rc02,
-    //  and our test dependencies depend on 1.3.0. We need to explicitly tell Gradle what version
-    //  to use.
-    implementation libs.androidx.activity.compose
 
     // ======================
     // Test dependencies

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/SheetContentHost.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/SheetContentHost.kt
@@ -41,8 +41,6 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.compose.LocalOwnersProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
@@ -64,7 +62,7 @@ import kotlinx.coroutines.withTimeout
  * pop the back stack here.
  */
 @ExperimentalMaterialNavigationApi
-@OptIn(ExperimentalMaterialApi::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun SheetContentHost(
     columnHost: ColumnScope,
@@ -141,11 +139,7 @@ internal fun SheetContentHost(
             onDispose {
                 scope.launch {
                     hideCalled = true
-                    try {
-                        sheetState.internalHide()
-                    } finally {
-                        hideCalled = false
-                    }
+                    sheetState.internalHide()
                 }
             }
         }

--- a/pager-indicators/build.gradle
+++ b/pager-indicators/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/pager/build.gradle
+++ b/pager/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/permissions/build.gradle
+++ b/permissions/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/placeholder-material/build.gradle
+++ b/placeholder-material/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/placeholder/build.gradle
+++ b/placeholder/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,12 +19,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.google.accompanist.sample"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 32
 
         versionCode 1
         versionName "1.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'com.gradle.enterprise' version '3.5'
+    id 'com.gradle.enterprise' version '3.10.1'
 }
 
 gradleEnterprise {

--- a/swiperefresh/build.gradle
+++ b/swiperefresh/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/systemuicontroller/build.gradle
+++ b/systemuicontroller/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -25,12 +25,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 31
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Fixed an issue in navigation material. It was setting hide called back to false too soon, removing the set fixes the issue. The flag is set back to false thanks to the remember being keyed with the backStackEntry