### PR TITLE
[SystemUiController] Add support for systemBarsBehavior

### DIFF
--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsVisibilitySample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/SystemBarsVisibilitySample.kt
@@ -20,22 +20,31 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.pager.ExperimentalPagerApi
+import androidx.core.view.WindowInsetsControllerCompat
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
@@ -54,7 +63,6 @@ class SystemBarsVisibilitySample : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalPagerApi::class)
 @Composable
 private fun Sample() {
     // Get the current SystemUiController
@@ -69,10 +77,61 @@ private fun Sample() {
         modifier = Modifier.fillMaxSize()
     ) { padding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(padding),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            Box {
+                var isShowingDropdownMenu by remember { mutableStateOf(false) }
+
+                Button(
+                    onClick = {
+                        isShowingDropdownMenu = true
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .padding(vertical = 8.dp)
+                ) {
+                    Text(text = "Change System Bars Behavior")
+                }
+
+                DropdownMenu(
+                    expanded = isShowingDropdownMenu,
+                    onDismissRequest = { isShowingDropdownMenu = false }
+                ) {
+                    DropdownMenuItem(
+                        onClick = {
+                            systemUiController.systemBarsBehavior =
+                                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH
+                            isShowingDropdownMenu = false
+                        }
+                    ) {
+                        Text("BEHAVIOR_SHOW_BARS_BY_TOUCH")
+                    }
+                    DropdownMenuItem(
+                        onClick = {
+                            systemUiController.systemBarsBehavior =
+                                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE
+                            isShowingDropdownMenu = false
+                        }
+                    ) {
+                        Text("BEHAVIOR_SHOW_BARS_BY_SWIPE")
+                    }
+                    DropdownMenuItem(
+                        onClick = {
+                            systemUiController.systemBarsBehavior =
+                                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                            isShowingDropdownMenu = false
+                        }
+                    ) {
+                        Text("BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE")
+                    }
+                }
+            }
+
             /** Status bar */
 
             Button(

--- a/systemuicontroller/api/current.api
+++ b/systemuicontroller/api/current.api
@@ -4,6 +4,7 @@ package com.google.accompanist.systemuicontroller {
   @androidx.compose.runtime.Stable public interface SystemUiController {
     method public boolean getNavigationBarDarkContentEnabled();
     method public boolean getStatusBarDarkContentEnabled();
+    method public int getSystemBarsBehavior();
     method public default boolean getSystemBarsDarkContentEnabled();
     method public boolean isNavigationBarContrastEnforced();
     method public boolean isNavigationBarVisible();
@@ -16,6 +17,7 @@ package com.google.accompanist.systemuicontroller {
     method public void setStatusBarColor(long color, optional boolean darkIcons, optional kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color> transformColorForLightContent);
     method public void setStatusBarDarkContentEnabled(boolean statusBarDarkContentEnabled);
     method public void setStatusBarVisible(boolean isStatusBarVisible);
+    method public void setSystemBarsBehavior(int systemBarsBehavior);
     method public default void setSystemBarsColor(long color, optional boolean darkIcons, optional boolean isNavigationBarContrastEnforced, optional kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.Color,androidx.compose.ui.graphics.Color> transformColorForLightContent);
     method public default void setSystemBarsDarkContentEnabled(boolean value);
     method public default void setSystemBarsVisible(boolean value);
@@ -25,6 +27,7 @@ package com.google.accompanist.systemuicontroller {
     property public default boolean isSystemBarsVisible;
     property public abstract boolean navigationBarDarkContentEnabled;
     property public abstract boolean statusBarDarkContentEnabled;
+    property public abstract int systemBarsBehavior;
     property public default boolean systemBarsDarkContentEnabled;
   }
 

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 /**
  * A class which provides easy-to-use utilities for updating the System UI bar
@@ -43,6 +44,15 @@ import androidx.core.view.WindowInsetsCompat
  */
 @Stable
 interface SystemUiController {
+
+    /**
+     * Control for the behavior of the system bars. This value should be one of the
+     * [WindowInsetsControllerCompat] behavior constants:
+     * [WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH],
+     * [WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE] and
+     * [WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE].
+     */
+    var systemBarsBehavior: Int
 
     /**
      * Property which holds the status bar visibility. If set to true, show the status bar,
@@ -241,6 +251,12 @@ internal class AndroidSystemUiController(
             else -> color
         }.toArgb()
     }
+
+    override var systemBarsBehavior: Int
+        get() = windowInsetsController?.systemBarsBehavior ?: 0
+        set(value) {
+            windowInsetsController?.systemBarsBehavior = value
+        }
 
     override var isStatusBarVisible: Boolean
         get() {

--- a/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/ActivityRememberSystemUiControllerTest.kt
+++ b/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/ActivityRememberSystemUiControllerTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.FlakyTest
 import androidx.test.filters.SdkSuppress
@@ -243,6 +244,60 @@ class ActivityRememberSystemUiControllerTest {
             // Assert that the controller reflects that the contrast is enforced
             assertThat(systemUiController.isNavigationBarContrastEnforced).isTrue()
         }
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsByTouch() {
+        lateinit var systemUiController: SystemUiController
+
+        rule.setContent {
+            systemUiController = rememberSystemUiController()
+        }
+
+        rule.activityRule.scenario.onActivity {
+            systemUiController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsBySwipe() {
+        lateinit var systemUiController: SystemUiController
+
+        rule.setContent {
+            systemUiController = rememberSystemUiController()
+        }
+
+        rule.activityRule.scenario.onActivity {
+            systemUiController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showTransientBarsBySwipe() {
+        lateinit var systemUiController: SystemUiController
+
+        rule.setContent {
+            systemUiController = rememberSystemUiController()
+        }
+
+        rule.activityRule.scenario.onActivity {
+            systemUiController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE)
     }
 
     @Test

--- a/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/ActivitySystemUiControllerTest.kt
+++ b/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/ActivitySystemUiControllerTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.FlakyTest
@@ -223,6 +224,52 @@ class ActivitySystemUiControllerTest {
             // Assert that the controller reflects that the contrast is enforced
             assertThat(controller.isNavigationBarContrastEnforced).isTrue()
         }
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsByTouch() {
+        val controller = rule.scenario.withActivity {
+            AndroidSystemUiController(contentView, window)
+        }
+
+        rule.scenario.onActivity {
+            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsBySwipe() {
+        val controller = rule.scenario.withActivity {
+            AndroidSystemUiController(contentView, window)
+        }
+
+        rule.scenario.onActivity {
+            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showTransientBarsBySwipe() {
+        val controller = rule.scenario.withActivity {
+            AndroidSystemUiController(contentView, window)
+        }
+
+        rule.scenario.onActivity {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE)
     }
 
     @Test

--- a/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/DialogRememberSystemUiControllerTest.kt
+++ b/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/DialogRememberSystemUiControllerTest.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.FlakyTest
 import androidx.test.filters.SdkSuppress
@@ -284,6 +285,75 @@ class DialogRememberSystemUiControllerTest {
             // Assert that the controller reflects that the contrast is enforced
             assertThat(systemUiController.isNavigationBarContrastEnforced).isTrue()
         }
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsByTouch() {
+        lateinit var systemUiController: SystemUiController
+
+        rule.setContent {
+            Dialog(onDismissRequest = {}) {
+                window = (LocalView.current.parent as DialogWindowProvider).window
+                contentView = LocalView.current
+
+                systemUiController = rememberSystemUiController()
+            }
+        }
+
+        rule.activityRule.scenario.onActivity {
+            systemUiController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsBySwipe() {
+        lateinit var systemUiController: SystemUiController
+
+        rule.setContent {
+            Dialog(onDismissRequest = {}) {
+                window = (LocalView.current.parent as DialogWindowProvider).window
+                contentView = LocalView.current
+
+                systemUiController = rememberSystemUiController()
+            }
+        }
+
+        rule.activityRule.scenario.onActivity {
+            systemUiController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showTransientBarsBySwipe() {
+        lateinit var systemUiController: SystemUiController
+
+        rule.setContent {
+            Dialog(onDismissRequest = {}) {
+                window = (LocalView.current.parent as DialogWindowProvider).window
+                contentView = LocalView.current
+
+                systemUiController = rememberSystemUiController()
+            }
+        }
+
+        rule.activityRule.scenario.onActivity {
+            systemUiController.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE)
     }
 
     @Test

--- a/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/DialogSystemUiControllerTest.kt
+++ b/systemuicontroller/src/sharedTest/kotlin/com/google/accompanist/systemuicontroller/DialogSystemUiControllerTest.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.FlakyTest
@@ -242,6 +243,54 @@ class DialogSystemUiControllerTest {
             // Assert that the controller reflects that the contrast is enforced
             assertThat(controller.isNavigationBarContrastEnforced).isTrue()
         }
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsByTouch() {
+        val controller = rule.scenario.withActivity {
+            AndroidSystemUiController(contentView, window)
+        }
+
+        rule.scenario.onActivity {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_TOUCH)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showBarsBySwipe() {
+        val controller = rule.scenario.withActivity {
+            AndroidSystemUiController(contentView, window)
+        }
+
+        rule.scenario.onActivity {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_BARS_BY_SWIPE)
+    }
+
+    @Test
+    @SdkSuppress(minSdkVersion = 30) // TODO: https://issuetracker.google.com/issues/189366125
+    fun systemBarsBehavior_showTransientBarsBySwipe() {
+        val controller = rule.scenario.withActivity {
+            AndroidSystemUiController(contentView, window)
+        }
+
+        rule.scenario.onActivity {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        assertThat(WindowCompat.getInsetsController(window, contentView).systemBarsBehavior)
+            .isEqualTo(WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE)
     }
 
     @Test


### PR DESCRIPTION
This PR exposes `SystemUiController.systemBarsBehavior`, which is just a small wrapper around `WindowInsetsControllerCompat.systemBarsBehavior`.

Since `SystemUiController` exposes `isSystemBarsVisible`, `isStatusBarVisible` and `isNavigationBarVisible`, it seems reasonable to also expose the behavior tweaking how those setters work.

This fixes #1205