### PR TITLE
[Navigation Animation] Change zIndex to match navigator back stack

### DIFF
--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
@@ -196,11 +196,7 @@ public fun AnimatedNavHost(
         transition.AnimatedContent(
             modifier,
             transitionSpec = {
-                val zIndex = if (composeNavigator.isPop.value) {
-                    visibleEntries.indexOf(initialState).toFloat()
-                } else {
-                    visibleEntries.indexOf(targetState).toFloat()
-                }
+                val zIndex = composeNavigator.backStack.value.size.toFloat()
                 // If the initialState of the AnimatedContent is not in visibleEntries, we are in
                 // a case where visible has cleared the old state for some reason, so instead of
                 // attempting to animate away from the initialState, we skip the animation.

--- a/sample/src/main/java/com/google/accompanist/sample/navigation/animation/AnimatedNavHostSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/navigation/animation/AnimatedNavHostSample.kt
@@ -342,43 +342,64 @@ fun NavigateBackButton(navController: NavController) {
 }
 
 object Destinations {
-    const val Login = "login"
-    const val Home = "home"
+    const val First = "first"
+    const val Second = "second"
+    const val Third = "third"
 }
-
 @ExperimentalAnimationApi
 @Composable
 fun NavTestScreen() {
     val navController = rememberAnimatedNavController()
     AnimatedNavHost(
         navController = navController,
-        startDestination = Destinations.Login,
+        startDestination = Destinations.First,
         modifier = Modifier.fillMaxSize()
     ) {
         composable(
-            Destinations.Login,
-            enterTransition = { NavigationTransition.IdentityEnter },
+            Destinations.First,
+            enterTransition = { NavigationTransition.slideInBottomAnimation },
+            popEnterTransition = { NavigationTransition.IdentityEnter },
             exitTransition = { NavigationTransition.IdentityExit },
+            popExitTransition = { NavigationTransition.slideOutBottomAnimation },
         ) {
             Button(onClick = {
-                navController.navigate(Destinations.Home)
+                navController.navigate(Destinations.Second)
             }) {
-                Text(text = "Next")
+                Text(text = "First")
             }
         }
         composable(
-            route = Destinations.Home,
+            route = Destinations.Second,
             enterTransition = { NavigationTransition.slideInBottomAnimation },
-            exitTransition = { NavigationTransition.slideOutBottomAnimation },
+            popEnterTransition = { NavigationTransition.IdentityEnter },
+            exitTransition = { NavigationTransition.IdentityExit },
+            popExitTransition = { NavigationTransition.slideOutBottomAnimation },
+        ) {
+            Button(
+                onClick = {
+                    navController.navigate(Destinations.Third)
+                },
+                colors = ButtonDefaults.buttonColors(backgroundColor = Color.Yellow),
+                modifier = Modifier.zIndex(100f)
+            ) {
+                Text(text = "Second")
+            }
+        }
+        composable(
+            route = Destinations.Third,
+            enterTransition = { NavigationTransition.slideInBottomAnimation },
+            popEnterTransition = { NavigationTransition.IdentityEnter },
+            exitTransition = { NavigationTransition.IdentityExit },
+            popExitTransition = { NavigationTransition.slideOutBottomAnimation },
         ) {
             Button(
                 onClick = {
                     navController.popBackStack()
                 },
-                colors = ButtonDefaults.buttonColors(backgroundColor = Color.Yellow),
+                colors = ButtonDefaults.buttonColors(backgroundColor = Color.Blue),
                 modifier = Modifier.zIndex(100f)
             ) {
-                Text(text = "label")
+                Text(text = "Third")
             }
         }
     }


### PR DESCRIPTION
The zIndex is currently based on the index of the entry from the list of visible entries available in the navigator. The visible entries get recreated each time the back stack changes and this means the index of the entries changes as well. When doing a pop, the zIndex of the ContentTransform is 0, when there is an additional pop, the zIndex of the new ContentTransform is also 0. Since both of them have the same value, the new ContentTransform is on top and that causes the pop enter transition to be on top.

If we provide the value of the back stack as the zIndex instead, each ContentTransform will increase in value as the stack gets larger, and when popping, the zIndex of outgoing entries will never be the same as the zIndex of incoming entries.

Fixes #1411
