### PR TITLE
[Navigation Material] Fix children of bottom sheet in sample being stacked on top of one another

### DIFF
--- a/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
@@ -101,11 +101,13 @@ private fun HomeScreen(showSheet: () -> Unit, showFeed: () -> Unit) {
 
 @Composable
 private fun BottomSheet(showFeed: () -> Unit, showAnotherSheet: () -> Unit, arg: String) {
-    Text("Sheet with arg: $arg")
-    Button(onClick = showFeed) {
-        Text("Click me to navigate!")
-    }
-    Button(onClick = showAnotherSheet) {
-        Text("Click me to show another sheet!")
+    Column {
+        Text("Sheet with arg: $arg")
+        Button(onClick = showFeed) {
+            Text("Click me to navigate!")
+        }
+        Button(onClick = showAnotherSheet) {
+            Text("Click me to show another sheet!")
+        }
     }
 }


### PR DESCRIPTION
This fixes an issue in the “Navigation: Bottom Sheets” sample where the children of the bottom sheet werenʼt placed in a `Column` and were consequently stacked on top of one another.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/56888459/177837800-e11e3441-b8fd-4b52-98bf-a1e5754efd43.png) | ![image](https://user-images.githubusercontent.com/56888459/177837615-d9b81cb3-3d77-4691-9eb9-c5b0f328d9d9.png) |