### PR TITLE
[SystemUiController] Remove @Stable from SystemUiController

### DIFF
--- a/systemuicontroller/api/current.api
+++ b/systemuicontroller/api/current.api
@@ -1,7 +1,7 @@
 // Signature format: 4.0
 package com.google.accompanist.systemuicontroller {
 
-  @androidx.compose.runtime.Stable public interface SystemUiController {
+  public interface SystemUiController {
     method public boolean getNavigationBarDarkContentEnabled();
     method public boolean getStatusBarDarkContentEnabled();
     method public int getSystemBarsBehavior();

--- a/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
+++ b/systemuicontroller/src/main/java/com/google/accompanist/systemuicontroller/SystemUiController.kt
@@ -23,7 +23,6 @@ import android.os.Build
 import android.view.View
 import android.view.Window
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
@@ -42,7 +41,6 @@ import androidx.core.view.WindowInsetsControllerCompat
  *
  * @sample com.google.accompanist.sample.systemuicontroller.SystemUiControllerSample
  */
-@Stable
 interface SystemUiController {
 
     /**


### PR DESCRIPTION
`@Stable` has a strong contract:

```
 * When applied to a class or an interface, [Stable] indicates that the following must be true:
 *
 *   1) The result of [equals] will always return the same result for the same two instances.
 *   2) When a public property of the type changes, composition will be notified.
 *   3) All public property types are stable.
 ```
 
 The current implementation of `SystemUiController` definitely does not adhere to item 2, since properties are being backed by calls to platform APIs that aren't snapshot state aware and won't notify composition if they change.
 
 I'm not entirely sure what the ramifications are for having `@Stable` when the points above aren't satisfied, but it seems safest to remove `@Stable`?