### PR TITLE
[Mdc3Theme] Upgrade MDC to 1.8 and map outline variant

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,7 +72,7 @@ androidx-window-testing = { module = "androidx.window:window-testing", version.r
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxnavigation" }
 androidx-navigation-testing = { module = "androidx.navigation:navigation-testing", version.ref = "androidxnavigation" }
 
-mdc = "com.google.android.material:material:1.7.0"
+mdc = "com.google.android.material:material:1.8.0"
 
 napier = "io.github.aakira:napier:1.4.1"
 

--- a/themeadapter-material3/src/main/java/com/google/accompanist/themeadapter/material3/Mdc3Theme.kt
+++ b/themeadapter-material3/src/main/java/com/google/accompanist/themeadapter/material3/Mdc3Theme.kt
@@ -191,6 +191,7 @@ fun createMdc3Theme(
             val surfaceInverse = ta.parseColor(R.styleable.ThemeAdapterMaterial3Theme_colorSurfaceInverse)
             val onSurfaceInverse = ta.parseColor(R.styleable.ThemeAdapterMaterial3Theme_colorOnSurfaceInverse)
             val outline = ta.parseColor(R.styleable.ThemeAdapterMaterial3Theme_colorOutline)
+            val outlineVariant = ta.parseColor(R.styleable.ThemeAdapterMaterial3Theme_colorOutlineVariant)
             val error = ta.parseColor(R.styleable.ThemeAdapterMaterial3Theme_colorError)
             val onError = ta.parseColor(R.styleable.ThemeAdapterMaterial3Theme_colorOnError)
             val errorContainer = ta.parseColor(R.styleable.ThemeAdapterMaterial3Theme_colorErrorContainer)
@@ -224,7 +225,7 @@ fun createMdc3Theme(
                     inverseSurface = surfaceInverse,
                     inverseOnSurface = onSurfaceInverse,
                     outline = outline,
-                    // TODO: MDC-Android doesn't include outlineVariant yet, add when available
+                    outlineVariant = outlineVariant,
                     error = error,
                     onError = onError,
                     errorContainer = errorContainer,
@@ -256,7 +257,7 @@ fun createMdc3Theme(
                     inverseSurface = surfaceInverse,
                     inverseOnSurface = onSurfaceInverse,
                     outline = outline,
-                    // TODO: MDC-Android doesn't include outlineVariant yet, add when available
+                    outlineVariant = outlineVariant,
                     error = error,
                     onError = onError,
                     errorContainer = errorContainer,

--- a/themeadapter-material3/src/main/res/values/theme_attrs.xml
+++ b/themeadapter-material3/src/main/res/values/theme_attrs.xml
@@ -44,6 +44,7 @@
         <attr name="colorSurfaceInverse" />
         <attr name="colorOnSurfaceInverse" />
         <attr name="colorOutline" />
+        <attr name="colorOutlineVariant" />
         <attr name="colorError" />
         <attr name="colorOnError" />
         <attr name="colorErrorContainer" />


### PR DESCRIPTION
- Upgrade to MDC `1.8.0` which has been available since 24 Jan 2023.
- `1.8.0` includes outline variant so we should map it https://github.com/material-components/material-components-android/commit/ac6f13c0bec818568bf413883a24358bfa33dd3a

Fixes #1526 
