### PR TITLE
Refactor webview to not need to override url loading

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,8 +83,8 @@ androidx-test-orchestrator = "androidx.test:orchestrator:1.4.1"
 androidx-test-uiAutomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 
 # alpha for robolectric x compose fix
-androidx-test-espressoCore = "androidx.test.espresso:espresso-core:3.5.0-alpha07"
-androidx-test-espressoWeb = "androidx.test.espresso:espresso-web:3.5.0-alpha07"
+androidx-test-espressoCore = "androidx.test.espresso:espresso-core:3.5.1"
+androidx-test-espressoWeb = "androidx.test.espresso:espresso-web:3.5.1"
 
 junit = "junit:junit:4.13.2"
 truth = "com.google.truth:truth:1.1.2"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -44,6 +44,13 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
     }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.debug
+        }
+    }
+
     namespace 'com.google.accompanist.sample'
 }
 

--- a/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/webview/BasicWebViewSample.kt
@@ -59,16 +59,16 @@ import com.google.accompanist.web.rememberWebViewNavigator
 import com.google.accompanist.web.rememberWebViewState
 
 class BasicWebViewSample : ComponentActivity() {
+    val initialUrl = "https://google.com"
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AccompanistSampleTheme {
-                var url by remember { mutableStateOf("https://google.com") }
-                val state = rememberWebViewState(url = url)
+                val state = rememberWebViewState(url = initialUrl)
                 val navigator = rememberWebViewNavigator()
-                var textFieldValue by remember(state.content.getCurrentUrl()) {
-                    mutableStateOf(state.content.getCurrentUrl() ?: "")
+                var textFieldValue by remember(state.lastLoadedUrl) {
+                    mutableStateOf(state.lastLoadedUrl)
                 }
 
                 Column {
@@ -100,7 +100,7 @@ class BasicWebViewSample : ComponentActivity() {
                             }
 
                             OutlinedTextField(
-                                value = textFieldValue,
+                                value = textFieldValue ?: "",
                                 onValueChange = { textFieldValue = it },
                                 modifier = Modifier.fillMaxWidth()
                             )
@@ -108,7 +108,9 @@ class BasicWebViewSample : ComponentActivity() {
 
                         Button(
                             onClick = {
-                                url = textFieldValue
+                                textFieldValue?.let {
+                                    navigator.loadUrl(it)
+                                }
                             },
                             modifier = Modifier.align(Alignment.CenterVertically)
                         ) {
@@ -140,7 +142,8 @@ class BasicWebViewSample : ComponentActivity() {
 
                     WebView(
                         state = state,
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f),
                         navigator = navigator,
                         onCreated = { webView ->
                             webView.settings.javaScriptEnabled = true

--- a/web/api/current.api
+++ b/web/api/current.api
@@ -94,7 +94,7 @@ package com.google.accompanist.web {
     ctor public WebViewNavigator(kotlinx.coroutines.CoroutineScope coroutineScope);
     method public boolean getCanGoBack();
     method public boolean getCanGoForward();
-    method public void loadHtml(String html, optional String? baseUrl);
+    method public void loadHtml(String html, optional String? baseUrl, optional String? mimeType, optional String? encoding, optional String? historyUrl);
     method public void loadUrl(String url, optional java.util.Map<java.lang.String,java.lang.String> additionalHttpHeaders);
     method public void navigateBack();
     method public void navigateForward();
@@ -108,7 +108,7 @@ package com.google.accompanist.web {
     ctor public WebViewState(com.google.accompanist.web.WebContent webContent);
     method public com.google.accompanist.web.WebContent getContent();
     method public androidx.compose.runtime.snapshots.SnapshotStateList<com.google.accompanist.web.WebViewError> getErrorsForCurrentRequest();
-    method public String? getLastLoadedUrl();
+    method public error.NonExistentClass! getLastLoadedUrl();
     method public com.google.accompanist.web.LoadingState getLoadingState();
     method public android.graphics.Bitmap? getPageIcon();
     method public String? getPageTitle();
@@ -117,7 +117,7 @@ package com.google.accompanist.web {
     property public final com.google.accompanist.web.WebContent content;
     property public final androidx.compose.runtime.snapshots.SnapshotStateList<com.google.accompanist.web.WebViewError> errorsForCurrentRequest;
     property public final boolean isLoading;
-    property public final String? lastLoadedUrl;
+    property public final error.NonExistentClass! lastLoadedUrl;
     property public final com.google.accompanist.web.LoadingState loadingState;
     property public final android.graphics.Bitmap? pageIcon;
     property public final String? pageTitle;

--- a/web/api/current.api
+++ b/web/api/current.api
@@ -38,18 +38,27 @@ package com.google.accompanist.web {
   }
 
   public abstract sealed class WebContent {
-    method public final String? getCurrentUrl();
+    method @Deprecated public final String? getCurrentUrl();
   }
 
   public static final class WebContent.Data extends com.google.accompanist.web.WebContent {
-    ctor public WebContent.Data(String data, optional String? baseUrl);
+    ctor public WebContent.Data(String data, optional String? baseUrl, optional String encoding, optional String? mimeType, optional String? historyUrl);
     method public String component1();
     method public String? component2();
-    method public com.google.accompanist.web.WebContent.Data copy(String data, String? baseUrl);
+    method public String component3();
+    method public String? component4();
+    method public String? component5();
+    method public com.google.accompanist.web.WebContent.Data copy(String data, String? baseUrl, String encoding, String? mimeType, String? historyUrl);
     method public String? getBaseUrl();
     method public String getData();
+    method public String getEncoding();
+    method public String? getHistoryUrl();
+    method public String? getMimeType();
     property public final String? baseUrl;
     property public final String data;
+    property public final String encoding;
+    property public final String? historyUrl;
+    property public final String? mimeType;
   }
 
   public static final class WebContent.Url extends com.google.accompanist.web.WebContent {
@@ -78,13 +87,15 @@ package com.google.accompanist.web {
     method @androidx.compose.runtime.Composable public static void WebView(com.google.accompanist.web.WebViewState state, optional androidx.compose.ui.Modifier modifier, optional boolean captureBackPresses, optional com.google.accompanist.web.WebViewNavigator navigator, optional kotlin.jvm.functions.Function1<? super android.webkit.WebView,kotlin.Unit> onCreated, optional kotlin.jvm.functions.Function1<? super android.webkit.WebView,kotlin.Unit> onDispose, optional com.google.accompanist.web.AccompanistWebViewClient client, optional com.google.accompanist.web.AccompanistWebChromeClient chromeClient, optional kotlin.jvm.functions.Function1<? super android.content.Context,? extends android.webkit.WebView>? factory);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewNavigator rememberWebViewNavigator(optional kotlinx.coroutines.CoroutineScope coroutineScope);
     method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewState(String url, optional java.util.Map<java.lang.String,java.lang.String> additionalHttpHeaders);
-    method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewStateWithHTMLData(String data, optional String? baseUrl);
+    method @androidx.compose.runtime.Composable public static com.google.accompanist.web.WebViewState rememberWebViewStateWithHTMLData(String data, optional String? baseUrl, optional String encoding, optional String? mimeType, optional String? historyUrl);
   }
 
   @androidx.compose.runtime.Stable public final class WebViewNavigator {
     ctor public WebViewNavigator(kotlinx.coroutines.CoroutineScope coroutineScope);
     method public boolean getCanGoBack();
     method public boolean getCanGoForward();
+    method public void loadHtml(String html, optional String? baseUrl);
+    method public void loadUrl(String url, optional java.util.Map<java.lang.String,java.lang.String> additionalHttpHeaders);
     method public void navigateBack();
     method public void navigateForward();
     method public void reload();
@@ -97,6 +108,7 @@ package com.google.accompanist.web {
     ctor public WebViewState(com.google.accompanist.web.WebContent webContent);
     method public com.google.accompanist.web.WebContent getContent();
     method public androidx.compose.runtime.snapshots.SnapshotStateList<com.google.accompanist.web.WebViewError> getErrorsForCurrentRequest();
+    method public String? getLastLoadedUrl();
     method public com.google.accompanist.web.LoadingState getLoadingState();
     method public android.graphics.Bitmap? getPageIcon();
     method public String? getPageTitle();
@@ -105,6 +117,7 @@ package com.google.accompanist.web {
     property public final com.google.accompanist.web.WebContent content;
     property public final androidx.compose.runtime.snapshots.SnapshotStateList<com.google.accompanist.web.WebViewError> errorsForCurrentRequest;
     property public final boolean isLoading;
+    property public final String? lastLoadedUrl;
     property public final com.google.accompanist.web.LoadingState loadingState;
     property public final android.graphics.Bitmap? pageIcon;
     property public final String? pageTitle;

--- a/web/src/androidTest/assets/test_link.html
+++ b/web/src/androidTest/assets/test_link.html
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2023 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<html>
+    <body>
+        <a href="test.html">
+            <span style="display: block;">
+                Test link
+            </span>
+        </a>
+    </body>
+</html>

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -71,7 +71,7 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 // Emulator image doesn't have a WebView until API 26
 // Google API emulator image seems to be really flaky before 28 so currently we will set these tests
-// to min 29 and max 30. 31/32 image is also really flaky
+// to min 29.
 @SdkSuppress(minSdkVersion = 28)
 class WebTest {
     @get:Rule
@@ -466,10 +466,7 @@ class WebTest {
         }
 
         rule.waitForIdle()
-
-        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
-        // so manually click the view
-        rule.onNodeWithTag(WebViewTag).performClick()
+        clickOnWebViewLink()
 
         rule.waitUntil { navigator.canGoBack }
         assertThat(state.lastLoadedUrl).isEqualTo(LINK_URL)
@@ -499,10 +496,7 @@ class WebTest {
         }
 
         rule.waitForIdle()
-
-        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
-        // so manually click the view
-        rule.onNodeWithTag(WebViewTag).performClick()
+        clickOnWebViewLink()
 
         rule.waitUntil { navigator.canGoBack }
         assertThat(state.lastLoadedUrl).isEqualTo(LINK_URL)
@@ -538,10 +532,7 @@ class WebTest {
         }
 
         rule.waitForIdle()
-
-        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
-        // so manually click the view
-        rule.onNodeWithTag(WebViewTag).performClick()
+        clickOnWebViewLink()
 
         rule.waitUntil { navigator.canGoBack }
         assertThat(navigator.canGoBack).isTrue()
@@ -565,10 +556,7 @@ class WebTest {
         }
 
         rule.waitForIdle()
-
-        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
-        // so manually click the view
-        rule.onNodeWithTag(WebViewTag).performClick()
+        clickOnWebViewLink()
 
         rule.waitUntil { navigator.canGoBack }
         navigator.navigateBack()
@@ -718,6 +706,12 @@ class WebTest {
 
         // If the WebView is wrapping it's content successfully, the box will have some height.
         rule.onNodeWithTag("box").assertHeightIsAtLeast(1.dp)
+    }
+
+    private fun clickOnWebViewLink() {
+        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
+        // so manually click the view
+        rule.onNodeWithTag(WebViewTag).performClick()
     }
 }
 

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -520,6 +520,7 @@ class WebTest {
         assertThat(state.lastLoadedUrl).isEqualTo(LINK_URL)
     }
 
+    @FlakyTest
     @Test
     fun testNavigatorCanGoBack() {
         lateinit var state: WebViewState
@@ -546,6 +547,7 @@ class WebTest {
         assertThat(navigator.canGoBack).isTrue()
     }
 
+    @FlakyTest
     @Test
     fun testNavigatorCanGoForward() {
         lateinit var state: WebViewState

--- a/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
+++ b/web/src/androidTest/kotlin/com/google/accompanist/web/WebTest.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.model.Atoms.getCurrentUrl
@@ -71,7 +72,7 @@ import java.util.concurrent.TimeUnit
 // Emulator image doesn't have a WebView until API 26
 // Google API emulator image seems to be really flaky before 28 so currently we will set these tests
 // to min 29 and max 30. 31/32 image is also really flaky
-@SdkSuppress(minSdkVersion = 28, maxSdkVersion = 30)
+@SdkSuppress(minSdkVersion = 28)
 class WebTest {
     @get:Rule
     val rule = createComposeRule()
@@ -148,7 +149,7 @@ class WebTest {
         // Wait for the webview to load and then perform the check
         rule.waitForIdle()
         onWebView().check(webMatches(getCurrentUrl(), containsString(LINK_URL)))
-        assertThat(state.content.getCurrentUrl())
+        assertThat(state.lastLoadedUrl)
             .isEqualTo(LINK_URL)
     }
 
@@ -326,7 +327,7 @@ class WebTest {
         rule.waitForIdle()
 
         onWebView().check(webMatches(getCurrentUrl(), containsString("about:blank")))
-        assertThat(state.content.getCurrentUrl())
+        assertThat(state.lastLoadedUrl)
             .isEqualTo("about:blank")
     }
 
@@ -349,7 +350,7 @@ class WebTest {
         // Wait for the webview to load and then perform the check
         rule.waitForIdle()
         onWebView().check(webMatches(getCurrentUrl(), containsString(LINK_URL)))
-        assertThat(state.content.getCurrentUrl())
+        assertThat(state.lastLoadedUrl)
             .isEqualTo(LINK_URL)
     }
 
@@ -447,13 +448,14 @@ class WebTest {
         mockServer.shutdown()
     }
 
+    @FlakyTest
     @Test
     fun testNavigatorBack() {
         lateinit var state: WebViewState
         lateinit var navigator: WebViewNavigator
 
         rule.setContent {
-            state = rememberWebViewStateWithHTMLData(data = TEST_DATA)
+            state = rememberWebViewState(url = TEST_LINK_FILE_URL)
             navigator = rememberWebViewNavigator()
 
             WebTestContent(
@@ -465,19 +467,18 @@ class WebTest {
 
         rule.waitForIdle()
 
-        onWebView()
-            .withElement(findElement(Locator.ID, "link"))
-            .perform(webClick())
+        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
+        // so manually click the view
+        rule.onNodeWithTag(WebViewTag).performClick()
 
         rule.waitUntil { navigator.canGoBack }
-        assertThat(state.content.getCurrentUrl()).isEqualTo(LINK_URL)
+        assertThat(state.lastLoadedUrl).isEqualTo(LINK_URL)
 
         navigator.navigateBack()
 
         // Check that we're back on the original page with the link
         onWebView()
-            .withElement(findElement(Locator.ID, "link"))
-            .check(webMatches(getText(), equalTo(LINK_TEXT)))
+            .withElement(findElement(Locator.LINK_TEXT, TEST_LINK_FILE_TEXT))
     }
 
     @FlakyTest
@@ -487,7 +488,7 @@ class WebTest {
         lateinit var navigator: WebViewNavigator
 
         rule.setContent {
-            state = rememberWebViewStateWithHTMLData(data = TEST_DATA)
+            state = rememberWebViewState(url = TEST_LINK_FILE_URL)
             navigator = rememberWebViewNavigator()
 
             WebTestContent(
@@ -499,23 +500,24 @@ class WebTest {
 
         rule.waitForIdle()
 
-        onWebView()
-            .withElement(findElement(Locator.ID, "link"))
-            .perform(webClick())
+        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
+        // so manually click the view
+        rule.onNodeWithTag(WebViewTag).performClick()
 
         rule.waitUntil { navigator.canGoBack }
+        assertThat(state.lastLoadedUrl).isEqualTo(LINK_URL)
+
         navigator.navigateBack()
 
         // Check that we're back on the original page with the link
         onWebView()
-            .withElement(findElement(Locator.ID, "link"))
-            .check(webMatches(getText(), equalTo(LINK_TEXT)))
+            .withElement(findElement(Locator.LINK_TEXT, TEST_LINK_FILE_TEXT))
 
         navigator.navigateForward()
         rule.waitUntil { navigator.canGoBack }
         rule.waitForIdle()
 
-        assertThat(state.content.getCurrentUrl()).isEqualTo(LINK_URL)
+        assertThat(state.lastLoadedUrl).isEqualTo(LINK_URL)
     }
 
     @Test
@@ -524,7 +526,7 @@ class WebTest {
         lateinit var navigator: WebViewNavigator
 
         rule.setContent {
-            state = rememberWebViewStateWithHTMLData(data = TEST_DATA)
+            state = rememberWebViewState(url = TEST_LINK_FILE_URL)
             navigator = rememberWebViewNavigator()
 
             WebTestContent(
@@ -535,11 +537,10 @@ class WebTest {
         }
 
         rule.waitForIdle()
-        assertThat(navigator.canGoBack).isFalse()
 
-        onWebView()
-            .withElement(findElement(Locator.ID, "link"))
-            .perform(webClick())
+        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
+        // so manually click the view
+        rule.onNodeWithTag(WebViewTag).performClick()
 
         rule.waitUntil { navigator.canGoBack }
         assertThat(navigator.canGoBack).isTrue()
@@ -551,7 +552,7 @@ class WebTest {
         lateinit var navigator: WebViewNavigator
 
         rule.setContent {
-            state = rememberWebViewStateWithHTMLData(data = TEST_DATA)
+            state = rememberWebViewState(url = TEST_LINK_FILE_URL)
             navigator = rememberWebViewNavigator()
 
             WebTestContent(
@@ -563,9 +564,9 @@ class WebTest {
 
         rule.waitForIdle()
 
-        onWebView()
-            .withElement(findElement(Locator.ID, "link"))
-            .perform(webClick())
+        // HACK: EspressoWeb webClick doesn't track back navigation for some reason
+        // so manually click the view
+        rule.onNodeWithTag(WebViewTag).performClick()
 
         rule.waitUntil { navigator.canGoBack }
         navigator.navigateBack()
@@ -721,6 +722,8 @@ class WebTest {
 private const val LINK_ID = "link"
 private const val LINK_TEXT = "Click me"
 private const val LINK_URL = "file:///android_asset/test.html"
+private const val TEST_LINK_FILE_URL = "file:///android_asset/test_link.html"
+private const val TEST_LINK_FILE_TEXT = "Test link"
 private const val TITLE_TEXT = "A Test Title"
 private const val TEST_DATA =
     "<html><body><a id=$LINK_ID href=\"$LINK_URL\">$LINK_TEXT</a></body></html>"

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -356,7 +356,13 @@ class WebViewNavigator(private val coroutineScope: CoroutineScope) {
             val additionalHttpHeaders: Map<String, String> = emptyMap()
         ) : NavigationEvent
 
-        data class LoadHtml(val html: String, val baseUrl: String? = null) : NavigationEvent
+        data class LoadHtml(
+            val html: String,
+            val baseUrl: String? = null,
+            val mimeType: String? = null,
+            val encoding: String? = "utf-8",
+            val historyUrl: String? = null
+        ) : NavigationEvent
     }
 
     private val navigationEvents: MutableSharedFlow<NavigationEvent> = MutableSharedFlow()
@@ -372,9 +378,9 @@ class WebViewNavigator(private val coroutineScope: CoroutineScope) {
                 is NavigationEvent.LoadHtml -> loadDataWithBaseURL(
                     event.baseUrl,
                     event.html,
-                    null,
-                    "utf-8",
-                    null
+                    event.mimeType,
+                    event.encoding,
+                    event.historyUrl
                 )
 
                 is NavigationEvent.LoadUrl -> {
@@ -407,8 +413,24 @@ class WebViewNavigator(private val coroutineScope: CoroutineScope) {
         }
     }
 
-    fun loadHtml(html: String, baseUrl: String? = null) {
-        coroutineScope.launch { navigationEvents.emit(NavigationEvent.LoadHtml(html, baseUrl)) }
+    fun loadHtml(
+        html: String,
+        baseUrl: String? = null,
+        mimeType: String? = null,
+        encoding: String? = "utf-8",
+        historyUrl: String? = null
+    ) {
+        coroutineScope.launch {
+            navigationEvents.emit(
+                NavigationEvent.LoadHtml(
+                    html,
+                    baseUrl,
+                    mimeType,
+                    encoding,
+                    historyUrl
+                )
+            )
+        }
     }
 
     /**

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -38,10 +38,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
+import com.google.accompanist.web.LoadingState.Finished
+import com.google.accompanist.web.LoadingState.Loading
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -89,9 +91,31 @@ fun WebView(
         with(navigator) { webView?.handleNavigationEvents() }
     }
 
+    LaunchedEffect(webView, state) {
+        if (webView == null) return@LaunchedEffect
+
+        snapshotFlow { state.content }.collect { content ->
+            when (content) {
+                is WebContent.Url -> {
+                    webView?.loadUrl(content.url, content.additionalHttpHeaders)
+                }
+
+                is WebContent.Data -> {
+                    webView?.loadDataWithBaseURL(
+                        content.baseUrl,
+                        content.data,
+                        content.mimeType,
+                        content.encoding,
+                        content.historyUrl
+                    )
+                }
+            }
+        }
+    }
+
     val currentOnDispose by rememberUpdatedState(onDispose)
 
-    webView?.let { it ->
+    webView?.let {
         DisposableEffect(it) {
             onDispose { currentOnDispose(it) }
         }
@@ -103,8 +127,6 @@ fun WebView(
     client.state = state
     client.navigator = navigator
     chromeClient.state = state
-
-    val runningInPreview = LocalInspectionMode.current
 
     BoxWithConstraints(modifier) {
         AndroidView(
@@ -135,27 +157,7 @@ fun WebView(
                     webViewClient = client
                 }.also { webView = it }
             }
-        ) { view ->
-            // AndroidViews are not supported by preview, bail early
-            if (runningInPreview) return@AndroidView
-
-            when (val content = state.content) {
-                is WebContent.Url -> {
-                    val url = content.url
-
-                    if (url.isNotEmpty() && url != view.url) {
-                        view.loadUrl(url, content.additionalHttpHeaders.toMutableMap())
-                    }
-                }
-
-                is WebContent.Data -> {
-                    view.loadDataWithBaseURL(content.baseUrl, content.data, null, "utf-8", null)
-                }
-            }
-
-            navigator.canGoBack = view.canGoBack()
-            navigator.canGoForward = view.canGoForward()
-        }
+        )
     }
 }
 
@@ -179,33 +181,20 @@ open class AccompanistWebViewClient : WebViewClient() {
         state.errorsForCurrentRequest.clear()
         state.pageTitle = null
         state.pageIcon = null
+
+        state.lastLoadedUrl = url
     }
 
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
         state.loadingState = LoadingState.Finished
-        navigator.canGoBack = view?.canGoBack() ?: false
-        navigator.canGoForward = view?.canGoForward() ?: false
     }
 
-    override fun doUpdateVisitedHistory(
-        view: WebView?,
-        url: String?,
-        isReload: Boolean
-    ) {
+    override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
         super.doUpdateVisitedHistory(view, url, isReload)
-        // WebView will often update the current url itself.
-        // This happens in situations like redirects and navigating through
-        // history. We capture this change and update our state holder url.
-        // On older APIs (28 and lower), this method is called when loading
-        // html data. We don't want to update the state in this case as that will
-        // overwrite the html being loaded.
-        if (url != null &&
-            !url.startsWith("data:text/html") &&
-            state.content.getCurrentUrl() != url
-        ) {
-            state.content = state.content.withUrl(url)
-        }
+
+        navigator.canGoBack = view?.canGoBack() ?: false
+        navigator.canGoForward = view?.canGoForward() ?: false
     }
 
     override fun onReceivedError(
@@ -218,24 +207,6 @@ open class AccompanistWebViewClient : WebViewClient() {
         if (error != null) {
             state.errorsForCurrentRequest.add(WebViewError(request, error))
         }
-    }
-
-    override fun shouldOverrideUrlLoading(
-        view: WebView?,
-        request: WebResourceRequest?
-    ): Boolean {
-        // If the url hasn't changed, this is probably an internal event like
-        // a javascript reload. We should let it happen.
-        if (view?.url == request?.url.toString()) {
-            return false
-        }
-
-        // Override all url loads to make the single source of truth
-        // of the URL the state holder Url
-        request?.let {
-            state.content = state.content.withUrl(it.url.toString())
-        }
-        return true
     }
 }
 
@@ -274,8 +245,15 @@ sealed class WebContent {
         val additionalHttpHeaders: Map<String, String> = emptyMap(),
     ) : WebContent()
 
-    data class Data(val data: String, val baseUrl: String? = null) : WebContent()
+    data class Data(
+        val data: String,
+        val baseUrl: String? = null,
+        val encoding: String = "utf-8",
+        val mimeType: String? = null,
+        val historyUrl: String? = null
+    ) : WebContent()
 
+    @Deprecated("Use state.lastLoadedUrl instead")
     fun getCurrentUrl(): String? {
         return when (this) {
             is Url -> url
@@ -317,6 +295,9 @@ sealed class LoadingState {
  */
 @Stable
 class WebViewState(webContent: WebContent) {
+    var lastLoadedUrl by mutableStateOf<String?>(null)
+        internal set
+
     /**
      *  The content being loaded by the WebView
      */
@@ -364,7 +345,19 @@ class WebViewState(webContent: WebContent) {
 @Stable
 class WebViewNavigator(private val coroutineScope: CoroutineScope) {
 
-    private enum class NavigationEvent { BACK, FORWARD, RELOAD, STOP_LOADING }
+    private sealed interface NavigationEvent {
+        object Back : NavigationEvent
+        object Forward : NavigationEvent
+        object Reload : NavigationEvent
+        object StopLoading : NavigationEvent
+
+        data class LoadUrl(
+            val url: String,
+            val additionalHttpHeaders: Map<String, String> = emptyMap()
+        ) : NavigationEvent
+
+        data class LoadHtml(val html: String, val baseUrl: String? = null) : NavigationEvent
+    }
 
     private val navigationEvents: MutableSharedFlow<NavigationEvent> = MutableSharedFlow()
 
@@ -372,10 +365,21 @@ class WebViewNavigator(private val coroutineScope: CoroutineScope) {
     internal suspend fun WebView.handleNavigationEvents(): Nothing = withContext(Dispatchers.Main) {
         navigationEvents.collect { event ->
             when (event) {
-                NavigationEvent.BACK -> goBack()
-                NavigationEvent.FORWARD -> goForward()
-                NavigationEvent.RELOAD -> reload()
-                NavigationEvent.STOP_LOADING -> stopLoading()
+                is NavigationEvent.Back -> goBack()
+                is NavigationEvent.Forward -> goForward()
+                is NavigationEvent.Reload -> reload()
+                is NavigationEvent.StopLoading -> stopLoading()
+                is NavigationEvent.LoadHtml -> loadDataWithBaseURL(
+                    event.baseUrl,
+                    event.html,
+                    null,
+                    "utf-8",
+                    null
+                )
+
+                is NavigationEvent.LoadUrl -> {
+                    loadUrl(event.url, event.additionalHttpHeaders)
+                }
             }
         }
     }
@@ -392,32 +396,47 @@ class WebViewNavigator(private val coroutineScope: CoroutineScope) {
     var canGoForward: Boolean by mutableStateOf(false)
         internal set
 
+    fun loadUrl(url: String, additionalHttpHeaders: Map<String, String> = emptyMap()) {
+        coroutineScope.launch {
+            navigationEvents.emit(
+                NavigationEvent.LoadUrl(
+                    url,
+                    additionalHttpHeaders
+                )
+            )
+        }
+    }
+
+    fun loadHtml(html: String, baseUrl: String? = null) {
+        coroutineScope.launch { navigationEvents.emit(NavigationEvent.LoadHtml(html, baseUrl)) }
+    }
+
     /**
      * Navigates the webview back to the previous page.
      */
     fun navigateBack() {
-        coroutineScope.launch { navigationEvents.emit(NavigationEvent.BACK) }
+        coroutineScope.launch { navigationEvents.emit(NavigationEvent.Back) }
     }
 
     /**
      * Navigates the webview forward after going back from a page.
      */
     fun navigateForward() {
-        coroutineScope.launch { navigationEvents.emit(NavigationEvent.FORWARD) }
+        coroutineScope.launch { navigationEvents.emit(NavigationEvent.Forward) }
     }
 
     /**
      * Reloads the current page in the webview.
      */
     fun reload() {
-        coroutineScope.launch { navigationEvents.emit(NavigationEvent.RELOAD) }
+        coroutineScope.launch { navigationEvents.emit(NavigationEvent.Reload) }
     }
 
     /**
      * Stops the current page load (if one is loading).
      */
     fun stopLoading() {
-        coroutineScope.launch { navigationEvents.emit(NavigationEvent.STOP_LOADING) }
+        coroutineScope.launch { navigationEvents.emit(NavigationEvent.StopLoading) }
     }
 }
 
@@ -459,12 +478,17 @@ fun rememberWebViewState(
 ): WebViewState =
 // Rather than using .apply {} here we will recreate the state, this prevents
     // a recomposition loop when the webview updates the url itself.
-    remember(url, additionalHttpHeaders) {
+    remember {
         WebViewState(
             WebContent.Url(
                 url = url,
                 additionalHttpHeaders = additionalHttpHeaders
             )
+        )
+    }.apply {
+        this.content = WebContent.Url(
+            url = url,
+            additionalHttpHeaders = additionalHttpHeaders
         )
     }
 
@@ -474,7 +498,17 @@ fun rememberWebViewState(
  * @param data The uri to load in the WebView
  */
 @Composable
-fun rememberWebViewStateWithHTMLData(data: String, baseUrl: String? = null): WebViewState =
-    remember(data, baseUrl) {
-        WebViewState(WebContent.Data(data, baseUrl))
+fun rememberWebViewStateWithHTMLData(
+    data: String,
+    baseUrl: String? = null,
+    encoding: String = "utf-8",
+    mimeType: String? = null,
+    historyUrl: String? = null
+): WebViewState =
+    remember {
+        WebViewState(WebContent.Data(data, baseUrl, encoding, mimeType, historyUrl))
+    }.apply {
+        this.content = WebContent.Data(
+            data, baseUrl, encoding, mimeType, historyUrl
+        )
     }


### PR DESCRIPTION
Refactors WebView to not have to use `overrideUrlLoading`. This was leading to a lot of navigation edge cases that weren't properly handled. The new wrapping method should provide a more stable foundation to build upon.

| Deprecated | Replacement |
|---|---|
| **state.content.getCurrentUrl()** - **state.content** will also no longer track what url the webview is showing | **state.lastLoadedUrl** - Compose state object for the last url loaded by the WebView |

Fixes not following all redirects correctly
Fixes #1433
Fixes #1476