### PR TITLE
[Web] Fix WebView always filling max available space

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.accompanist.sample">
 
     <!-- Used for loading images from the network -->
@@ -34,6 +35,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
+
+        <profileable android:shell="true"
+            tools:targetApi="q" />
 
         <activity
             android:name="com.google.accompanist.sample.MainActivity"
@@ -406,6 +410,15 @@
         <activity
             android:name=".webview.BasicWebViewSample"
             android:label="@string/webview_title_basic"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.accompanist.sample.SAMPLE_CODE" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".webview.WrappedContentWebViewSample"
+            android:label="@string/webview_title_wrapped"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/sample/src/main/java/com/google/accompanist/sample/webview/WrappedContentWebViewSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/webview/WrappedContentWebViewSample.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.sample.webview
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.Button
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.web.WebView
+import com.google.accompanist.web.rememberWebViewStateWithHTMLData
+import kotlinx.coroutines.launch
+
+class WrappedContentWebViewSample : ComponentActivity() {
+    @OptIn(ExperimentalMaterialApi::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface {
+                    val sheetState = rememberModalBottomSheetState(
+                        initialValue = ModalBottomSheetValue.Hidden
+                    )
+                    ModalBottomSheetLayout(
+                        sheetState = sheetState,
+                        sheetContent = {
+                            WebContent()
+                        }
+                    ) {
+                        val scope = rememberCoroutineScope()
+                        Box(Modifier.fillMaxSize()) {
+                            Button(onClick = {
+                                scope.launch { sheetState.show() }
+                            }, Modifier.align(Alignment.Center)) {
+                                Text("Open Sheet")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/***
+ * A sample WebView that is wrapping it's content inside of a bottom sheet.
+ * The sheet should be the size of the rendered content and not unbounded.
+ */
+@Composable
+fun WebContent() {
+    val webViewState = rememberWebViewStateWithHTMLData(
+        data = "<html><head>\n" +
+            "<style>\n" +
+            "body {\n" +
+            "  background-color: #f00;\n" +
+            "}\n" +
+            "</style>\n" +
+            "</head><body><p>Hello</p></body></html>"
+    )
+    WebView(
+        state = webViewState,
+        modifier = Modifier.fillMaxWidth()
+            .wrapContentHeight()
+            .heightIn(min = 1.dp) // A bottom sheet can't support content with 0 height.
+    )
+}

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="placeholder_title_shimmer">Placeholder: Shimmer</string>
 
     <string name="webview_title_basic">WebView: Basic</string>
+    <string name="webview_title_wrapped">WebView: Wrapped Content</string>
 
     <string name="adaptive_two_pane_basic">Adaptive: TwoPane Basic</string>
     <string name="adaptive_two_pane_horizontal">Adaptive: TwoPane Horizontal</string>

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -115,6 +115,11 @@ fun WebView(
                     // WebView changes it's layout strategy based on
                     // it's layoutParams. We convert from Compose Modifier to
                     // layout params here.
+                    val width =
+                        if (constraints.hasFixedWidth)
+                            LayoutParams.MATCH_PARENT
+                        else
+                            LayoutParams.WRAP_CONTENT
                     val height =
                         if (constraints.hasFixedHeight)
                             LayoutParams.MATCH_PARENT
@@ -122,7 +127,7 @@ fun WebView(
                             LayoutParams.WRAP_CONTENT
 
                     layoutParams = LayoutParams(
-                        LayoutParams.MATCH_PARENT,
+                        width,
                         height
                     )
 


### PR DESCRIPTION
Fixes #1297

WebView changes its layout engine based on its layoutParams. This PR converts from a Compose modifier into view layoutParams in order to support this. I thought this was a better integration than simply exposing the layoutParams parameter.

![Screenshot_20221114_133703](https://user-images.githubusercontent.com/19445/201563524-8d943d90-947a-434f-9686-b6b791e4ec18.png)
