### PR TITLE
[navigation material] use result of assertThat

### DIFF
--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
@@ -101,7 +101,7 @@ internal class SheetContentHostTest {
             onSheetDismissed = { entry -> dismissedBackStackEntries.add(entry) }
         )
 
-        assertThat(sheetState.currentValue == ModalBottomSheetValue.Expanded)
+        assertThat(sheetState.currentValue == ModalBottomSheetValue.Expanded).isTrue()
         composeTestRule.onNodeWithTag(bodyContentTag).performClick()
         composeTestRule.runOnIdle {
             assertWithMessage("Sheet is visible")
@@ -126,7 +126,7 @@ internal class SheetContentHostTest {
             onSheetDismissed = { entry -> dismissedBackStackEntries.add(entry) }
         )
 
-        assertThat(sheetState.currentValue == ModalBottomSheetValue.Expanded)
+        assertThat(sheetState.currentValue == ModalBottomSheetValue.Expanded).isTrue()
         composeTestRule.onNodeWithTag(bodyContentTag).performClick()
         composeTestRule.runOnIdle {
             assertWithMessage("Sheet is not visible")


### PR DESCRIPTION
result of `assertThat` is unused in `SheetContentHostTest`