### PR TITLE
[Insets] Migrate gradle file to Kotlin DSL

### DIFF
--- a/insets/build.gradle
+++ b/insets/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
+    id("com.android.library")
+    id("kotlin-android")
+    id("org.jetbrains.dokka")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 kotlin {
@@ -26,36 +26,36 @@ kotlin {
 }
 
 android {
-    namespace "com.google.accompanist.insets"
+    namespace = "com.google.accompanist.insets"
 
-    compileSdkVersion 33
+    compileSdkVersion = 33
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
         targetSdkVersion 33
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
-        buildConfig false
-        compose true
+        buildConfig = false
+        compose = true
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 
     lintOptions {
-        textReport true
+        textReport = true
         textOutput 'stdout'
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
-        checkReleaseBuilds false
+        checkReleaseBuilds = false
     }
 
     packagingOptions {
@@ -69,7 +69,7 @@ android {
         unitTests {
             includeAndroidResources = true
         }
-        animationsDisabled true
+        animationsDisabled = true
     }
 
     sourceSets {
@@ -91,35 +91,35 @@ metalava {
 }
 
 dependencies {
-    implementation libs.androidx.core
-    implementation libs.androidx.dynamicanimation
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.dynamicanimation)
 
-    implementation libs.compose.foundation.foundation
-    implementation libs.kotlin.coroutines.android
+    implementation(libs.compose.foundation.foundation)
+    implementation(libs.kotlin.coroutines.android)
 
     // ======================
     // Test dependencies
     // ======================
 
-    androidTestImplementation project(':internal-testutils')
-    testImplementation project(':internal-testutils')
+    androidTestImplementation(project(":internal-testutils"))
+    testImplementation(project(":internal-testutils"))
 
-    androidTestImplementation libs.junit
-    testImplementation libs.junit
+    androidTestImplementation(libs.junit)
+    testImplementation(libs.junit)
 
-    androidTestImplementation libs.truth
-    testImplementation libs.truth
+    androidTestImplementation(libs.truth)
+    testImplementation(libs.truth)
 
-    androidTestImplementation libs.compose.ui.test.junit4
-    testImplementation libs.compose.ui.test.junit4
+    androidTestImplementation(libs.compose.ui.test.junit4)
+    testImplementation(libs.compose.ui.test.junit4)
 
-    androidTestImplementation libs.compose.ui.test.manifest
-    testImplementation libs.compose.ui.test.manifest
+    androidTestImplementation(libs.compose.ui.test.manifest)
+    testImplementation(libs.compose.ui.test.manifest)
 
-    androidTestImplementation libs.androidx.test.runner
-    testImplementation libs.androidx.test.runner
+    androidTestImplementation(libs.androidx.test.runner)
+    testImplementation(libs.androidx.test.runner)
 
-    testImplementation libs.robolectric
+    testImplementation(libs.robolectric)
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/insets/build.gradle.kts
+++ b/insets/build.gradle.kts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("UnstableApiUsage")
 
 plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    id(libs.plugins.android.library.get().pluginId)
+    id(libs.plugins.android.kotlin.get().pluginId)
+    id(libs.plugins.jetbrains.dokka.get().pluginId)
+    id(libs.plugins.gradle.metalava.get().pluginId)
+    id(libs.plugins.vanniktech.maven.publish.get().pluginId)
 }
 
 kotlin {
@@ -28,12 +30,12 @@ kotlin {
 android {
     namespace = "com.google.accompanist.insets"
 
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk = 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 33
+        targetSdk = 33
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -51,35 +53,36 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 
-    lintOptions {
+    lint {
         textReport = true
-        textOutput 'stdout'
+        textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
     }
 
-    packagingOptions {
+    packaging {
         // Some of the META-INF files conflict with coroutines-test. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
-        excludes += "/META-INF/AL2.0"
-        excludes += "/META-INF/LGPL2.1"
+        resources {
+            excludes += listOf("/META-INF/AL2.0", "/META-INF/LGPL2.1")
+        }
     }
 
     testOptions {
         unitTests {
-            includeAndroidResources = true
+            isIncludeAndroidResources = true
         }
         animationsDisabled = true
     }
 
     sourceSets {
-        test {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+        named("test") {
+            java.srcDirs("src/sharedTest/kotlin")
+            res.srcDirs("src/sharedTest/res")
         }
-        androidTest {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+        named("androidTest") {
+            java.srcDirs("src/sharedTest/kotlin")
+            res.srcDirs("src/sharedTest/res")
         }
     }
 }
@@ -121,5 +124,3 @@ dependencies {
 
     testImplementation(libs.robolectric)
 }
-
-apply plugin: "com.vanniktech.maven.publish"


### PR DESCRIPTION
Following up https://github.com/google/accompanist/issues/1578 and relating to https://github.com/google/accompanist/pull/1579

Migrating the `:insets` module to Kotlin DSL.

I have split up the PR into two commits. The first one prepares the file to be migrated by using steps described in [these docs](https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#prepare_your_groovy_scripts). The second one is where I actually convert the file to .kts file and updates the rest of the file to be compatible with Kotlin DSL.

# Testing

Ths testing I have done for this is to check that it syncs and build the sample application. Let me know if there is any other test that what the CI runs that you want me to run as well.