### PR TITLE
[Pager] Make Pager able to scroll by flinging a nested scroll child

### DIFF
--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -92,7 +92,7 @@ class PagerState(
 
     internal var afterContentPadding = 0
 
-    private val currentPageLayoutInfo: LazyListItemInfo?
+    internal val currentPageLayoutInfo: LazyListItemInfo?
         get() = lazyListState.layoutInfo.visibleItemsInfo.lastOrNull {
             it.index == currentPage
         }

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/HorizontalPagerScrollingContentTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/HorizontalPagerScrollingContentTest.kt
@@ -89,6 +89,17 @@ class HorizontalPagerScrollingContentTest {
         // Assert that we're still on page 0
         assertThat(pagerState.currentPage).isEqualTo(0)
         assertThat(pagerState.currentPageOffset).isWithin(0.01f).of(0f)
+
+        // Perform a scroll in the same direction again
+        rule.onNodeWithTag(TestTag)
+            .swipeAcrossCenterWithVelocity(velocityPerSec = 2_000.dp, distancePercentageX = -0.5f)
+
+        // Wait for the flings to end
+        rule.waitForIdle()
+
+        // Assert that we're now on page 1
+        assertThat(pagerState.currentPage).isEqualTo(1)
+        assertThat(pagerState.currentPageOffset).isWithin(0.01f).of(0f)
     }
 
     companion object {

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/VerticalPagerScrollingContentTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/VerticalPagerScrollingContentTest.kt
@@ -88,6 +88,17 @@ class VerticalPagerScrollingContentTest {
         // Assert that we're still on page 0
         assertThat(pagerState.currentPage).isEqualTo(0)
         assertThat(pagerState.currentPageOffset).isWithin(0.01f).of(0f)
+
+        // Perform a scroll in the same direction again
+        rule.onNodeWithTag(TestTag)
+            .swipeAcrossCenterWithVelocity(velocityPerSec = 2_000.dp, distancePercentageY = -0.5f)
+
+        // Wait for the flings to end
+        rule.waitForIdle()
+
+        // Assert that we're now on page 1
+        assertThat(pagerState.currentPage).isEqualTo(1)
+        assertThat(pagerState.currentPageOffset).isWithin(0.01f).of(0f)
     }
 
     companion object {


### PR DESCRIPTION
Currently, Pager cannot scroll by flinging a nested scroll child.

https://user-images.githubusercontent.com/14194909/189514161-8326d628-2135-425c-abe5-df7bc64f7ac1.mp4

The reason is that Pager consumes ALL flings from children to prevent #347

I think that Pager should not consume flings when it is already scrolling