### PR TITLE
[WebView] Fixed sizing bug when showing a website that isn't covering all screen

### DIFF
--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -130,24 +130,25 @@ fun WebView(
     chromeClient.state = state
 
     BoxWithConstraints(modifier) {
+
+        // WebView changes it's layout strategy based on
+        // it's layoutParams. We convert from Compose Modifier to
+        // layout params here.
+        val width =
+            if (constraints.hasFixedWidth)
+                LayoutParams.MATCH_PARENT
+            else
+                LayoutParams.WRAP_CONTENT
+        val height =
+            if (constraints.hasFixedHeight)
+                LayoutParams.MATCH_PARENT
+            else
+                LayoutParams.WRAP_CONTENT
+
         AndroidView(
             factory = { context ->
                 val childView = (factory?.invoke(context) ?: WebView(context)).apply {
                     onCreated(this)
-
-                    // WebView changes it's layout strategy based on
-                    // it's layoutParams. We convert from Compose Modifier to
-                    // layout params here.
-                    val width =
-                        if (constraints.hasFixedWidth)
-                            LayoutParams.MATCH_PARENT
-                        else
-                            LayoutParams.WRAP_CONTENT
-                    val height =
-                        if (constraints.hasFixedHeight)
-                            LayoutParams.MATCH_PARENT
-                        else
-                            LayoutParams.WRAP_CONTENT
 
                     layoutParams = LayoutParams(
                         width,
@@ -162,6 +163,10 @@ fun WebView(
                 // wrapped in a ViewGroup.
                 // b/243567497
                 val parentLayout = FrameLayout(context)
+                parentLayout.layoutParams = LayoutParams(
+                    width,
+                    height
+                )
                 parentLayout.addView(childView)
 
                 parentLayout


### PR DESCRIPTION
Since you added a frame layout around the webview some websites have started get weird sizing problems.
The problem is visible on websites that isn't that tall and doesn't need scrolling. This PR fixes that issue.

I can also add that I think this can be simplified by setting match parent on the WebView and only use the height and width variables for the frame layout but don't know if the WebView would react differently then but I think that should work.