### PR TITLE
[Pager] Migrate build gradle file to Kotlin DSL

### DIFF
--- a/pager/build.gradle
+++ b/pager/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
+    id("com.android.library")
+    id("kotlin-android")
+    id("org.jetbrains.dokka")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 kotlin {
@@ -26,36 +26,36 @@ kotlin {
 }
 
 android {
-    namespace "com.google.accompanist.pager"
+    namespace = "com.google.accompanist.pager"
 
-    compileSdkVersion 33
+    compileSdkVersion = 33
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
         targetSdkVersion 33
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
-        buildConfig false
-        compose true
+        buildConfig = false
+        compose = true
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 
     lintOptions {
-        textReport true
+        textReport = true
         textOutput 'stdout'
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
-        checkReleaseBuilds false
+        checkReleaseBuilds = false
     }
 
     packagingOptions {
@@ -69,17 +69,17 @@ android {
         unitTests {
             includeAndroidResources = true
         }
-        animationsDisabled true
+        animationsDisabled = true
     }
 
     sourceSets {
         test {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
         androidTest {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
     }
 }
@@ -91,38 +91,38 @@ metalava {
 }
 
 dependencies {
-    api libs.compose.foundation.foundation
-    api libs.snapper
+    api(libs.compose.foundation.foundation)
+    api(libs.snapper)
 
-    implementation libs.napier
-    implementation libs.kotlin.coroutines.android
+    implementation(libs.napier)
+    implementation(libs.kotlin.coroutines.android)
 
     // ======================
     // Test dependencies
     // ======================
 
-    androidTestImplementation project(':internal-testutils')
-    testImplementation project(':internal-testutils')
+    androidTestImplementation(project(":internal-testutils"))
+    testImplementation(project(":internal-testutils"))
 
-    androidTestImplementation project(':testharness')
-    testImplementation project(':testharness')
+    androidTestImplementation(project(":testharness"))
+    testImplementation(project(":testharness"))
 
-    androidTestImplementation libs.junit
-    testImplementation libs.junit
+    androidTestImplementation(libs.junit)
+    testImplementation(libs.junit)
 
-    androidTestImplementation libs.truth
-    testImplementation libs.truth
+    androidTestImplementation(libs.truth)
+    testImplementation(libs.truth)
 
-    androidTestImplementation libs.compose.ui.test.junit4
-    testImplementation libs.compose.ui.test.junit4
+    androidTestImplementation(libs.compose.ui.test.junit4)
+    testImplementation(libs.compose.ui.test.junit4)
 
-    androidTestImplementation libs.compose.ui.test.manifest
-    testImplementation libs.compose.ui.test.manifest
+    androidTestImplementation(libs.compose.ui.test.manifest)
+    testImplementation(libs.compose.ui.test.manifest)
 
-    androidTestImplementation libs.androidx.test.runner
-    testImplementation libs.androidx.test.runner
+    androidTestImplementation(libs.androidx.test.runner)
+    testImplementation(libs.androidx.test.runner)
 
-    testImplementation libs.robolectric
+    testImplementation(libs.robolectric)
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/pager/build.gradle.kts
+++ b/pager/build.gradle.kts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("UnstableApiUsage")
 
 plugins {
-    id("com.android.library")
-    id("kotlin-android")
-    id("org.jetbrains.dokka")
-    id("me.tylerbwong.gradle.metalava")
+    id(libs.plugins.android.library.get().pluginId)
+    id(libs.plugins.android.kotlin.get().pluginId)
+    id(libs.plugins.jetbrains.dokka.get().pluginId)
+    id(libs.plugins.gradle.metalava.get().pluginId)
+    id(libs.plugins.vanniktech.maven.publish.get().pluginId)
 }
 
 kotlin {
@@ -28,12 +30,12 @@ kotlin {
 android {
     namespace = "com.google.accompanist.pager"
 
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk = 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
-        targetSdkVersion 33
+        targetSdk = 33
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -51,35 +53,36 @@ android {
         kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 
-    lintOptions {
+    lint {
         textReport = true
-        textOutput 'stdout'
+        textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
     }
 
-    packagingOptions {
+    packaging {
         // Some of the META-INF files conflict with coroutines-test. Exclude them to enable
         // our test APK to build (has no effect on our AARs)
-        excludes += "/META-INF/AL2.0"
-        excludes += "/META-INF/LGPL2.1"
+        resources {
+            excludes += listOf("/META-INF/AL2.0", "/META-INF/LGPL2.1")
+        }
     }
 
     testOptions {
         unitTests {
-            includeAndroidResources = true
+            isIncludeAndroidResources = true
         }
         animationsDisabled = true
     }
 
     sourceSets {
-        test {
-            java.srcDirs += "src/sharedTest/kotlin"
-            res.srcDirs += "src/sharedTest/res"
+        named("test") {
+            java.srcDirs("src/sharedTest/kotlin")
+            res.srcDirs("src/sharedTest/res")
         }
-        androidTest {
-            java.srcDirs += "src/sharedTest/kotlin"
-            res.srcDirs += "src/sharedTest/res"
+        named("androidTest") {
+            java.srcDirs("src/sharedTest/kotlin")
+            res.srcDirs("src/sharedTest/res")
         }
     }
 }
@@ -124,5 +127,3 @@ dependencies {
 
     testImplementation(libs.robolectric)
 }
-
-apply plugin: "com.vanniktech.maven.publish"


### PR DESCRIPTION
Following up https://github.com/google/accompanist/issues/1578 and relating to https://github.com/google/accompanist/pull/1579

Migrating the `:pager` module to Kotlin DSL.

I have split up the PR into two commits. The first one prepares the file to be migrated by using steps described in [these docs](https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#prepare_your_groovy_scripts). The second one is where I actually convert the file to .kts file and updates the rest of the file to be compatible with Kotlin DSL.

Testing

Ths testing I have done for this is to check that it syncs and build the sample application. Let me know if there is any other test that what the CI runs that you want me to run as well.