### PR TITLE
[SystemUiController] Update SystemUiController to hoist dark theme

### DIFF
--- a/docs/systemuicontroller.md
+++ b/docs/systemuicontroller.md
@@ -12,9 +12,9 @@ In your layouts you can update the system bar colors like so:
 ``` kotlin
 // Remember a SystemUiController
 val systemUiController = rememberSystemUiController()
-val useDarkIcons = MaterialTheme.colors.isLight
+val useDarkIcons = !isSystemInDarkTheme()
 
-SideEffect {
+DisposableEffect(systemUiController, useDarkIcons) {
     // Update all of the system bar colors to be transparent, and use
     // dark icons if we're in light theme
     systemUiController.setSystemBarsColor(
@@ -23,6 +23,8 @@ SideEffect {
     )
 
     // setStatusBarColor() and setNavigationBarColor() also exist
+
+    onDispose {}
 }
 ```
 

--- a/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/systemuicontroller/DocsSamples.kt
@@ -16,19 +16,19 @@
 
 package com.google.accompanist.sample.systemuicontroller
 
-import androidx.compose.material.MaterialTheme
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 @Composable
 fun SystemUiControllerSample() {
-    // Get the current SystemUiController
+    // Remember a SystemUiController
     val systemUiController = rememberSystemUiController()
-    val useDarkIcons = MaterialTheme.colors.isLight
+    val useDarkIcons = !isSystemInDarkTheme()
 
-    SideEffect {
+    DisposableEffect(systemUiController, useDarkIcons) {
         // Update all of the system bar colors to be transparent, and use
         // dark icons if we're in light theme
         systemUiController.setSystemBarsColor(
@@ -37,5 +37,6 @@ fun SystemUiControllerSample() {
         )
 
         // setStatusBarColor() and setNavigationBarColor() also exist
+        onDispose {}
     }
 }


### PR DESCRIPTION
Reworks the primary docs entrance to the system ui controller module slightly.

First, it removes the reference to `MaterialTheme.colors.isLight`. This is M2 specific, and [doesn't exist](https://issuetracker.google.com/208860800) in M3 in favor of hoisting the decision directly.

Second, it replaces `SideEffect` with a `DisposableEffect` with keys. I could go either way here, but I'm less of a fan of the implicit nature in how `SideEffect` reruns. It's not super obvious that this wouldn't work when `useDarkIcons` changes:

```
val systemUiController = rememberSystemUiController()
var useDarkIcons by remember { mutableStateOf(false) }

SideEffect {
    systemUiController.setSystemBarsColor(
        color = Color.Transparent,
        darkIcons = useDarkIcons
    )
}
```