### PR TITLE
[Test Harness] Add custom ContextThemeWrapper to improve test harness behavior in previews

### DIFF
--- a/docs/testharness.md
+++ b/docs/testharness.md
@@ -136,8 +136,8 @@ The mechanism that the test harness uses is also not suitable for production cod
 the default configuration as specified by the user and the system should be used.
 
 The mechanism that the test harness uses to override the configuration (`ContextThemeWrapper`) is
-currently not supported by layoutlib, meaning `TestHarness` will not work in Android Studio
-previews or screenshot testing that uses layoutlib.
+not fully supported by layoutlib. In particular, alternate resources are available just by using
+`TestHarness`.
 
 ## Download
 

--- a/sample/src/main/java/com/google/accompanist/sample/testharness/TestHarnessSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/testharness/TestHarnessSample.kt
@@ -50,29 +50,35 @@ class TestHarnessSample : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            Column(
-                modifier = Modifier
-                    .padding(16.dp)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                TestHarnessScreen()
-                TestHarness(size = DpSize(100.dp, 100.dp)) {
-                    TestHarnessScreen("with a set size")
-                }
-                TestHarness(darkMode = true) {
-                    TestHarnessScreen("with darkMode enabled")
-                }
-                TestHarness(fontScale = 2f) {
-                    TestHarnessScreen("with a big font scale")
-                }
-                TestHarness(layoutDirection = LayoutDirection.Rtl) {
-                    TestHarnessScreen("in RTL")
-                }
-                TestHarness(locales = LocaleListCompat.create(Locale("ar"))) {
-                    TestHarnessScreen("in Arabic")
-                }
-            }
+            TestHarnessSampleScreen()
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TestHarnessSampleScreen() {
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        TestHarnessScreen()
+        TestHarness(size = DpSize(100.dp, 100.dp)) {
+            TestHarnessScreen("with a set size")
+        }
+        TestHarness(darkMode = true) {
+            TestHarnessScreen("with darkMode enabled")
+        }
+        TestHarness(fontScale = 2f) {
+            TestHarnessScreen("with a big font scale")
+        }
+        TestHarness(layoutDirection = LayoutDirection.Rtl) {
+            TestHarnessScreen("in RTL")
+        }
+        TestHarness(locales = LocaleListCompat.create(Locale("ar"))) {
+            TestHarnessScreen("in Arabic")
         }
     }
 }

--- a/testharness/src/main/java/com/google/accompanist/testharness/ContextThemeWrapper.java
+++ b/testharness/src/main/java/com/google/accompanist/testharness/ContextThemeWrapper.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.testharness;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.AssetManager;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.view.LayoutInflater;
+
+import androidx.annotation.RequiresApi;
+import androidx.annotation.StyleRes;
+
+/**
+ * A context wrapper that allows you to modify or replace the theme of the wrapped context.
+ * <p>
+ * This is a modification of androidx.appcompat.view.ContextThemeWrapper to allow the
+ * TestHarness to work in previews.
+ */
+class ContextThemeWrapper extends ContextWrapper {
+    /**
+     * Lazily-populated configuration object representing an empty, default configuration.
+     */
+    private static Configuration sEmptyConfig;
+
+    private int mThemeResource;
+    private Resources.Theme mTheme;
+    private LayoutInflater mInflater;
+    private Configuration mOverrideConfiguration;
+    private Resources mResources;
+
+    /**
+     * Creates a new context wrapper with no theme and no base context.
+     * <p class="note">
+     * <strong>Note:</strong> A base context <strong>must</strong> be attached
+     * using {@link #attachBaseContext(Context)} before calling any other
+     * method on the newly constructed context wrapper.
+     */
+    public ContextThemeWrapper() {
+        super(null);
+    }
+
+    /**
+     * Creates a new context wrapper with the specified theme.
+     * <p>
+     * The specified theme will be applied on top of the base context's theme.
+     * Any attributes not explicitly defined in the theme identified by
+     * <var>themeResId</var> will retain their original values.
+     *
+     * @param base the base context
+     * @param themeResId the resource ID of the theme to be applied on top of
+     *                   the base context's theme
+     */
+    public ContextThemeWrapper(Context base, @StyleRes int themeResId) {
+        super(base);
+        mThemeResource = themeResId;
+    }
+
+    /**
+     * Creates a new context wrapper with the specified theme.
+     * <p>
+     * Unlike {@link #ContextThemeWrapper(Context, int)}, the theme passed to
+     * this constructor will completely replace the base context's theme.
+     *
+     * @param base the base context
+     * @param theme the theme against which resources should be inflated
+     */
+    public ContextThemeWrapper(Context base, Resources.Theme theme) {
+        super(base);
+        mTheme = theme;
+    }
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(newBase);
+    }
+
+    /**
+     * Call to set an "override configuration" on this context -- this is
+     * a configuration that replies one or more values of the standard
+     * configuration that is applied to the context.  See
+     * {@link Context#createConfigurationContext(Configuration)} for more
+     * information.
+     *
+     * <p>This method can only be called once, and must be called before any
+     * calls to {@link #getResources()} or {@link #getAssets()} are made.
+     */
+    public void applyOverrideConfiguration(Configuration overrideConfiguration) {
+        if (mResources != null) {
+            throw new IllegalStateException(
+                "getResources() or getAssets() has already been called");
+        }
+        if (mOverrideConfiguration != null) {
+            throw new IllegalStateException("Override configuration has already been set");
+        }
+        mOverrideConfiguration = new Configuration(overrideConfiguration);
+    }
+
+    @Override
+    public Resources getResources() {
+        return getResourcesInternal();
+    }
+
+    private Resources getResourcesInternal() {
+        if (mResources == null) {
+            if (mOverrideConfiguration == null
+                || (Build.VERSION.SDK_INT >= 26
+                    && isEmptyConfiguration(mOverrideConfiguration))) {
+                // If we're not applying any overrides, use the base context's resources. On API
+                // 26+, this will avoid pulling in resources that share a backing implementation
+                // with the application context.
+                mResources = super.getResources();
+            } else {
+                final Context resContext = createConfigurationContext(mOverrideConfiguration);
+
+                // MAIN UPDATE: If resContext is null, fallback to the deprecated Resources
+                // constructor instead of crashing
+                if (resContext != null) {
+                    mResources = resContext.getResources();
+                } else {
+                    Resources res = super.getResources();
+                    Configuration newConfig = new Configuration(res.getConfiguration());
+                    newConfig.updateFrom(mOverrideConfiguration);
+                    mResources = new Resources(res.getAssets(), res.getDisplayMetrics(), newConfig);
+                }
+            }
+        }
+        return mResources;
+    }
+
+    @Override
+    public void setTheme(int resid) {
+        if (mThemeResource != resid) {
+            mThemeResource = resid;
+            initializeTheme();
+        }
+    }
+
+    /**
+     * Returns the resource ID of the theme that is to be applied on top of the base context's
+     * theme.
+     */
+    public int getThemeResId() {
+        return mThemeResource;
+    }
+
+    @Override
+    public Resources.Theme getTheme() {
+        if (mTheme != null) {
+            return mTheme;
+        }
+
+        initializeTheme();
+
+        return mTheme;
+    }
+
+    @Override
+    public Object getSystemService(String name) {
+        if (LAYOUT_INFLATER_SERVICE.equals(name)) {
+            if (mInflater == null) {
+                mInflater = LayoutInflater.from(getBaseContext()).cloneInContext(this);
+            }
+            return mInflater;
+        }
+        return getBaseContext().getSystemService(name);
+    }
+
+    /**
+     * Called by {@link #setTheme} and {@link #getTheme} to apply a theme
+     * resource to the current Theme object.  Can override to change the
+     * default (simple) behavior.  This method will not be called in multiple
+     * threads simultaneously.
+     *
+     * @param theme The Theme object being modified.
+     * @param resid The theme style resource being applied to <var>theme</var>.
+     * @param first Set to true if this is the first time a style is being
+     *              applied to <var>theme</var>.
+     */
+    protected void onApplyThemeResource(Resources.Theme theme, int resid, boolean first) {
+        theme.applyStyle(resid, true);
+    }
+
+    private void initializeTheme() {
+        final boolean first = mTheme == null;
+        if (first) {
+            mTheme = getResources().newTheme();
+            Resources.Theme theme = getBaseContext().getTheme();
+            if (theme != null) {
+                mTheme.setTo(theme);
+            }
+        }
+        onApplyThemeResource(mTheme, mThemeResource, first);
+    }
+
+    @Override
+    public AssetManager getAssets() {
+        // Ensure we're returning assets with the correct configuration.
+        return getResources().getAssets();
+    }
+
+    /**
+     * @return {@code true} if the specified configuration is {@code null} or is a no-op when
+     *         used as a configuration overlay
+     */
+    @RequiresApi(26)
+    private static boolean isEmptyConfiguration(Configuration overrideConfiguration) {
+        if (overrideConfiguration == null) {
+            return true;
+        }
+
+        if (sEmptyConfig == null) {
+            Configuration emptyConfig = new Configuration();
+            // Workaround for incorrect default fontScale on earlier SDKs (b/29924927). Note
+            // that Configuration.setToDefaults() is *not* a no-op configuration overlay.
+            emptyConfig.fontScale = 0.0f;
+            sEmptyConfig = emptyConfig;
+        }
+
+        return overrideConfiguration.equals(sEmptyConfig);
+    }
+}

--- a/testharness/src/main/java/com/google/accompanist/testharness/TestHarness.kt
+++ b/testharness/src/main/java/com/google/accompanist/testharness/TestHarness.kt
@@ -20,7 +20,6 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.LocaleList
 import android.util.DisplayMetrics
-import android.view.ContextThemeWrapper
 import android.view.View
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box


### PR DESCRIPTION
Adds a custom `ContextThemeWrapper` to work around the issue that currently causes `TestHarness` to fail in previews.

The cause of the crash is that `Context.createConfigurationContext` returns `null` for `BridgeContext` in layoutlib: https://cs.android.com/android/platform/superproject/+/master:frameworks/layoutlib/bridge/src/com/android/layoutlib/bridge/android/BridgeContext.java;l=1380;drc=58bd418e161b5d4fdde39b46523d3e49269117e3

`ContextThemeWrapper` uses this `Context.createConfigurationContext` internally and assumes it is not null, which causes the crash.

The `androidx.appcompat.view.ContextThemeWrapper` has a fallback mechanism for older API versions using a deprecated `Resources` constructor, so this PR adds a custom `ContextThemeWrapper` based on the appcompat one that uses that fallback mechanism in case `Context.createConfigurationContext` is null.

This improves behavior, preventing the crash, but doesn't remove all of the limitations. In particular, alternate resources are not loaded (such as the string not translated in the below image), which is probably related to how layoutlib manages resources.

<img width="201" alt="Screen Shot 2022-11-22 at 12 05 11 PM" src="https://user-images.githubusercontent.com/4217560/203648286-a766f4fb-181c-4681-968f-34c86d8e29e1.png">
