### PR TITLE
[SwipeRefresh] Deprecate SwipeRefresh

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,9 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value />
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="99" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="99" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="true" />

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -3,4 +3,7 @@
   <component name="Kotlin2JvmCompilerArguments">
     <option name="jvmTarget" value="1.8" />
   </component>
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ A library which provides [Compose Material](https://developer.android.com/jetpac
 ### 🖌️ [Drawable Painter](./drawablepainter/)
 A library which provides a way to use Android Drawables as Jetpack Compose Painters.
 
-### ⬇️ [Swipe to Refresh](./swiperefresh/)
-A library that provides a layout implementing the swipe-to-refresh UX pattern, similar to Android's [SwipeRefreshLayout](https://developer.android.com/jetpack/androidx/releases/swiperefreshlayout).
-
 ### 🌏 [Web](./web/)
 A wrapper around WebView for basic WebView support in Jetpack Compose.
 
@@ -69,6 +66,9 @@ A library providing a collection of utilities for adaptive layouts.
 
 ### 📐 [Insets](./insets/) (Deprecated)
 See our [Migration Guide](https://google.github.io/accompanist/insets/) for migrating to Insets in Compose.
+
+### ⬇️ [Swipe to Refresh](./swiperefresh/) (Deprecated)
+See our [Migration Guide](https://google.github.io/accompanist/swiperefresh/) for migrating to PullRefresh in Compose Material.
 
 ---
 

--- a/docs/swiperefresh.md
+++ b/docs/swiperefresh.md
@@ -2,6 +2,43 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-swiperefresh)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+!!! warning
+    **This library is deprecated, with official insets support in androidx.compose.foundation.** The migration guide and original documentation is below.
+
+## Migration
+
+Accompanist SwipeRefresh has been replaced by PullRefresh in [Compose Material 1.3.0](https://developer.android.com/jetpack/androidx/releases/compose-material#1.3.0). The implementation is similar but instead of being a Composable function, it is a Modifier that can be applied to a Composable function.
+
+A simple example is as follows:
+
+```kotlin
+val viewModel: MyViewModel = viewModel()
+val refreshing by viewModel.isRefreshing
+
+val pullRefreshState = rememberPullRefreshState(refreshing, { viewModel.refresh() })
+
+Box(Modifier.pullRefresh(pullRefreshState)) {
+    LazyColumn(Modifier.fillMaxSize()) {
+        ...
+    }
+
+    PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
+}
+```
+
+### Migration steps
+
+1. Replace SwipeRefresh with a Box or other layout of your choice, save your `onRefresh` lambda for the next step.
+2. Replace `rememberSwipeRefreshState()` with `rememberPullRefreshState(refreshing, onRefresh)`
+3. Add either the default `PullRefreshIndicator` or your own custom implementation to your layout.
+
+### Custom Indicator
+
+Instead of using the provided `PullRefreshIndicator` composable, you can create your own custom indicator.
+A full sample can be seen in the [Compose samples](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material/material/samples/src/main/java/androidx/compose/material/samples/PullRefreshSamples.kt;l=91?q=pullrefresh).
+
+## Original Docs
+
 A library which provides a layout which provides the swipe-to-refresh UX pattern, similar to Android's [`SwipeRefreshLayout`](https://developer.android.com/training/swipe/add-swipe-interface).
 
 <figure>

--- a/docs/swiperefresh.md
+++ b/docs/swiperefresh.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-swiperefresh)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-    **This library is deprecated, with official insets support in androidx.compose.foundation.** The migration guide and original documentation is below.
+    **This library is deprecated, with official pull refresh support in androidx.compose.material.pullrefresh The migration guide and original documentation is below.
 
 ## Migration
 

--- a/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderBasicSample.kt
@@ -19,21 +19,27 @@ package com.google.accompanist.sample.placeholder
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
@@ -43,8 +49,6 @@ import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.delay
 
 class PlaceholderBasicSample : ComponentActivity() {
@@ -59,7 +63,7 @@ class PlaceholderBasicSample : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalCoilApi::class)
+@OptIn(ExperimentalCoilApi::class, ExperimentalMaterialApi::class)
 @Composable
 private fun Sample() {
     Scaffold(
@@ -81,10 +85,12 @@ private fun Sample() {
             }
         }
 
-        SwipeRefresh(
-            state = rememberSwipeRefreshState(isRefreshing = refreshing),
-            onRefresh = { refreshing = true },
-        ) {
+        val state = rememberPullRefreshState(
+            refreshing = refreshing,
+            onRefresh = { refreshing = true }
+        )
+
+        Box(Modifier.pullRefresh(state)) {
             LazyColumn(contentPadding = padding) {
                 if (refreshing.not()) {
                     item {
@@ -104,6 +110,12 @@ private fun Sample() {
                     )
                 }
             }
+
+            PullRefreshIndicator(
+                refreshing = refreshing,
+                state = state,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
     }
 }

--- a/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderFadeSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderFadeSample.kt
@@ -19,20 +19,26 @@ package com.google.accompanist.sample.placeholder
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
@@ -44,8 +50,6 @@ import com.google.accompanist.placeholder.material.placeholder
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.delay
 
 class PlaceholderFadeSample : ComponentActivity() {
@@ -60,7 +64,7 @@ class PlaceholderFadeSample : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalCoilApi::class)
+@OptIn(ExperimentalCoilApi::class, ExperimentalMaterialApi::class)
 @Composable
 private fun Sample() {
     Scaffold(
@@ -82,10 +86,12 @@ private fun Sample() {
             }
         }
 
-        SwipeRefresh(
-            state = rememberSwipeRefreshState(isRefreshing = refreshing),
-            onRefresh = { refreshing = true },
-        ) {
+        val state = rememberPullRefreshState(
+            refreshing = refreshing,
+            onRefresh = { refreshing = true }
+        )
+
+        Box(Modifier.pullRefresh(state)) {
             LazyColumn(contentPadding = padding) {
                 if (refreshing.not()) {
                     item {
@@ -108,6 +114,12 @@ private fun Sample() {
                     )
                 }
             }
+
+            PullRefreshIndicator(
+                refreshing = refreshing,
+                state = state,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
     }
 }

--- a/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderShimmerSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/placeholder/PlaceholderShimmerSample.kt
@@ -19,20 +19,26 @@ package com.google.accompanist.sample.placeholder
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.stringResource
@@ -44,8 +50,6 @@ import com.google.accompanist.placeholder.material.shimmer
 import com.google.accompanist.sample.AccompanistSampleTheme
 import com.google.accompanist.sample.R
 import com.google.accompanist.sample.randomSampleImageUrl
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import kotlinx.coroutines.delay
 
 class PlaceholderShimmerSample : ComponentActivity() {
@@ -60,7 +64,7 @@ class PlaceholderShimmerSample : ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalCoilApi::class)
+@OptIn(ExperimentalCoilApi::class, ExperimentalMaterialApi::class)
 @Composable
 private fun Sample() {
     Scaffold(
@@ -82,10 +86,12 @@ private fun Sample() {
             }
         }
 
-        SwipeRefresh(
-            state = rememberSwipeRefreshState(isRefreshing = refreshing),
-            onRefresh = { refreshing = true },
-        ) {
+        val state = rememberPullRefreshState(
+            refreshing = refreshing,
+            onRefresh = { refreshing = true }
+        )
+
+        Box(Modifier.pullRefresh(state)) {
             LazyColumn(contentPadding = padding) {
                 if (refreshing.not()) {
                     item {
@@ -108,6 +114,12 @@ private fun Sample() {
                     )
                 }
             }
+
+            PullRefreshIndicator(
+                refreshing = refreshing,
+                state = state,
+                modifier = Modifier.align(Alignment.TopCenter)
+            )
         }
     }
 }

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/DocsSamples.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/DocsSamples.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:Suppress("UNUSED_ANONYMOUS_PARAMETER")
+@file:Suppress("UNUSED_ANONYMOUS_PARAMETER", "DEPRECATION")
 
 package com.google.accompanist.sample.swiperefresh
 

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
@@ -62,7 +62,6 @@ class SwipeRefreshBasicSample : ComponentActivity() {
     }
 }
 
-// @Suppress("DEPRECATION")
 @Suppress("DEPRECATION")
 @OptIn(ExperimentalCoilApi::class)
 @Composable

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -62,6 +63,8 @@ class SwipeRefreshBasicSample : ComponentActivity() {
     }
 }
 
+//@Suppress("DEPRECATION")
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalCoilApi::class)
 @Composable
 private fun Sample() {
@@ -84,8 +87,9 @@ private fun Sample() {
             }
         }
 
+        val state = rememberSwipeRefreshState(isRefreshing = true)
         SwipeRefresh(
-            state = rememberSwipeRefreshState(isRefreshing = refreshing),
+            state = state,
             onRefresh = { refreshing = true },
         ) {
             LazyColumn(contentPadding = padding) {

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshBasicSample.kt
@@ -20,7 +20,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -63,7 +62,7 @@ class SwipeRefreshBasicSample : ComponentActivity() {
     }
 }
 
-//@Suppress("DEPRECATION")
+// @Suppress("DEPRECATION")
 @Suppress("DEPRECATION")
 @OptIn(ExperimentalCoilApi::class)
 @Composable

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshContentPaddingSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshContentPaddingSample.kt
@@ -72,6 +72,7 @@ class SwipeRefreshContentPaddingSample : ComponentActivity() {
 
 private val listItems = List(40) { randomSampleImageUrl(it) }
 
+@Suppress("DEPRECATION")
 @Composable
 private fun Sample() {
     val systemUiController = rememberSystemUiController()

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshCustomIndicatorSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshCustomIndicatorSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.swiperefresh
 
 import android.os.Bundle
@@ -71,6 +73,7 @@ class SwipeRefreshCustomIndicatorSample : ComponentActivity() {
     }
 }
 
+@Suppress("DEPRECATION")
 @Composable
 private fun Sample() {
     Scaffold(

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshTweakedIndicatorSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshTweakedIndicatorSample.kt
@@ -63,6 +63,7 @@ class SwipeRefreshTweakedIndicatorSample : ComponentActivity() {
     }
 }
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalCoilApi::class)
 @Composable
 private fun Sample() {

--- a/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshVerticalPagerSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/swiperefresh/SwipeRefreshVerticalPagerSample.kt
@@ -68,6 +68,7 @@ class SwipeRefreshVerticalPagerSample : ComponentActivity() {
     }
 }
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalPagerApi::class, ExperimentalCoilApi::class)
 @Composable
 private fun Sample() {

--- a/swiperefresh/README.md
+++ b/swiperefresh/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-swiperefresh)](https://search.maven.org/search?q=g:com.google.accompanist)
 
-For more information, visit the documentation: https://google.github.io/accompanist/swiperefresh
+> :warning: This library has been deprecated as official support is now available in Compose Material 1.3.0. Please see our [Migration Guide](https://google.github.io/accompanist/swiperefresh/) for how to migrate.
 
 ## Download
 

--- a/swiperefresh/api/current.api
+++ b/swiperefresh/api/current.api
@@ -5,20 +5,20 @@ package com.google.accompanist.swiperefresh {
   }
 
   public final class SwipeRefreshIndicatorKt {
-    method @androidx.compose.runtime.Composable public static void SwipeRefreshIndicator(com.google.accompanist.swiperefresh.SwipeRefreshState state, float refreshTriggerDistance, optional androidx.compose.ui.Modifier modifier, optional boolean fade, optional boolean scale, optional boolean arrowEnabled, optional long backgroundColor, optional long contentColor, optional androidx.compose.ui.graphics.Shape shape, optional float refreshingOffset, optional boolean largeIndication, optional float elevation);
+    method @Deprecated @androidx.compose.runtime.Composable public static void SwipeRefreshIndicator(com.google.accompanist.swiperefresh.SwipeRefreshState state, float refreshTriggerDistance, optional androidx.compose.ui.Modifier modifier, optional boolean fade, optional boolean scale, optional boolean arrowEnabled, optional long backgroundColor, optional long contentColor, optional androidx.compose.ui.graphics.Shape shape, optional float refreshingOffset, optional boolean largeIndication, optional float elevation);
   }
 
   public final class SwipeRefreshKt {
-    method @androidx.compose.runtime.Composable public static void SwipeRefresh(com.google.accompanist.swiperefresh.SwipeRefreshState state, kotlin.jvm.functions.Function0<kotlin.Unit> onRefresh, optional androidx.compose.ui.Modifier modifier, optional boolean swipeEnabled, optional float refreshTriggerDistance, optional androidx.compose.ui.Alignment indicatorAlignment, optional androidx.compose.foundation.layout.PaddingValues indicatorPadding, optional kotlin.jvm.functions.Function2<? super com.google.accompanist.swiperefresh.SwipeRefreshState,? super androidx.compose.ui.unit.Dp,kotlin.Unit> indicator, optional boolean clipIndicatorToPadding, kotlin.jvm.functions.Function0<kotlin.Unit> content);
-    method @androidx.compose.runtime.Composable public static com.google.accompanist.swiperefresh.SwipeRefreshState rememberSwipeRefreshState(boolean isRefreshing);
+    method @Deprecated @androidx.compose.runtime.Composable public static void SwipeRefresh(com.google.accompanist.swiperefresh.SwipeRefreshState state, kotlin.jvm.functions.Function0<kotlin.Unit> onRefresh, optional androidx.compose.ui.Modifier modifier, optional boolean swipeEnabled, optional float refreshTriggerDistance, optional androidx.compose.ui.Alignment indicatorAlignment, optional androidx.compose.foundation.layout.PaddingValues indicatorPadding, optional kotlin.jvm.functions.Function2<? super com.google.accompanist.swiperefresh.SwipeRefreshState,? super androidx.compose.ui.unit.Dp,kotlin.Unit> indicator, optional boolean clipIndicatorToPadding, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @Deprecated @androidx.compose.runtime.Composable public static com.google.accompanist.swiperefresh.SwipeRefreshState rememberSwipeRefreshState(boolean isRefreshing);
   }
 
-  @androidx.compose.runtime.Stable public final class SwipeRefreshState {
-    ctor public SwipeRefreshState(boolean isRefreshing);
-    method public float getIndicatorOffset();
-    method public boolean isRefreshing();
-    method public boolean isSwipeInProgress();
-    method public void setRefreshing(boolean isRefreshing);
+  @Deprecated @androidx.compose.runtime.Stable public final class SwipeRefreshState {
+    ctor @Deprecated public SwipeRefreshState(boolean isRefreshing);
+    method @Deprecated public float getIndicatorOffset();
+    method @Deprecated public boolean isRefreshing();
+    method @Deprecated public boolean isSwipeInProgress();
+    method @Deprecated public void setRefreshing(boolean isRefreshing);
     property public final float indicatorOffset;
     property public final boolean isRefreshing;
     property public final boolean isSwipeInProgress;

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefresh.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefresh.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 @file:Suppress("DEPRECATION")
 
 package com.google.accompanist.swiperefresh

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefresh.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefresh.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
 
 package com.google.accompanist.swiperefresh
 
@@ -56,6 +57,17 @@ private const val DragMultiplier = 0.5f
  *
  * @param isRefreshing the value for [SwipeRefreshState.isRefreshing]
  */
+@Deprecated(
+    """
+     accompanist/swiperefresh is deprecated.
+     The androidx.compose equivalent of rememberSwipeRefreshState() is rememberPullRefreshState().
+     For more migration information, please visit https://google.github.io/accompanist/swiperefresh/#migration
+    """,
+    replaceWith = ReplaceWith(
+        "rememberPullRefreshState(isRefreshing, onRefresh = )",
+        "androidx.compose.material.pullrefresh.rememberPullRefreshState"
+    )
+)
 @Composable
 fun rememberSwipeRefreshState(
     isRefreshing: Boolean
@@ -76,6 +88,13 @@ fun rememberSwipeRefreshState(
  *
  * @param isRefreshing the initial value for [SwipeRefreshState.isRefreshing]
  */
+@Deprecated(
+    """
+     accompanist/swiperefresh is deprecated.
+     The androidx.compose equivalent of SwipeRefreshState is PullRefreshState.
+     For more migration information, please visit https://google.github.io/accompanist/swiperefresh/#migration
+    """
+)
 @Stable
 class SwipeRefreshState(
     isRefreshing: Boolean,
@@ -223,6 +242,19 @@ private class SwipeRefreshNestedScrollConnection(
  * provided the indicator will be clipped to the [content] bounds. Defaults to true.
  * @param content The content containing a scroll composable.
  */
+@Deprecated(
+    """
+ accompanist/swiperefresh is deprecated.
+ The androidx.compose equivalent of SwipeRefresh is Modifier.pullRefresh().
+ This is often migrated as:
+ Box(modifier = Modifier.pullRefresh(refreshState)) { 
+    ... 
+    PullRefreshIndicator(...) 
+ }
+ 
+ For more migration information, please visit https://google.github.io/accompanist/swiperefresh/#migration
+"""
+)
 @Composable
 fun SwipeRefresh(
     state: SwipeRefreshState,

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 @file:Suppress("DEPRECATION")
 
 package com.google.accompanist.swiperefresh

--- a/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
+++ b/swiperefresh/src/main/java/com/google/accompanist/swiperefresh/SwipeRefreshIndicator.kt
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
 
 package com.google.accompanist.swiperefresh
 
@@ -100,6 +101,13 @@ private val LargeSizes = SwipeRefreshIndicatorSizes(
  * @param largeIndication Whether the indicator should be 'large' or not. Defaults to false.
  * @param elevation The size of the shadow below the indicator.
  */
+@Deprecated(
+    """
+     accompanist/swiperefresh is deprecated.
+     The androidx.compose equivalent of SwipeRefreshIndicator() is PullRefreshIndicator().
+     For more migration information, please visit https://google.github.io/accompanist/swiperefresh/#migration
+    """
+)
 @Composable
 fun SwipeRefreshIndicator(
     state: SwipeRefreshState,

--- a/swiperefresh/src/sharedTest/kotlin/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
+++ b/swiperefresh/src/sharedTest/kotlin/com/google/accompanist/swiperefresh/SwipeRefreshTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.swiperefresh
 
 import androidx.compose.foundation.layout.fillMaxSize


### PR DESCRIPTION
Deprecates `SwipeRefresh` in Accompanist.
Write documentation for migration to Compose Material PullRefresh.