### PR TITLE
[Pager Indicators] Fix behavior of `pagerTabIndicatorOffset` in RTL layouts

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
@@ -68,7 +68,7 @@ fun Modifier.pagerTabIndicatorOffset(
             )
         )
         layout(constraints.maxWidth, maxOf(placeable.height, constraints.minHeight)) {
-            placeable.place(
+            placeable.placeRelative(
                 indicatorOffset,
                 maxOf(constraints.minHeight - placeable.height, 0)
             )


### PR DESCRIPTION
As reported in issue #1218, `pagerTabIndicatorOffset` doesnʼt work correctly in RTL layouts. This PR resolves the issue.

| Layout direction | Before | After |
| --- | --- | --- |
| LTR | https://user-images.githubusercontent.com/56888459/176960447-82ba04df-cbac-45d2-bc93-bcc630de5a91.mp4 | https://user-images.githubusercontent.com/56888459/176960778-53ef36b7-7ebc-45d5-99cf-95e37659a4df.mp4 |
| RTL | https://user-images.githubusercontent.com/56888459/176960636-359e9123-5382-40fb-81e2-971803eb3c04.mp4 | https://user-images.githubusercontent.com/56888459/176960896-8fa927c7-d56b-4d28-96dc-8ef25530c5ac.mp4 |