### PR TITLE
[Pager] Fix typo in pager.md

### DIFF
--- a/docs/pager.md
+++ b/docs/pager.md
@@ -5,7 +5,7 @@
 A library which provides paging layouts for Jetpack Compose. If you've used Android's [`ViewPager`](https://developer.android.com/reference/kotlin/androidx/viewpager/widget/ViewPager) before, it has similar properties.
 
 !!! warning
-**This library is deprecated, with official pager support in `androidx.compose.foundation.pager` ** 
+**This library is deprecated, with official pager support in `androidx.compose.foundation.pager`**
 The original documentation is below the migration guide.
 
 ## Migration


### PR DESCRIPTION
Removes a space which caused the markdown to render incorrectly.
