### PR TITLE
Use Gradle Managed Devices for instrumentation tests

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -84,7 +84,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 29, 31, 32 ]
+        api-level: [ 22, 26 ]
         shard: [ 0, 1 ] # Need to update shard-count below if this changes
 
     env:
@@ -147,14 +147,86 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          name: logs-aer-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
           path: logcat.txt
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test-results-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          name: test-aer-results-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          path: |
+            **/build/reports/*
+            **/build/outputs/*/connected/*
+
+  test-gmd:
+    runs-on: macos-latest
+    needs: build
+    timeout-minutes: 50
+
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level: [ 29, 31, 32 ]
+        shard: [ 0, 1 ] # Need to update shard-count below if this changes
+
+    env:
+      TERM: dumb
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Fetch expanded history, which is needed for affected module detection
+          fetch-depth: '500'
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Decrypt secrets
+        run: release/signing-setup.sh ${{ secrets.ENCRYPT_KEY }}
+
+      - name: Generate cache key
+        run: ./checksum.sh checksum.txt
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Accept licenses
+        run: |
+          echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_SDK_ROOT/licenses/android-sdk-license"
+          echo -e "\n859f317696f67ef3d7f30a50a5560e7834b43903" > "$ANDROID_SDK_ROOT/licenses/android-sdk-arm-dbt-license"
+          echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_SDK_ROOT/licenses/android-sdk-preview-license"
+
+      - name: Run tests
+        run: ./scripts/run-tests.sh --log-file=logcat.txt --gmd-api=${{ matrix.api-level }} --run-affected --affected-base-ref=$BASE_REF --shard-index=${{ matrix.shard }} --shard-count=2
+
+      - name: Clean secrets
+        if: always()
+        run: release/signing-cleanup.sh
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-gmd-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: logcat.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-gmd-results-${{ matrix.api-level }}-${{ matrix.shard }}
           path: |
             **/build/reports/*
             **/build/outputs/*/connected/*
@@ -163,7 +235,7 @@ jobs:
     if: github.event_name == 'push' # only deploy for pushed commits (not PRs)
 
     runs-on: ubuntu-latest
-    needs: [ build, test ]
+    needs: [ build, test-aer, test-gmd ]
     timeout-minutes: 30
     env:
       TERM: dumb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         if: always()
         run: release/signing-cleanup.sh
 
-  test:
+  test-aer:
     runs-on: macos-latest
     needs: build
     timeout-minutes: 70
@@ -82,7 +82,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 29 ]
+        api-level: [ 22, 26 ]
         shard: [ 0, 1 ] # Need to update shard-count below if this changes
 
     env:
@@ -155,14 +155,86 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          name: logs-aer-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
           path: logcat.txt
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test-results-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          name: test-aer-results-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          path: |
+            **/build/reports/*
+            **/build/outputs/*/connected/*
+
+  test-gmd:
+    runs-on: macos-latest
+    needs: build
+    timeout-minutes: 70
+
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level: [ 29, 31 ]
+        shard: [ 0, 1 ] # Need to update shard-count below if this changes
+
+    env:
+      TERM: dumb
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Fetch expanded history, which is needed for affected module detection
+          fetch-depth: '500'
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Decrypt secrets
+        run: release/signing-setup.sh ${{ secrets.ENCRYPT_KEY }}
+
+      - name: Generate cache key
+        run: ./checksum.sh checksum.txt
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Accept licenses
+        run: |
+          echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_SDK_ROOT/licenses/android-sdk-license"
+          echo -e "\n859f317696f67ef3d7f30a50a5560e7834b43903" > "$ANDROID_SDK_ROOT/licenses/android-sdk-arm-dbt-license"
+          echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_SDK_ROOT/licenses/android-sdk-preview-license"
+
+      - name: Run tests
+        run: ./scripts/run-tests.sh --log-file=logcat.txt --gmd-api=${{ matrix.api-level }} --run-affected --affected-base-ref=$BASE_REF --shard-index=${{ matrix.shard }} --shard-count=2
+
+      - name: Clean secrets
+        if: always()
+        run: release/signing-cleanup.sh
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-gmd-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: logcat.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-gmd-results-${{ matrix.api-level }}-${{ matrix.shard }}
           path: |
             **/build/reports/*
             **/build/outputs/*/connected/*
@@ -171,7 +243,7 @@ jobs:
     if: github.event_name == 'push' # only deploy for pushed commits (not PRs)
 
     runs-on: ubuntu-latest
-    needs: [ build, test ]
+    needs: [ build, test-aer, test-gmd ]
     timeout-minutes: 30
     env:
       TERM: dumb

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -11,7 +11,7 @@ on:
       - '.github/workflows/device-tests.yml'
 
 jobs:
-  android-test:
+  test-aer:
     runs-on: macos-latest
     if: github.repository == 'google/accompanist'
     timeout-minutes: 80
@@ -20,7 +20,7 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
-        api-level: [ 22, 26, 28, 29 ]
+        api-level: [ 22, 26 ]
         shard: [ 0, 1, 2 ] # Need to update shard-count below if this changes
 
     steps:
@@ -79,14 +79,82 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          name: logs-aer-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
           path: logcat.txt
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: test-results-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
+          name: test-aer-results-${{ matrix.api-level }}-${{ steps.determine-target.outputs.TARGET }}-${{ matrix.shard }}
           path: |
             **/build/reports/*
             **/build/outputs/*/connected/*
+
+
+  test-gmd:
+    runs-on: macos-latest
+    if: github.repository == 'google/accompanist'
+    timeout-minutes: 80
+
+    strategy:
+      # Allow tests to continue on other devices if they fail on one device.
+      fail-fast: false
+      matrix:
+        api-level: [ 28, 29, 31, 32 ]
+        shard: [ 0, 1, 2 ] # Need to update shard-count below if this changes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Decrypt secrets
+        run: release/signing-setup.sh ${{ secrets.ENCRYPT_KEY }}
+
+      - name: Generate cache key
+        run: ./checksum.sh checksum.txt
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/modules-*
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/build-cache-*
+          key: gradle-${{ hashFiles('checksum.txt') }}
+
+      - name: Accept licenses
+        run: |
+          echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_SDK_ROOT/licenses/android-sdk-license"
+          echo -e "\n859f317696f67ef3d7f30a50a5560e7834b43903" > "$ANDROID_SDK_ROOT/licenses/android-sdk-arm-dbt-license"
+          echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_SDK_ROOT/licenses/android-sdk-preview-license"
+
+      - name: Run tests
+        run: ./scripts/run-tests.sh --log-file=logcat.txt --gmd-api=${{ matrix.api-level }} --shard-index=${{ matrix.shard }} --shard-count=3
+
+      - name: Clean secrets
+        if: always()
+        run: release/signing-cleanup.sh
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-gmd-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: logcat.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-gmd-results-${{ matrix.api-level }}-${{ matrix.shard }}
+          path: |
+            **/build/reports/*
+            **/build/outputs/*/connected/*
+

--- a/adaptive/build.gradle
+++ b/adaptive/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/appcompat-theme/build.gradle
+++ b/appcompat-theme/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.dropbox.affectedmoduledetector.AffectedModuleConfiguration
 
 buildscript {
     repositories {
@@ -58,6 +59,13 @@ affectedModuleDetector {
 
     logFilename = "output.log"
     logFolder = "${rootProject.buildDir}/affectedModuleDetector"
+    customTasks = [28, 29, 31, 32].collect { api ->
+        new AffectedModuleConfiguration.CustomTask(
+                "runAffectedApi${api}AndroidTests",
+                "api${api}DebugAndroidTest",
+                "Run API ${api} GMD Android tests by Impact"
+        )
+    }
 
     String baseRef = findProperty("affected_base_ref")
     // If we have a base ref to diff against, extract the branch name and use it

--- a/drawablepainter/build.gradle
+++ b/drawablepainter/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -62,6 +64,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/flowlayout/build.gradle
+++ b/flowlayout/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,7 +90,7 @@ junit = "junit:junit:4.13.2"
 truth = "com.google.truth:truth:1.1.2"
 robolectric = "org.robolectric:robolectric:4.9"
 
-affectedmoduledetector = "com.dropbox.affectedmoduledetector:affectedmoduledetector:0.1.2"
+affectedmoduledetector = "com.dropbox.affectedmoduledetector:affectedmoduledetector:0.1.6"
 
 android-tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 android-tools-lint-lint = { module = "com.android.tools.lint:lint", version.ref = "lintMinCompose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ composeMaterial3 = "1.0.1"
 composesnapshot = "-" # a single character = no snapshot
 
 # gradlePlugin and lint need to be updated together
-gradlePlugin = "7.3.1"
+gradlePlugin = "7.4.0-rc01"
 lintMinCompose = "30.0.0"
 
 ktlint = "0.45.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ composeMaterial3 = "1.0.1"
 composesnapshot = "-" # a single character = no snapshot
 
 # gradlePlugin and lint need to be updated together
-gradlePlugin = "7.4.0-rc01"
+gradlePlugin = "8.0.0-alpha09"
 lintMinCompose = "30.0.0"
 
 ktlint = "0.45.2"

--- a/insets-ui/build.gradle
+++ b/insets-ui/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -74,6 +76,17 @@ android {
             }
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/insets/build.gradle
+++ b/insets/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/internal-testutils/build.gradle
+++ b/internal-testutils/build.gradle
@@ -58,6 +58,11 @@ android {
     }
 }
 
+// TODO: Workaround https://github.com/dropbox/AffectedModuleDetector/issues/159
+[28, 29, 31, 32].collect { api ->
+    tasks.register("api${api}DebugAndroidTest")
+}
+
 dependencies {
     implementation libs.kotlin.stdlib
     implementation libs.kotlin.coroutines.android

--- a/navigation-animation/build.gradle
+++ b/navigation-animation/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -63,6 +65,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     packagingOptions {

--- a/navigation-material/build.gradle
+++ b/navigation-material/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -63,6 +65,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     packagingOptions {

--- a/pager-indicators/build.gradle
+++ b/pager-indicators/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/pager/build.gradle
+++ b/pager/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/permissions-lint/build.gradle
+++ b/permissions-lint/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'java-library'
@@ -35,6 +37,11 @@ lintOptions {
 
 affectedTestConfiguration {
     jvmTestTask = "test"
+}
+
+// TODO: Workaround https://github.com/dropbox/AffectedModuleDetector/issues/159
+[28, 29, 31, 32].collect { api ->
+    tasks.register("api${api}DebugAndroidTest")
 }
 
 /**

--- a/permissions/build.gradle
+++ b/permissions/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
         }
         animationsDisabled true
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     packagingOptions {

--- a/placeholder-material/build.gradle
+++ b/placeholder-material/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/placeholder/build.gradle
+++ b/placeholder/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -72,6 +74,17 @@ android {
             }
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -47,6 +47,11 @@ android {
     namespace 'com.google.accompanist.sample'
 }
 
+// TODO: Workaround https://github.com/dropbox/AffectedModuleDetector/issues/159
+[28, 29, 31, 32].collect { api ->
+    tasks.register("api${api}DebugAndroidTest")
+}
+
 dependencies {
     implementation project(':adaptive')
     implementation project(':drawablepainter')

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Used for loading images from the network -->
+
     <uses-permission android:name="android.permission.INTERNET" />
 
     <!-- Used for the permissions sample -->
@@ -26,6 +27,13 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
 
     <application
         android:allowBackup="false"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -113,7 +113,7 @@ fi
 # Add Gradle Managed Devices specific properties for CI
 # TODO: Remove --no-parallel and -Dorg.gradle.workers.max=2 when GMD handles parallelization better
 if [[ ! -z "$GMD_API" ]]; then
-  TASK="$TASK -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --no-parallel -Dorg.gradle.workers.max=2"
+  TASK="$TASK -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --no-parallel -Dorg.gradle.workers.max=2 -Pandroid.experimental.testOptions.installApkTimeout=600"
 fi
 
 SHARD_OPTS=""

--- a/swiperefresh/build.gradle
+++ b/swiperefresh/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/systemuicontroller/build.gradle
+++ b/systemuicontroller/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -72,6 +74,17 @@ android {
             }
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -93,6 +95,17 @@ android {
             }
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/themeadapter-appcompat/build.gradle
+++ b/themeadapter-appcompat/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -70,6 +72,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/themeadapter-core/build.gradle
+++ b/themeadapter-core/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/themeadapter-material/build.gradle
+++ b/themeadapter-material/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/themeadapter-material3/build.gradle
+++ b/themeadapter-material3/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import com.android.build.api.dsl.ManagedVirtualDevice
+
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     id 'com.android.library'
@@ -69,6 +71,17 @@ android {
             includeAndroidResources = true
         }
         animationsDisabled true
+        managedDevices {
+            devices {
+                [28, 29, 31, 32].each { api ->
+                    create("api$api", ManagedVirtualDevice) {
+                        device = "Pixel 6"
+                        apiLevel = api
+                        systemImageSource = "google"
+                    }
+                }
+            }
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Fixes #1337 

This PR replaces using android-emulator-runner with Gradle Managed Devices on supported API levels (27 and above)

Implementation notes:

- API 26 and below are not supported by default, so I didn't convert to GMD for those (but we could using [an experimental property](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/options/BooleanOption.kt;l=150-158;drc=8564d0509d7d43c14686f15f9b6bf9837e176b46))
- I kept the current structure of copying the configuration between all modules, convention plugins to centralize configuration like this would be great to have in the future
- I didn't add in any Automated Test Devices as those are still experimental, although we definitely try them out if we wanted to