### PR TITLE
[DrawablePainter] Fix overwriting bounds of drawable when drawing it via DrawablePainter

### DIFF
--- a/drawablepainter/build.gradle
+++ b/drawablepainter/build.gradle
@@ -66,6 +66,32 @@ android {
 dependencies {
     implementation libs.compose.ui.ui
     implementation libs.kotlin.coroutines.android
+
+    // ======================
+    // Test dependencies
+    // ======================
+
+    androidTestImplementation libs.compose.foundation.foundation
+
+    androidTestImplementation project(':internal-testutils')
+    testImplementation project(':internal-testutils')
+
+    androidTestImplementation libs.junit
+    testImplementation libs.junit
+
+    androidTestImplementation libs.truth
+    testImplementation libs.truth
+
+    androidTestImplementation libs.compose.ui.test.junit4
+    testImplementation libs.compose.ui.test.junit4
+
+    androidTestImplementation libs.compose.ui.test.manifest
+    testImplementation libs.compose.ui.test.manifest
+
+    androidTestImplementation libs.androidx.test.runner
+    testImplementation libs.androidx.test.runner
+
+    testImplementation libs.robolectric
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/drawablepainter/src/androidTest/kotlin/com/google/accompanist/drawablepainter/DrawablePainterTest.kt
+++ b/drawablepainter/src/androidTest/kotlin/com/google/accompanist/drawablepainter/DrawablePainterTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.drawablepainter
+
+import android.graphics.drawable.Drawable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DrawablePainterTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun drawableWithIntrinsicSize() {
+        lateinit var drawable: Drawable
+        rule.setContent {
+            with(LocalDensity.current) {
+                drawable = IntrinsicSizeDrawable(
+                    width = 128.dp.roundToPx(),
+                    height = 32.dp.roundToPx()
+                )
+            }
+            Image(
+                modifier = Modifier.width(256.dp),
+                painter = rememberDrawablePainter(drawable = drawable),
+                contentDescription = null,
+                contentScale = ContentScale.FillWidth,
+            )
+        }
+
+        rule.waitForIdle()
+        assertThat(drawable.bounds.width()).isEqualTo(drawable.intrinsicWidth)
+        assertThat(drawable.bounds.height()).isEqualTo(drawable.intrinsicHeight)
+    }
+
+    @Test
+    fun drawableWithoutIntrinsicSize() {
+        val drawable = NoIntrinsicSizeDrawable()
+        rule.setContent {
+            Image(
+                modifier = Modifier
+                    .width(128.dp)
+                    .height(64.dp)
+                    .testTag(TestTag),
+                painter = rememberDrawablePainter(drawable = drawable),
+                contentDescription = null,
+                contentScale = ContentScale.FillWidth,
+            )
+        }
+
+        rule.waitForIdle()
+        val imageSize = rule.onNodeWithTag(TestTag).fetchSemanticsNode().size
+        assertThat(drawable.bounds.width()).isEqualTo(imageSize.width)
+        assertThat(drawable.bounds.height()).isEqualTo(imageSize.height)
+    }
+
+    private companion object {
+        const val TestTag = "ImageItem"
+    }
+}

--- a/drawablepainter/src/androidTest/kotlin/com/google/accompanist/drawablepainter/Drawables.kt
+++ b/drawablepainter/src/androidTest/kotlin/com/google/accompanist/drawablepainter/Drawables.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.drawablepainter
+
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.PixelFormat
+import android.graphics.drawable.Drawable
+
+class NoIntrinsicSizeDrawable : IntrinsicSizeDrawable(-1, -1)
+
+open class IntrinsicSizeDrawable(val width: Int, val height: Int) : Drawable() {
+
+    override fun getIntrinsicWidth(): Int = width
+
+    override fun getIntrinsicHeight(): Int = height
+
+    override fun draw(canvas: Canvas) = Unit
+
+    override fun setAlpha(alpha: Int) = Unit
+
+    override fun setColorFilter(colorFilter: ColorFilter?) = Unit
+
+    @Deprecated("Deprecated in Java")
+    override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+}

--- a/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
+++ b/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
@@ -130,8 +130,10 @@ class DrawablePainter(
             // Reading this ensures that we invalidate when invalidateDrawable() is called
             drawInvalidateTick
 
-            // Update the Drawable's bounds
-            drawable.setBounds(0, 0, size.width.roundToInt(), size.height.roundToInt())
+            // Update the Drawable's bounds if necessary
+            if (drawable.bounds.isEmpty) {
+                drawable.setBounds(0, 0, size.width.roundToInt(), size.height.roundToInt())
+            }
 
             canvas.withSave {
                 drawable.draw(canvas.nativeCanvas)


### PR DESCRIPTION
This PR fixes the bug when `DrawablePainter` overwrites bounds of the drawable instance when drawing it. It leads to incorrect behaviour of content scaling of `Image`.