### PR TITLE
[Navigation Animation] Add contentZIndex for AnimatedNavHost

### DIFF
--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
@@ -202,6 +202,8 @@ public fun AnimatedNavHost(
                     finalEnter(this) with finalExit(this)
                 } else {
                     EnterTransition.None with ExitTransition.None
+                }.apply {
+                    targetContentZIndex = navController.backQueue.size.toFloat()
                 }
             },
             contentAlignment,


### PR DESCRIPTION
### The problem
I found a weird issue is that the back layer covers the front layer when pop back stack like this:

https://user-images.githubusercontent.com/32984161/183241563-1ead44e3-114a-4000-b279-fb16db54a681.mp4

### Why and How
The reason is that the z-indices of all layers are same as default. I add `contentZIndex` for `NavGraphBuilder.navigation()` and pass it to `AnimatedContent` in `AnimatedNavHost`.

Now it looks good:

https://user-images.githubusercontent.com/32984161/183241711-a83be5c6-0081-45d3-8dd2-b00fc99f697a.mp4

Here is my test code:
```kotlin
AnimatedNavHost(
    navController = navHostController,
    startDestination = Screen.Homepage.route,
    enterTransition = {
        slideIntoContainer(
            towards = AnimatedContentScope.SlideDirection.Left,
            animationSpec = tween(800)
        )
    },
    exitTransition = {
        slideOutOfContainer(
            towards = AnimatedContentScope.SlideDirection.Left,
            animationSpec = tween(800),
            targetOffset = { it / 2 }
        )
    },
    popEnterTransition = {
        slideIntoContainer(
            towards = AnimatedContentScope.SlideDirection.Right,
            animationSpec = tween(800),
            initialOffset = { it / 2 }
        )
    },
    popExitTransition = {
        slideOutOfContainer(
            towards = AnimatedContentScope.SlideDirection.Right,
            animationSpec = tween(800)
        )
    }
) {
    composable(route = Screen.Homepage.route) {
        HomepageScreen()
    }
    composable(route = Screen.Theme.route) {
        ThemeScreen(theme = theme) { theme = it }
    }
}
```