### PR TITLE
[Web] Fix webview breaking preview

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ androidxnavigation = "2.5.0-rc01"
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 compose-foundation-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -70,7 +70,8 @@ dependencies {
     implementation libs.compose.material.material
     implementation libs.compose.material.iconsext
     implementation libs.compose.foundation.layout
-    implementation libs.compose.ui.tooling
+    debugImplementation libs.compose.ui.tooling
+    implementation libs.compose.ui.tooling.preview
     implementation libs.compose.ui.util
 
     implementation libs.androidx.lifecycle.viewmodel.compose

--- a/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
@@ -39,6 +40,7 @@ import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +49,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.web.AccompanistWebViewClient
@@ -146,6 +149,20 @@ class BasicWebViewSample : ComponentActivity() {
                     )
                 }
             }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun WebViewPreview() {
+    AccompanistSampleTheme {
+        Column {
+            Text("Preview should still load but WebView will be grey box.")
+            WebView(
+                state = rememberWebViewState(url = "localhost"),
+                modifier = Modifier.height(100.dp)
+            )
         }
     }
 }

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -87,6 +88,8 @@ fun WebView(
     client.navigator = navigator
     chromeClient.state = state
 
+    val runningInPreview = LocalInspectionMode.current
+
     AndroidView(
         factory = { context ->
             WebView(context).apply {
@@ -103,6 +106,9 @@ fun WebView(
         },
         modifier = modifier
     ) { view ->
+        // AndroidViews are not supported by preview, bail early
+        if (runningInPreview) return@AndroidView
+
         when (val content = state.content) {
             is WebContent.Url -> {
                 val url = content.url


### PR DESCRIPTION
Fixes #1177

AndroidViews just get rendered as grey placeholders in preview so just bail early.

<img width="536" alt="Screen Shot 2022-06-08 at 2 25 14 pm" src="https://user-images.githubusercontent.com/19445/172531582-d6624a74-29b0-4e4a-911a-89deb85aaed5.png">

