### PR TITLE
[Navigation Material] Make BottomSheetNavigatorSheetState can manually show or hide

### DIFF
--- a/navigation-material/api/current.api
+++ b/navigation-material/api/current.api
@@ -30,7 +30,9 @@ package com.google.accompanist.navigation.material {
     method public androidx.compose.runtime.State<java.lang.Float> getOverflow();
     method public androidx.compose.material.SwipeProgress<androidx.compose.material.ModalBottomSheetValue> getProgress();
     method public androidx.compose.material.ModalBottomSheetValue getTargetValue();
+    method public suspend Object? hide(kotlin.coroutines.Continuation<? super kotlin.Unit> p);
     method public boolean isVisible();
+    method public suspend Object? show(kotlin.coroutines.Continuation<? super kotlin.Unit> p);
     property public final androidx.compose.material.ModalBottomSheetValue currentValue;
     property public final float direction;
     property public final boolean isVisible;

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -93,6 +93,20 @@ public class BottomSheetNavigatorSheetState(private val sheetState: ModalBottomS
      */
     public val progress: SwipeProgress<ModalBottomSheetValue>
         get() = sheetState.progress
+
+    /**
+     * @see ModalBottomSheetState.show
+     */
+    public suspend fun show() {
+        sheetState.show()
+    }
+
+    /**
+     * @see ModalBottomSheetState.show
+     */
+    public suspend fun hide() {
+        sheetState.hide()
+    }
 }
 
 /**


### PR DESCRIPTION
Currently, I cannot find a method to show or hide the bottom sheet manually.

Usage:
```
val bottomSheetNavigator: BottomSheetNavigator = rememberBottomSheetNavigator()
val coroutineScope: CoroutineScope = rememberCoroutineScope()
Button(
    onClick = {
        coroutineScope.launch {
            bottomSheetNavigator.navigatorSheetState.show() // or hide()
        }
    },
    content = { Text(text = "Button") },
)
``