### PR TITLE
[Navigation Material] Remove usages of undefined `Destinations.Home` string from code samples in documentation

### DIFF
--- a/docs/navigation-material.md
+++ b/docs/navigation-material.md
@@ -31,7 +31,7 @@ This features composable bottom sheet destinations.
         val bottomSheetNavigator = rememberBottomSheetNavigator()
         val navController = rememberNavController(bottomSheetNavigator)
         ModalBottomSheetLayout(bottomSheetNavigator) {
-            NavHost(navController, Destinations.Home) {
+            NavHost(navController, "home") {
                // We'll define our graph here in a bit!
             }
         }
@@ -46,7 +46,7 @@ This features composable bottom sheet destinations.
         val bottomSheetNavigator = rememberBottomSheetNavigator()
         val navController = rememberNavController(bottomSheetNavigator)
         ModalBottomSheetLayout(bottomSheetNavigator) {
-            NavHost(navController, Destinations.Home) {
+            NavHost(navController, "home") {
                composable(route = "home") {
                    ...
                }


### PR DESCRIPTION
In the documentation for Navigation Material, the following code sample is present:

```kotlin
@Composable
fun MyApp() {
    val bottomSheetNavigator = rememberBottomSheetNavigator()
    val navController = rememberNavController(bottomSheetNavigator)
    ModalBottomSheetLayout(bottomSheetNavigator) {
        NavHost(navController, Destinations.Home) {
           composable(route = "home") {
               ...
           }
           bottomSheet(route = "sheet") {
               Text("This is a cool bottom sheet!")
           }
        }
    }
}
```

In the sixth line, `Destinations.Home` is used, but no such thing is defined anywhere in the documentation, making the code sample somewhat unclear. This pull request replaces `NavHost(navController, Destinations.Home)` with `NavHost(navController, "home")` to ensure that the code samples in the Navigation Material documentation donʼt include references to any undefined items. This is consistent with [the documentation for the Navigation Animation library](https://google.github.io/accompanist/navigation-animation/).