### PR TITLE
[All] Bump vanniktechPublish plugin version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidxnavigation = "2.6.0-alpha08"
 androidxWindow = "1.0.0"
 
 metalava = "0.3.2"
-vanniktechPublish = "0.17.0"
+vanniktechPublish = "0.25.2"
 
 [libraries]
 compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }


### PR DESCRIPTION
After bumping to AGP 8.0 I think the publish task was broken.  Sorry about that. I could reproduce it locally with `gradle publishToMavenLocal`. Bumping this version fixed the issue locally. Would be nice to test this thoroughly before merging since it minor version bump. Is there a better way to test this than running `gradle publishToMavenLocal`?

