### PR TITLE
[Test Harness] Update test harness icon to 🗜

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A wrapper around WebView for basic WebView support in Jetpack Compose.
 ### 📜 [Adaptive](./adaptive/)
 A library providing a collection of utilities for adaptive layouts.
 
-### 📜 [Test Harness](./testharness/)
+### 🗜 [Test Harness](./testharness/)
 Utilities for testing Compose layouts.
 
 ### 📐 [Insets](./insets/) (Deprecated)


### PR DESCRIPTION
Proposal to update the emoji for the testharness library to :clamp, to represent holding a composable in place to test it.