### PR TITLE
[testharness] Add support for Wear to test harness

### DIFF
--- a/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/WearTest.kt
+++ b/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/WearTest.kt
@@ -16,15 +16,13 @@
 
 package com.google.accompanist.adaptive
 
-import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
 import com.google.accompanist.testharness.TestHarness
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assume
-import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,19 +34,20 @@ class WearTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
+    @SdkSuppress(minSdkVersion = 23) // SCREENLAYOUT_ROUND_YES supported on API 23+
     fun is_round_for_wear() {
-        assumeTrue(Build.VERSION.SDK_INT >= 23)
-
         var defaultRound: Boolean? = null
         var forcedRound: Boolean? = null
         var forcedNotRound: Boolean? = null
 
         composeTestRule.setContent {
             defaultRound = LocalConfiguration.current.isScreenRound
-            TestHarness(isScreenRound = true) {
-                forcedRound = LocalConfiguration.current.isScreenRound
-                TestHarness(isScreenRound = false) {
-                    forcedNotRound = LocalConfiguration.current.isScreenRound
+            TestHarness(isScreenRound = false) {
+                TestHarness(isScreenRound = true) {
+                    forcedRound = LocalConfiguration.current.isScreenRound
+                    TestHarness(isScreenRound = false) {
+                        forcedNotRound = LocalConfiguration.current.isScreenRound
+                    }
                 }
             }
         }

--- a/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/WearTest.kt
+++ b/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/WearTest.kt
@@ -16,12 +16,15 @@
 
 package com.google.accompanist.adaptive
 
+import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.accompanist.testharness.TestHarness
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assume
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,6 +37,8 @@ class WearTest {
 
     @Test
     fun is_round_for_wear() {
+        assumeTrue(Build.VERSION.SDK_INT >= 23)
+
         var defaultRound: Boolean? = null
         var forcedRound: Boolean? = null
         var forcedNotRound: Boolean? = null

--- a/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/WearTest.kt
+++ b/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/WearTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.adaptive
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.accompanist.testharness.TestHarness
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WearTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun is_round_for_wear() {
+        var defaultRound: Boolean? = null
+        var forcedRound: Boolean? = null
+        var forcedNotRound: Boolean? = null
+
+        composeTestRule.setContent {
+            defaultRound = LocalConfiguration.current.isScreenRound
+            TestHarness(isScreenRound = true) {
+                forcedRound = LocalConfiguration.current.isScreenRound
+                TestHarness(isScreenRound = false) {
+                    forcedNotRound = LocalConfiguration.current.isScreenRound
+                }
+            }
+        }
+
+        assertThat(defaultRound).isEqualTo(composeTestRule.activity.resources.configuration.isScreenRound)
+        assertThat(forcedRound).isTrue()
+        assertThat(forcedNotRound).isFalse()
+    }
+}

--- a/testharness/api/current.api
+++ b/testharness/api/current.api
@@ -2,7 +2,7 @@
 package com.google.accompanist.testharness {
 
   public final class TestHarnessKt {
-    method @androidx.compose.runtime.Composable public static void TestHarness(optional long size, optional boolean darkMode, optional androidx.core.os.LocaleListCompat locales, optional androidx.compose.ui.unit.LayoutDirection? layoutDirection, optional float fontScale, optional Integer? fontWeightAdjustment, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void TestHarness(optional long size, optional boolean darkMode, optional androidx.core.os.LocaleListCompat locales, optional androidx.compose.ui.unit.LayoutDirection? layoutDirection, optional float fontScale, optional Integer? fontWeightAdjustment, optional Boolean? isScreenRound, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
 }

--- a/testharness/src/main/java/com/google/accompanist/testharness/TestHarness.kt
+++ b/testharness/src/main/java/com/google/accompanist/testharness/TestHarness.kt
@@ -65,6 +65,9 @@ import kotlin.math.floor
  *
  * @param fontWeightAdjustment the font weight adjustment for fonts. This defaults to the current
  * [fontWeightAdjustment] (if any). If `null`, the [fontWeightAdjustment] will be left unchanged.
+ *
+ * @param isScreenRound the device roundness. This defaults to null. If `null`,
+ * the [isScreenRound] will be left unchanged.
  */
 @Composable
 fun TestHarness(
@@ -75,6 +78,7 @@ fun TestHarness(
     fontScale: Float = LocalDensity.current.fontScale,
     fontWeightAdjustment: Int? =
         if (Build.VERSION.SDK_INT >= 31) LocalConfiguration.current.fontWeightAdjustment else null,
+    isScreenRound: Boolean? = null,
     content: @Composable () -> Unit
 ) {
     // Use the DensityForcedSize content wrapper if specified
@@ -114,6 +118,15 @@ fun TestHarness(
                 // Maybe override fontWeightAdjustment
                 if (Build.VERSION.SDK_INT >= 31 && fontWeightAdjustment != null) {
                     this.fontWeightAdjustment = fontWeightAdjustment
+                }
+                // override isRound for Wear
+                if (Build.VERSION.SDK_INT >= 23 && isScreenRound != null) {
+                    screenLayout = when (isScreenRound) {
+                        true -> (screenLayout and Configuration.SCREENLAYOUT_ROUND_MASK.inv()) or
+                            Configuration.SCREENLAYOUT_ROUND_YES
+                        false -> (screenLayout and Configuration.SCREENLAYOUT_ROUND_MASK.inv()) or
+                            Configuration.SCREENLAYOUT_ROUND_NO
+                    }
                 }
             },
         ) {
@@ -199,7 +212,9 @@ internal fun DensityForcedSize(
         ) {
             Box(
                 // This size will now be guaranteed to be able to match the constraints
-                modifier = Modifier.size(size).fillMaxSize()
+                modifier = Modifier
+                    .size(size)
+                    .fillMaxSize()
             ) {
                 content()
             }


### PR DESCRIPTION
Add support for Wear to test harness.  

To replace existing test libraries like https://github.com/google/horologist/blob/1ab282cf951b0386650acfff3ee8ed8acaf2ea2d/compose-tools/src/main/java/com/google/android/horologist/compose/tools/RoundPreview.kt