### PR TITLE
[Testharness] Migrate gradle module to Kotlin DSL

### DIFF
--- a/testharness/build.gradle
+++ b/testharness/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 
 plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-    id 'org.jetbrains.dokka'
-    id 'me.tylerbwong.gradle.metalava'
+    id("com.android.library")
+    id("kotlin-android")
+    id("org.jetbrains.dokka")
+    id("me.tylerbwong.gradle.metalava")
 }
 
 kotlin {
@@ -26,20 +26,20 @@ kotlin {
 }
 
 android {
-    namespace "com.google.accompanist.testharness"
+    namespace = "com.google.accompanist.testharness"
 
-    compileSdkVersion 33
+    compileSdkVersion = 33
 
     defaultConfig {
         minSdkVersion 21
         // targetSdkVersion has no effect for libraries. This is only used for the test APK
         targetSdkVersion 33
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     buildTypes {
@@ -49,19 +49,19 @@ android {
     }
 
     buildFeatures {
-        buildConfig false
-        compose true
+        buildConfig = false
+        compose = true
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
 
     lintOptions {
-        textReport true
+        textReport = true
         textOutput 'stdout'
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
-        checkReleaseBuilds false
+        checkReleaseBuilds = false
     }
 
     packagingOptions {
@@ -81,7 +81,7 @@ android {
         }
         unitTests.all {
             useJUnit {
-                excludeCategories 'com.google.accompanist.internal.test.IgnoreOnRobolectric'
+                excludeCategories "com.google.accompanist.internal.test.IgnoreOnRobolectric"
             }
             jacoco {
                 // Required for JaCoCo + Robolectric
@@ -93,17 +93,17 @@ android {
                 excludes = ["jdk.internal.*"]
             }
         }
-        animationsDisabled true
+        animationsDisabled = true
     }
 
     sourceSets {
         test {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
         androidTest {
-            java.srcDirs += 'src/sharedTest/kotlin'
-            res.srcDirs += 'src/sharedTest/res'
+            java.srcDirs += "src/sharedTest/kotlin"
+            res.srcDirs += "src/sharedTest/res"
         }
     }
 }
@@ -115,35 +115,35 @@ metalava {
 }
 
 dependencies {
-    implementation libs.compose.foundation.foundation
-    implementation libs.androidx.core
-    testImplementation libs.androidx.core
-    implementation libs.napier
-    implementation libs.kotlin.coroutines.android
+    implementation(libs.compose.foundation.foundation)
+    implementation(libs.androidx.core)
+    testImplementation(libs.androidx.core)
+    implementation(libs.napier)
+    implementation(libs.kotlin.coroutines.android)
 
     // ======================
     // Test dependencies
     // ======================
 
-    androidTestImplementation project(':internal-testutils')
-    testImplementation project(':internal-testutils')
+    androidTestImplementation(project(":internal-testutils"))
+    testImplementation(project(":internal-testutils"))
 
-    androidTestImplementation libs.junit
-    testImplementation libs.junit
+    androidTestImplementation(libs.junit)
+    testImplementation(libs.junit)
 
-    androidTestImplementation libs.truth
-    testImplementation libs.truth
+    androidTestImplementation(libs.truth)
+    testImplementation(libs.truth)
 
-    androidTestImplementation libs.compose.ui.test.junit4
-    testImplementation libs.compose.ui.test.junit4
+    androidTestImplementation(libs.compose.ui.test.junit4)
+    testImplementation(libs.compose.ui.test.junit4)
 
-    androidTestImplementation libs.compose.ui.test.manifest
-    testImplementation libs.compose.ui.test.manifest
+    androidTestImplementation(libs.compose.ui.test.manifest)
+    testImplementation(libs.compose.ui.test.manifest)
 
-    androidTestImplementation libs.androidx.test.runner
-    testImplementation libs.androidx.test.runner
+    androidTestImplementation(libs.androidx.test.runner)
+    testImplementation(libs.androidx.test.runner)
 
-    testImplementation libs.robolectric
+    testImplementation(libs.robolectric)
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/testharness/build.gradle.kts
+++ b/testharness/build.gradle.kts
@@ -21,23 +21,10 @@ plugins {
     id(libs.plugins.jetbrains.dokka.get().pluginId)
     id(libs.plugins.gradle.metalava.get().pluginId)
     id(libs.plugins.vanniktech.maven.publish.get().pluginId)
-    jacoco
 }
 
 kotlin {
     explicitApi()
-}
-
-tasks.withType<Test> {
-    configure<JacocoTaskExtension> {
-        // Required for JaCoCo + Robolectric
-        // https://github.com/robolectric/robolectric/issues/2230
-        isIncludeNoLocationClasses = true
-
-        // Required for JDK 11 with the above
-        // https://github.com/gradle/gradle/issues/5184#issuecomment-391982009
-        excludes?.add("jdk.internal.*")
-    }
 }
 
 android {
@@ -85,10 +72,6 @@ android {
         resources {
             excludes += listOf("/META-INF/AL2.0", "/META-INF/LGPL2.1")
         }
-    }
-
-    testCoverage {
-        jacocoVersion = "0.8.8"
     }
 
     testOptions {


### PR DESCRIPTION
Following up https://github.com/google/accompanist/issues/1578 and relating to https://github.com/google/accompanist/pull/1579

Migrating the `:testharness` module to Kotlin DSL.

I have split up the PR into two commits. The first one prepares the file to be migrated by using steps described in [these docs](https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#prepare_your_groovy_scripts). The second one is where I actually convert the file to .kts file and updates the rest of the file to be compatible with Kotlin DSL.