### PR TITLE
[Navigation] Bump Navigation version to 2.5.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ okhttp = "3.12.13"
 coil = "1.3.2"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.5.0-rc02"
+androidxnavigation = "2.5.3"
 androidxWindow = "1.0.0"
 
 [libraries]


### PR DESCRIPTION
Updating the navigation library version to 2.5.3.

Release notes: https://developer.android.com/jetpack/androidx/releases/navigation#2.5.3