### PR TITLE
[Pager indicators]Don't draw active dot indicators for empty pagers.

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerIndicator.kt
@@ -113,9 +113,12 @@ fun HorizontalPagerIndicator(
                     )
                 }
                 .size(width = indicatorWidth, height = indicatorHeight)
-                .background(
-                    color = activeColor,
-                    shape = indicatorShape,
+                .then(
+                    if (pageCount > 0) Modifier.background(
+                        color = activeColor,
+                        shape = indicatorShape,
+                    )
+                    else Modifier
                 )
         )
     }
@@ -195,9 +198,12 @@ fun VerticalPagerIndicator(
                     )
                 }
                 .size(width = indicatorWidth, height = indicatorHeight)
-                .background(
-                    color = activeColor,
-                    shape = indicatorShape,
+                .then(
+                    if (pageCount > 0) Modifier.background(
+                        color = activeColor,
+                        shape = indicatorShape,
+                    )
+                    else Modifier
                 )
         )
     }


### PR DESCRIPTION
Fixes #1319

Before:
![Screenshot_20220909_180010](https://user-images.githubusercontent.com/3340954/189393911-4cad729d-b214-40ee-9cff-e6280bea3484.png)

After:
![Screenshot_20220909_175923](https://user-images.githubusercontent.com/3340954/189393901-691572c6-1c8c-4f63-b4c6-cdae95143b9a.png)

Analogous change for vertical pager indicator.
