### PR TITLE
[Navigation Material] Add `skipHalfExpanded` parameter with default value equal to `false`.

### DIFF
--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -102,11 +102,13 @@ public class BottomSheetNavigatorSheetState(private val sheetState: ModalBottomS
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 public fun rememberBottomSheetNavigator(
-    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec
+    animationSpec: AnimationSpec<Float> = SwipeableDefaults.AnimationSpec,
+    skipHalfExpanded: Boolean = false
 ): BottomSheetNavigator {
     val sheetState = rememberModalBottomSheetState(
-        ModalBottomSheetValue.Hidden,
-        animationSpec
+        initialValue = ModalBottomSheetValue.Hidden,
+        animationSpec = animationSpec,
+        skipHalfExpanded = skipHalfExpanded
     )
     return remember(sheetState) {
         BottomSheetNavigator(sheetState = sheetState)


### PR DESCRIPTION
Hey, 
I added `skipHalfExpanded` boolean to the parameters of `rememberBottomSheetNavigator` function, because I think it is a popular use case to make it skip half expanded state as a default behaviour, especially when it is treated as separate navigation destination.