### PR TITLE
Add minSdk info to AndroidManifest

### DIFF
--- a/appcompat-theme/src/androidTest/AndroidManifest.xml
+++ b/appcompat-theme/src/androidTest/AndroidManifest.xml
@@ -15,7 +15,9 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.accompanist.appcompattheme">
+    <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 
     <application>
         <activity

--- a/appcompat-theme/src/main/AndroidManifest.xml
+++ b/appcompat-theme/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.appcompattheme">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.appcompattheme">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/drawablepainter/src/main/AndroidManifest.xml
+++ b/drawablepainter/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.drawablepainter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.drawablepainter">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/flowlayout/src/main/AndroidManifest.xml
+++ b/flowlayout/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.flowlayout">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.flowlayout">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/insets-ui/src/androidTest/AndroidManifest.xml
+++ b/insets-ui/src/androidTest/AndroidManifest.xml
@@ -15,6 +15,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.accompanist.insets.test">
 
     <uses-sdk android:targetSdkVersion="30" />

--- a/insets-ui/src/main/AndroidManifest.xml
+++ b/insets-ui/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.insets.ui">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.insets.ui">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/insets/src/main/AndroidManifest.xml
+++ b/insets/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.insets">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.insets">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/navigation-animation/src/main/AndroidManifest.xml
+++ b/navigation-animation/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.navigation.animation">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.navigation.animation">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/navigation-material/src/main/AndroidManifest.xml
+++ b/navigation-material/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.navigation.material">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.navigation.material">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/pager-indicators/src/main/AndroidManifest.xml
+++ b/pager-indicators/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.pager.indicators">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.pager.indicators">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/pager/src/main/AndroidManifest.xml
+++ b/pager/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.pager">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.pager">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/permissions/src/main/AndroidManifest.xml
+++ b/permissions/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.permissions">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.permissions">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/placeholder-material/src/main/AndroidManifest.xml
+++ b/placeholder-material/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.placeholder.material">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.placeholder.material">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/placeholder/src/main/AndroidManifest.xml
+++ b/placeholder/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.placeholder">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.placeholder">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/swiperefresh/src/main/AndroidManifest.xml
+++ b/swiperefresh/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.swiperefresh">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.swiperefresh">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/systemuicontroller/src/main/AndroidManifest.xml
+++ b/systemuicontroller/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.systemuicontroller">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.systemuicontroller">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/testharness/src/main/AndroidManifest.xml
+++ b/testharness/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.testharness">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.testharness">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/themeadapter-appcompat/src/main/AndroidManifest.xml
+++ b/themeadapter-appcompat/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.themeadapter.appcompat">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.themeadapter.appcompat">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/themeadapter-core/src/main/AndroidManifest.xml
+++ b/themeadapter-core/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.themeadapter.core">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.themeadapter.core">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/themeadapter-material/src/main/AndroidManifest.xml
+++ b/themeadapter-material/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.themeadapter.material">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.themeadapter.material">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/themeadapter-material3/src/main/AndroidManifest.xml
+++ b/themeadapter-material3/src/main/AndroidManifest.xml
@@ -14,5 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.google.accompanist.themeadapter.material3">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.google.accompanist.themeadapter.material3">
+  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>

--- a/web/src/main/AndroidManifest.xml
+++ b/web/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.google.accompanist.web">
-
+    <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
 </manifest>


### PR DESCRIPTION
This makes it easier to import Accompanist into non-gradle build environments