### PR TITLE
[Documentation] Update Dokka to 1.8.10, Fix search

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,32 +18,24 @@ jobs:
       - name: Copy CI gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-      - name: set up JDK
-        uses: actions/setup-java@v1
+      - name: Setup java
+        uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: 17
 
-      - name: Generate cache key
-        run: ./checksum.sh checksum.txt
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches/modules-*
-            ~/.gradle/caches/jars-*
-            ~/.gradle/caches/build-cache-*
-          key: gradle-${{ hashFiles('checksum.txt') }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install mkdocs
-          python3 -m pip install mkdocs-material
+          python3 -m pip install mkdocs-material=="9.*"
 
       - name: Generate docs
         run: ./generate_docs.sh

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,6 @@ buildscript {
 
         classpath libs.gradleMavenPublishPlugin
 
-        classpath libs.dokka
-
         classpath libs.metalavaGradle
 
         classpath libs.affectedmoduledetector
@@ -38,9 +36,9 @@ buildscript {
 
 plugins {
     id "com.diffplug.spotless" version "6.5.2"
+    alias(libs.plugins.jetbrains.dokka)
 }
 
-apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.dropbox.affectedmoduledetector'
 apply plugin: 'com.diffplug.spotless'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ composeCompiler = "1.4.6"
 composeMaterial3 = "1.0.1"
 composesnapshot = "-" # a single character = no snapshot
 
-dokka = "1.5.0"
+dokka = "1.8.10"
 
 # gradlePlugin and lint need to be updated together
 gradlePlugin = "8.0.0"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,5 +99,6 @@ markdown_extensions:
       permalink: true
   - pymdownx.betterem
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.details


### PR DESCRIPTION
#### Update Dokka to 1.8.10
This fixes the NoSuchMethodError exception when running the `dokkaHtmlMultiModule` task that appeared after upgrading Gradle to 8.1 (https://github.com/Kotlin/dokka/issues/2796). 
This also brings a new UI for the API documentation pages.

#### Fixed search on documentation page
Turned on alternate style on the Tabbed extension of the `mkdocs-material` to fix search on internal doc pages (fixes #1533). 
Also locked the major version of the `mkdocs-material` to prevent uncontrolled updates in the future and added the `gradle/gradle-build-action@v2` action to the publishing documentation workflow as in other workflows
