### PR TITLE
[Pager] Correct the error message requireCurrentPageOffset

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -338,7 +338,7 @@ class PagerState(
     }
 
     private fun requireCurrentPageOffset(value: Float, name: String) {
-        require(value in -1f..1f) { "$name must be >= 0 and <= 1" }
+        require(value in -1f..1f) { "$name must be >= -1 and <= 1" }
     }
 
     companion object {


### PR DESCRIPTION
In the require() check, it checks the value is within [-1, 1], but the error message is different.

Correct the error message to fix.
