### PR TITLE
[Pager] Update snapper dependency to resolve target page skips on fling

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ compose-material-material = { module = "androidx.compose.material:material", ver
 compose-material-iconsext = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
 compose-animation-animation = { module = "androidx.compose.animation:animation", version.ref = "compose" }
 
-snapper = "dev.chrisbanes.snapper:snapper:0.2.0"
+snapper = "dev.chrisbanes.snapper:snapper:0.2.2"
 
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.17.0"


### PR DESCRIPTION
Resolves #1118 .

Updates [snapper](https://github.com/chrisbanes/snapper) dependency to version `0.2.2`.
This version contains the fix for the above mentioned issue.

For further details, see: https://github.com/google/accompanist/issues/1118#issuecomment-1157410298