### PR TITLE
[Pager] Deprecate PagerState.targetPage

### DIFF
--- a/pager/api/current.api
+++ b/pager/api/current.api
@@ -37,7 +37,7 @@ package com.google.accompanist.pager {
     method public float getCurrentPageOffset();
     method public androidx.compose.foundation.interaction.InteractionSource getInteractionSource();
     method @IntRange(from=0) public int getPageCount();
-    method public int getTargetPage();
+    method @Deprecated public int getTargetPage();
     method public boolean isScrollInProgress();
     method public suspend Object? scroll(androidx.compose.foundation.MutatePriority scrollPriority, kotlin.jvm.functions.Function2<? super androidx.compose.foundation.gestures.ScrollScope,? super kotlin.coroutines.Continuation<? super kotlin.Unit>,?> block, kotlin.coroutines.Continuation<? super kotlin.Unit> p);
     method public suspend Object? scrollToPage(@IntRange(from=0) int page, optional @FloatRange(from=-1.0, to=1.0) float pageOffset, optional kotlin.coroutines.Continuation<? super kotlin.Unit> p);
@@ -46,7 +46,7 @@ package com.google.accompanist.pager {
     property public final androidx.compose.foundation.interaction.InteractionSource interactionSource;
     property public boolean isScrollInProgress;
     property @IntRange(from=0) public final int pageCount;
-    property public final int targetPage;
+    property @Deprecated public final int targetPage;
     field public static final com.google.accompanist.pager.PagerState.Companion Companion;
   }
 

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -155,6 +155,13 @@ class PagerState(
      * The target page for any on-going animations or scrolls by the user.
      * Returns the current page if a scroll or animation is not currently in progress.
      */
+    @Deprecated(
+        "targetPage is deprecated in favor of currentPage as currentPage property is" +
+            "now being updated right after we over scrolled the half of the previous current page." +
+            "If you still think that you need targetPage, not currentPage please file a bug as " +
+            "we are planning to remove this property in future.",
+        ReplaceWith("currentPage")
+    )
     val targetPage: Int
         get() = animationTargetPage
             ?: flingAnimationTarget?.invoke()

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/PagerTest.kt
@@ -159,6 +159,7 @@ abstract class PagerTest {
         assertPagerLayout(0, pagerState.pageCount)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mediumDistance_fastSwipe_toFling() {
         composeTestRule.mainClock.autoAdvance = false
@@ -190,6 +191,7 @@ abstract class PagerTest {
         assertPagerLayout(1, pagerState.pageCount)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun mediumDistance_slowSwipe_toSnapForward() {
         composeTestRule.mainClock.autoAdvance = false
@@ -221,6 +223,7 @@ abstract class PagerTest {
         assertPagerLayout(1, pagerState.pageCount)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun shortDistance_fastSwipe_toFling() {
         composeTestRule.mainClock.autoAdvance = false
@@ -252,6 +255,7 @@ abstract class PagerTest {
         assertPagerLayout(1, pagerState.pageCount)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun shortDistance_slowSwipe_toSnapBack() {
         composeTestRule.mainClock.autoAdvance = false


### PR DESCRIPTION
targetPage is deprecated in favor of currentPage as currentPage property is now being updated right after we over scrolled the half of the previous current page. If you still think that you need targetPage, not currentPage please file a bug as we are planning to remove this property in future.