### PR TITLE
Fix webview loading state finish

### DIFF
--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -313,6 +313,10 @@ open class AccompanistWebChromeClient : WebChromeClient() {
 
     override fun onProgressChanged(view: WebView, newProgress: Int) {
         super.onProgressChanged(view, newProgress)
+        if (newProgress == 100.0f) {
+            state.loadingState = LoadingState.Finished
+            return
+        }
         if (state.loadingState is LoadingState.Finished) return
         state.loadingState = LoadingState.Loading(newProgress / 100.0f)
     }


### PR DESCRIPTION
Hi, I found some inconsistency with the current webview loading state implementation.

Sometimes the loadingState ends with Finished, sometimes it ends with Loading(1.0f). So the isLoading var doesn't work reliably.

Here are a few examples that are reproduced with the sample project.

```
Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.0)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished
Loading(progress=1.0)

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Loading(progress=1.0)

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Loading(progress=1.0)

Initializing
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Loading(progress=1.0)

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Loading(progress=1.0)

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.1)
Loading(progress=0.0)
Finished

Initializing
Loading(progress=0.0)
Finished
```

To try to fix this, when the loading value is 100% it changes directly to finished.

### Please add the library name to the PR title. Example: "[Insets] Fixes typo" ###
