### PR TITLE
[Gradle] Add root project name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -49,3 +49,5 @@ include ':themeadapter-appcompat'
 include ':themeadapter-material'
 include ':themeadapter-material3'
 include ':web'
+
+rootProject.name = 'accompanist'


### PR DESCRIPTION
Currently, I'm still waiting for https://github.com/google/accompanist/pull/1437 to be merged. I was letting the accompanist as a composite build replace the original version. 

But this introduces a warning:
`Project accessors enabled, but root project name not explicitly set for 'accompanist'. Checking out the project in different folders will impact the generated code and implicitly the buildscript classpath, breaking caching.`

I believe the composite build will become more and more commonly used by the developer, which is why I am creating this simple PR.