### PR TITLE
[Sample] Migrate gradle file to Kotlin DSL

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ android-tools-lint-tests = { module = "com.android.tools.lint:lint-tests", versi
 squareup-mockwebserver = "com.squareup.okhttp3:mockwebserver:4.9.3"
 
 [plugins]
+android-application = { id = "com.android.application", version.ref = "gradlePlugin" }
 android-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "gradlePlugin" }
 jetbrains-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,90 +14,90 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.android.application'
-
-apply plugin: 'kotlin-android'
-
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+}
 android {
-    compileSdkVersion 33
+    compileSdkVersion = 33
 
     defaultConfig {
-        applicationId "com.google.accompanist.sample"
+        applicationId = "com.google.accompanist.sample"
         minSdkVersion 21
         targetSdkVersion 33
 
-        versionCode 1
-        versionName "1.0"
+        versionCode = 1
+        versionName = "1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildFeatures {
-        compose true
+        compose = true
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 
     buildTypes {
         release {
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 
-    namespace 'com.google.accompanist.sample'
+    namespace = "com.google.accompanist.sample"
 }
 
 dependencies {
-    implementation project(':adaptive')
-    implementation project(':drawablepainter')
-    implementation project(':insets')
-    implementation project(':insets-ui')
-    implementation project(':navigation-animation')
-    implementation project(':navigation-material')
-    implementation project(':pager')
-    implementation project(':pager-indicators')
-    implementation project(':permissions')
-    implementation project(':placeholder')
-    implementation project(':placeholder-material')
-    implementation project(':flowlayout')
-    implementation project(':systemuicontroller')
-    implementation project(':swiperefresh')
-    implementation project(':testharness') // Don't use in production! Use the configurations below.
-    testImplementation project(':testharness')
+    implementation(project(":adaptive"))
+    implementation(project(":drawablepainter"))
+    implementation(project(":insets"))
+    implementation(project(":insets-ui"))
+    implementation(project(":navigation-animation"))
+    implementation(project(":navigation-material"))
+    implementation(project(":pager"))
+    implementation(project(":pager-indicators"))
+    implementation(project(":permissions"))
+    implementation(project(":placeholder"))
+    implementation(project(":placeholder-material"))
+    implementation(project(":flowlayout"))
+    implementation(project(":systemuicontroller"))
+    implementation(project(":swiperefresh"))
+    implementation(project(":testharness")) // Don't use in production! Use the configurations below
+    testImplementation(project(":testharness"))
     androidTestImplementation project(':testharness')
-    implementation project(':themeadapter-material')
-    implementation project(':themeadapter-material3')
-    implementation project(':web')
+    implementation(project(":themeadapter-material"))
+    implementation(project(":themeadapter-material3"))
+    implementation(project(":web"))
 
-    implementation libs.androidx.appcompat
-    implementation libs.mdc
+    implementation(libs.androidx.appcompat)
+    implementation(libs.mdc)
 
-    implementation libs.coil.compose
-    implementation libs.coil.gif
+    implementation(libs.coil.compose)
+    implementation(libs.coil.gif)
 
-    implementation libs.compose.material.material
-    implementation libs.compose.material.iconsext
-    implementation libs.compose.material3.material3
-    implementation libs.compose.foundation.layout
-    debugImplementation libs.compose.ui.tooling
-    implementation libs.compose.ui.tooling.preview
-    implementation libs.compose.ui.util
+    implementation(libs.compose.material.material)
+    implementation(libs.compose.material.iconsext)
+    implementation(libs.compose.material3.material3)
+    implementation(libs.compose.foundation.layout)
+    debugImplementation(libs.compose.ui.tooling)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.ui.util)
 
-    implementation libs.androidx.lifecycle.viewmodel.compose
-    implementation libs.androidx.activity.compose
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.activity.compose)
 
-    implementation libs.androidx.core
-    implementation libs.androidx.fragment
-    implementation libs.androidx.lifecycle.runtime
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.fragment)
+    implementation(libs.androidx.lifecycle.runtime)
 
-    implementation libs.kotlin.stdlib
+    implementation(libs.kotlin.stdlib)
 
     lintChecks(project(":permissions-lint"))
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("UnstableApiUsage")
 
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
+    id(libs.plugins.android.application.get().pluginId)
+    id(libs.plugins.android.kotlin.get().pluginId)
 }
+
 android {
-    compileSdkVersion = 33
+    compileSdk = 33
 
     defaultConfig {
         applicationId = "com.google.accompanist.sample"
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdk = 21
+        targetSdk = 33
 
         versionCode = 1
         versionName = "1.0"
@@ -46,8 +48,8 @@ android {
     }
 
     buildTypes {
-        release {
-            signingConfig = signingConfigs.debug
+        getByName("release") {
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 
@@ -71,7 +73,7 @@ dependencies {
     implementation(project(":swiperefresh"))
     implementation(project(":testharness")) // Don't use in production! Use the configurations below
     testImplementation(project(":testharness"))
-    androidTestImplementation project(':testharness')
+    androidTestImplementation(project(":testharness"))
     implementation(project(":themeadapter-material"))
     implementation(project(":themeadapter-material3"))
     implementation(project(":web"))


### PR DESCRIPTION
Following up https://github.com/google/accompanist/issues/1578 and relating to https://github.com/google/accompanist/pull/1579

Migrating the `:sample`  module to Kotlin DSL.

I have split up the PR into two commits. The first one prepares the file to be migrated by using steps described in [these docs](https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#prepare_your_groovy_scripts). The second one is where I actually convert the file to .kts file and updates the rest of the file to be compatible with Kotlin DSL.