### PR TITLE
[Pager] Migrate from Snapper to SnapFlingBehavior; Support Snap on Mouse Scroll

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,8 +33,6 @@ compose-material-iconsext = { module = "androidx.compose.material:material-icons
 compose-material3-material3 = { module = "androidx.compose.material3:material3", version.ref = "composeMaterial3" }
 compose-animation-animation = { module = "androidx.compose.animation:animation", version.ref = "compose" }
 
-snapper = "dev.chrisbanes.snapper:snapper:0.2.2"
-
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 gradleMavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.17.0"
 metalavaGradle = "me.tylerbwong.gradle:metalava-gradle:0.1.9"

--- a/pager/api/current.api
+++ b/pager/api/current.api
@@ -10,17 +10,6 @@ package com.google.accompanist.pager {
     method @com.google.accompanist.pager.ExperimentalPagerApi public static float calculateCurrentOffsetForPage(com.google.accompanist.pager.PagerScope, int page);
   }
 
-  @com.google.accompanist.pager.ExperimentalPagerApi public final class PagerDefaults {
-    method @Deprecated @androidx.compose.runtime.Composable @dev.chrisbanes.snapper.ExperimentalSnapperApi public androidx.compose.foundation.gestures.FlingBehavior flingBehavior(com.google.accompanist.pager.PagerState state, optional androidx.compose.animation.core.DecayAnimationSpec<java.lang.Float> decayAnimationSpec, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> snapAnimationSpec, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> maximumFlingDistance, optional float endContentPadding);
-    method @androidx.compose.runtime.Composable @dev.chrisbanes.snapper.ExperimentalSnapperApi public androidx.compose.foundation.gestures.FlingBehavior flingBehavior(com.google.accompanist.pager.PagerState state, optional androidx.compose.animation.core.DecayAnimationSpec<java.lang.Float> decayAnimationSpec, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> snapAnimationSpec, optional float endContentPadding, kotlin.jvm.functions.Function3<? super dev.chrisbanes.snapper.SnapperLayoutInfo,? super java.lang.Integer,? super java.lang.Integer,java.lang.Integer> snapIndex);
-    method @androidx.compose.runtime.Composable @dev.chrisbanes.snapper.ExperimentalSnapperApi public androidx.compose.foundation.gestures.FlingBehavior flingBehavior(com.google.accompanist.pager.PagerState state, optional androidx.compose.animation.core.DecayAnimationSpec<java.lang.Float> decayAnimationSpec, optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> snapAnimationSpec, optional float endContentPadding);
-    method @Deprecated public kotlin.jvm.functions.Function1<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> getSinglePageFlingDistance();
-    method public kotlin.jvm.functions.Function3<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Integer,java.lang.Integer,java.lang.Integer> getSinglePageSnapIndex();
-    property @Deprecated public final kotlin.jvm.functions.Function1<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Float> singlePageFlingDistance;
-    property public final kotlin.jvm.functions.Function3<dev.chrisbanes.snapper.SnapperLayoutInfo,java.lang.Integer,java.lang.Integer,java.lang.Integer> singlePageSnapIndex;
-    field public static final com.google.accompanist.pager.PagerDefaults INSTANCE;
-  }
-
   @androidx.compose.runtime.Stable @com.google.accompanist.pager.ExperimentalPagerApi public interface PagerScope {
     method public int getCurrentPage();
     method public float getCurrentPageOffset();

--- a/pager/build.gradle
+++ b/pager/build.gradle
@@ -85,7 +85,6 @@ android {
 
 dependencies {
     api libs.compose.foundation.foundation
-    api libs.snapper
 
     implementation libs.napier
     implementation libs.kotlin.coroutines.android

--- a/pager/src/main/java/com/google/accompanist/pager/Pager.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/Pager.kt
@@ -18,14 +18,12 @@
 
 package com.google.accompanist.pager
 
-import androidx.compose.animation.core.AnimationSpec
-import androidx.compose.animation.core.DecayAnimationSpec
-import androidx.compose.animation.rememberSplineBasedDecay
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -42,7 +40,6 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.snapper.ExperimentalSnapperApi
@@ -65,138 +62,6 @@ internal const val DebugLog = false
 annotation class ExperimentalPagerApi
 
 /**
- * Contains the default values used by [HorizontalPager] and [VerticalPager].
- */
-@ExperimentalPagerApi
-object PagerDefaults {
-    /**
-     * The default implementation for the `maximumFlingDistance` parameter of
-     * [flingBehavior] which limits the fling distance to a single page.
-     */
-    @ExperimentalSnapperApi
-    @Suppress("MemberVisibilityCanBePrivate")
-    @Deprecated("MaximumFlingDistance has been deprecated in Snapper")
-    val singlePageFlingDistance: (SnapperLayoutInfo) -> Float = { layoutInfo ->
-        // We can scroll up to the scrollable size of the lazy layout
-        layoutInfo.endScrollOffset - layoutInfo.startScrollOffset.toFloat()
-    }
-
-    /**
-     * The default implementation for the `snapIndex` parameter of
-     * [flingBehavior] which limits the fling distance to a single page.
-     */
-    @ExperimentalSnapperApi
-    val singlePageSnapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int =
-        { layoutInfo, startIndex, targetIndex ->
-            targetIndex
-                .coerceIn(startIndex - 1, startIndex + 1)
-                .coerceIn(0, layoutInfo.totalItemsCount - 1)
-        }
-
-    /**
-     * Remember the default [FlingBehavior] that represents the scroll curve.
-     *
-     * Please remember to provide the correct [endContentPadding] if supplying your own
-     * [FlingBehavior] to [VerticalPager] or [HorizontalPager]. See those functions for how they
-     * calculate the value.
-     *
-     * @param state The [PagerState] to update.
-     * @param decayAnimationSpec The decay animation spec to use for decayed flings.
-     * @param snapAnimationSpec The animation spec to use when snapping.
-     * @param maximumFlingDistance Block which returns the maximum fling distance in pixels.
-     * @param endContentPadding The amount of content padding on the end edge of the lazy list
-     * in pixels (end/bottom depending on the scrolling direction).
-     */
-    @Composable
-    @ExperimentalSnapperApi
-    @Deprecated("MaximumFlingDistance has been deprecated in Snapper, replaced with snapIndex")
-    @Suppress("DEPRECATION")
-    fun flingBehavior(
-        state: PagerState,
-        decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
-        snapAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
-        maximumFlingDistance: (SnapperLayoutInfo) -> Float = singlePageFlingDistance,
-        endContentPadding: Dp = 0.dp,
-    ): FlingBehavior = rememberSnapperFlingBehavior(
-        lazyListState = state.lazyListState,
-        snapOffsetForItem = SnapOffsets.Start, // pages are full width, so we use the simplest
-        decayAnimationSpec = decayAnimationSpec,
-        springAnimationSpec = snapAnimationSpec,
-        maximumFlingDistance = maximumFlingDistance,
-        endContentPadding = endContentPadding,
-    )
-
-    /**
-     * Remember the default [FlingBehavior] that represents the scroll curve.
-     *
-     * Please remember to provide the correct [endContentPadding] if supplying your own
-     * [FlingBehavior] to [VerticalPager] or [HorizontalPager]. See those functions for how they
-     * calculate the value.
-     *
-     * @param state The [PagerState] to update.
-     * @param decayAnimationSpec The decay animation spec to use for decayed flings.
-     * @param snapAnimationSpec The animation spec to use when snapping.
-     * @param endContentPadding The amount of content padding on the end edge of the lazy list
-     * in pixels (end/bottom depending on the scrolling direction).
-     * @param snapIndex Block which returns the index to snap to. The block is provided with the
-     * [SnapperLayoutInfo], the index where the fling started, and the index which Snapper has
-     * determined is the correct target index. Callers can override this value to any valid index
-     * for the layout. Some common use cases include limiting the fling distance, and rounding up/down
-     * to achieve snapping to groups of items.
-     */
-    @Composable
-    @ExperimentalSnapperApi
-    fun flingBehavior(
-        state: PagerState,
-        decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
-        snapAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
-        endContentPadding: Dp = 0.dp,
-        snapIndex: (SnapperLayoutInfo, startIndex: Int, targetIndex: Int) -> Int,
-    ): FlingBehavior = rememberSnapperFlingBehavior(
-        lazyListState = state.lazyListState,
-        snapOffsetForItem = SnapOffsets.Start, // pages are full width, so we use the simplest
-        decayAnimationSpec = decayAnimationSpec,
-        springAnimationSpec = snapAnimationSpec,
-        endContentPadding = endContentPadding,
-        snapIndex = snapIndex,
-    )
-
-    /**
-     * Remember the default [FlingBehavior] that represents the scroll curve.
-     *
-     * Please remember to provide the correct [endContentPadding] if supplying your own
-     * [FlingBehavior] to [VerticalPager] or [HorizontalPager]. See those functions for how they
-     * calculate the value.
-     *
-     * @param state The [PagerState] to update.
-     * @param decayAnimationSpec The decay animation spec to use for decayed flings.
-     * @param snapAnimationSpec The animation spec to use when snapping.
-     * @param endContentPadding The amount of content padding on the end edge of the lazy list
-     * in pixels (end/bottom depending on the scrolling direction).
-     */
-    @Composable
-    @ExperimentalSnapperApi
-    fun flingBehavior(
-        state: PagerState,
-        decayAnimationSpec: DecayAnimationSpec<Float> = rememberSplineBasedDecay(),
-        snapAnimationSpec: AnimationSpec<Float> = SnapperFlingBehaviorDefaults.SpringAnimationSpec,
-        endContentPadding: Dp = 0.dp,
-    ): FlingBehavior {
-        // You might be wondering this is function exists rather than a default value for snapIndex
-        // above. It was done to remove overload ambiguity with the maximumFlingDistance overload
-        // below. When that function is removed, we also remove this function and move to a default
-        // param value.
-        return flingBehavior(
-            state = state,
-            decayAnimationSpec = decayAnimationSpec,
-            snapAnimationSpec = snapAnimationSpec,
-            endContentPadding = endContentPadding,
-            snapIndex = singlePageSnapIndex,
-        )
-    }
-}
-
-/**
  * A horizontally scrolling layout that allows users to flip between items to the left and right.
  *
  * @sample com.google.accompanist.sample.pager.HorizontalPagerSample
@@ -217,7 +82,7 @@ object PagerDefaults {
  * @param content a block which describes the content. Inside this block you can reference
  * [PagerScope.currentPage] and other properties in [PagerScope].
  */
-@OptIn(ExperimentalSnapperApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @ExperimentalPagerApi
 @Composable
 fun HorizontalPager(
@@ -228,10 +93,7 @@ fun HorizontalPager(
     itemSpacing: Dp = 0.dp,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     verticalAlignment: Alignment.Vertical = Alignment.CenterVertically,
-    flingBehavior: FlingBehavior = PagerDefaults.flingBehavior(
-        state = state,
-        endContentPadding = contentPadding.calculateEndPadding(LayoutDirection.Ltr),
-    ),
+    flingBehavior: FlingBehavior = rememberSnapFlingBehavior(state.lazyListState),
     key: ((page: Int) -> Any)? = null,
     userScrollEnabled: Boolean = true,
     content: @Composable PagerScope.(page: Int) -> Unit,
@@ -273,7 +135,7 @@ fun HorizontalPager(
  * @param content a block which describes the content. Inside this block you can reference
  * [PagerScope.currentPage] and other properties in [PagerScope].
  */
-@OptIn(ExperimentalSnapperApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @ExperimentalPagerApi
 @Composable
 fun VerticalPager(
@@ -284,10 +146,7 @@ fun VerticalPager(
     itemSpacing: Dp = 0.dp,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
-    flingBehavior: FlingBehavior = PagerDefaults.flingBehavior(
-        state = state,
-        endContentPadding = contentPadding.calculateBottomPadding(),
-    ),
+    flingBehavior: FlingBehavior = rememberSnapFlingBehavior(state.lazyListState),
     key: ((page: Int) -> Any)? = null,
     userScrollEnabled: Boolean = true,
     content: @Composable PagerScope.(page: Int) -> Unit,
@@ -329,10 +188,7 @@ internal fun Pager(
 
     // Provide our PagerState with access to the SnappingFlingBehavior animation target
     // TODO: can this be done in a better way?
-    state.flingAnimationTarget = {
-        @OptIn(ExperimentalSnapperApi::class)
-        (flingBehavior as? SnapperFlingBehavior)?.animationTarget
-    }
+    state.flingAnimationTarget = { state.currentPage }
 
     LaunchedEffect(count) {
         state.currentPage = minOf(count - 1, state.currentPage).coerceAtLeast(0)

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -148,7 +148,8 @@ class PagerState(
     /**
      * The target page for any on-going animations.
      */
-    private var animationTargetPage: Int? by mutableStateOf(null)
+    var animationTargetPage: Int? by mutableStateOf(null)
+        private set
 
     internal var flingAnimationTarget: (() -> Int?)? by mutableStateOf(null)
 

--- a/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
+++ b/pager/src/main/java/com/google/accompanist/pager/PagerState.kt
@@ -207,8 +207,8 @@ class PagerState(
         @IntRange(from = 0) page: Int,
         @FloatRange(from = -1.0, to = 1.0) pageOffset: Float = 0f,
     ) {
-        requireCurrentPage(page, "page")
-        requireCurrentPageOffset(pageOffset, "pageOffset")
+        requireCurrentPage(page)
+        requireCurrentPageOffset(pageOffset)
         try {
             animationTargetPage = page
 
@@ -280,8 +280,8 @@ class PagerState(
         @IntRange(from = 0) page: Int,
         @FloatRange(from = -1.0, to = 1.0) pageOffset: Float = 0f,
     ) {
-        requireCurrentPage(page, "page")
-        requireCurrentPageOffset(pageOffset, "pageOffset")
+        requireCurrentPage(page)
+        requireCurrentPageOffset(pageOffset)
         try {
             animationTargetPage = page
 
@@ -335,12 +335,12 @@ class PagerState(
         "currentPageOffset=$currentPageOffset" +
         ")"
 
-    private fun requireCurrentPage(value: Int, name: String) {
-        require(value >= 0) { "$name[$value] must be >= 0" }
+    private fun requireCurrentPage(value: Int) {
+        require(value >= 0) { "page[$value] must be >= 0" }
     }
 
-    private fun requireCurrentPageOffset(value: Float, name: String) {
-        require(value in -1f..1f) { "$name must be >= -1 and <= 1" }
+    private fun requireCurrentPageOffset(value: Float) {
+        require(value in -1f..1f) { "pageOffset must be >= -1 and <= 1" }
     }
 
     companion object {


### PR DESCRIPTION
- Removes dependency on Snapper in favor of SnapFlingBehavior, as per Snapper's deprecation.

- Adds support for snapping when scrolling with a mouse (in other words, fixes scrolling on desktop with Compose Multiplatform).

- Fixes a small compiler warning in a modified file.

Tested the Pager code in isolation in my Compose Multiplatform project (MacOS + Android), and tested the Android sample.

Background: I needed to use Pager in a Compose Multiplatform project, and made these two changes in order to accommodate that. I'm not sure what else is needed for Accompanist to support compose-jb, but this fixes Pager.
