### PR TITLE
[Pager] Nested Scrolling list offset issue

### DIFF
--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/HorizontalPagerScrollingContentTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/HorizontalPagerScrollingContentTest.kt
@@ -92,7 +92,7 @@ class HorizontalPagerScrollingContentTest {
 
         // Perform a scroll in the same direction again
         rule.onNodeWithTag(TestTag)
-            .swipeAcrossCenterWithVelocity(velocityPerSec = 2_000.dp, distancePercentageX = -0.5f)
+            .swipeAcrossCenterWithVelocity(velocityPerSec = 2_000.dp, distancePercentageX = -0.6f)
 
         // Wait for the flings to end
         rule.waitForIdle()

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/VerticalPagerScrollingContentTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/VerticalPagerScrollingContentTest.kt
@@ -91,7 +91,7 @@ class VerticalPagerScrollingContentTest {
 
         // Perform a scroll in the same direction again
         rule.onNodeWithTag(TestTag)
-            .swipeAcrossCenterWithVelocity(velocityPerSec = 2_000.dp, distancePercentageY = -0.5f)
+            .swipeAcrossCenterWithVelocity(velocityPerSec = 2_000.dp, distancePercentageY = -0.6f)
 
         // Wait for the flings to end
         rule.waitForIdle()


### PR DESCRIPTION
When nested scrolling in a pager, if we don't scroll over half a pager before letting the fling start, we'll snap back after the fling finishes scrolling the inner list. In this PR I'm making the scrolling list to scroll over half a pager so when the fling finishes we can continue the scrolling towards the next page.
