### PR TITLE
[DrawablePainter] Fix rememberDrawablePainter for BitmapDrawable

### DIFF
--- a/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
+++ b/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
@@ -17,7 +17,6 @@
 package com.google.accompanist.drawablepainter
 
 import android.graphics.drawable.Animatable
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
@@ -34,11 +33,9 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.asAndroidColorFilter
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.withSave
@@ -155,7 +152,6 @@ class DrawablePainter(
 fun rememberDrawablePainter(drawable: Drawable?): Painter = remember(drawable) {
     when (drawable) {
         null -> EmptyPainter
-        is BitmapDrawable -> BitmapPainter(drawable.bitmap.asImageBitmap())
         is ColorDrawable -> ColorPainter(Color(drawable.color))
         // Since the DrawablePainter will be remembered and it implements RememberObserver, it
         // will receive the necessary events


### PR DESCRIPTION
This PR removes special case handling for BitmapDrawable. The previous handling was problematic in several ways:
1. bitmap in BitmapDrawable can be null. This was not handled.
2. BitmapDrawable handles density scaling internally. The density information was dropped in previous code, and the returned BitmapPainter would have wrong intrinsic size if specified density for drawable resource was different from device density, which is a common case in resource density fallback.
3. Mutation of BitmapDrawable after creating the Painter is ignored. But mutation of drawables with non-BitmapDrawable types are reflected in the returned DrawablePainter. This behavior difference seems not appropriate to me.

The ColorDrawable special case suffers from 3rd point but not 1st or 2nd point. If removal for ColorDrawable special case is wanted, I'd be glad to do that job too.