### PR TITLE
[Adaptive] Fix technically incorrect usage of produceState

### DIFF
--- a/adaptive/src/main/java/com/google/accompanist/adaptive/DisplayFeatures.kt
+++ b/adaptive/src/main/java/com/google/accompanist/adaptive/DisplayFeatures.kt
@@ -29,12 +29,13 @@ import androidx.window.layout.WindowInfoTracker
  */
 @Composable
 public fun calculateDisplayFeatures(activity: Activity): List<DisplayFeature> {
-    val windowInfoTracker = remember(activity) { WindowInfoTracker.getOrCreate(activity) }
-    val windowLayoutInfo = remember(windowInfoTracker, activity) {
-        windowInfoTracker.windowLayoutInfo(activity)
+    val windowLayoutInfo = remember(activity) {
+        WindowInfoTracker.getOrCreate(activity).windowLayoutInfo(activity)
     }
-
-    val displayFeatures by produceState(initialValue = emptyList<DisplayFeature>()) {
+    val displayFeatures by produceState(
+        initialValue = emptyList<DisplayFeature>(),
+        key1 = windowLayoutInfo
+    ) {
         windowLayoutInfo.collect { info ->
             value = info.displayFeatures
         }


### PR DESCRIPTION
The previously incorrect usage of `produceState` would capture the very first instance of `windowLayoutInfo`, and not cancel collecting and switch to a new one if it changed.

This probably couldn't ever actually happen in practice since it would require the `Activity` to change (and somehow not tear down the entire UI?) but for reference it would be good to do this correctly.