### PR TITLE
[Settings gradle] Migrate settings.gradle to Kotlin DSL

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,40 +15,40 @@
  */
 
 plugins {
-    id 'com.gradle.enterprise' version '3.10.3'
+    id("com.gradle.enterprise") version("3.10.3")
 }
 
 gradleEnterprise {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
     }
 }
 
-include ':adaptive'
-include ':internal-testutils'
-include ':insets'
-include ':insets-ui'
-include ':appcompat-theme'
-include ':drawablepainter'
-include ':navigation-animation'
-include ':navigation-material'
-include ':pager'
-include ':pager-indicators'
-include ':permissions'
-include ':permissions-lint'
-include ':placeholder'
-include ':placeholder-material'
-include ':placeholder-material3'
-include ':flowlayout'
-include ':systemuicontroller'
-include ':swiperefresh'
-include ':sample'
-include ':testharness'
-include ':themeadapter-core'
-include ':themeadapter-appcompat'
-include ':themeadapter-material'
-include ':themeadapter-material3'
-include ':web'
+include(":adaptive")
+include(":internal-testutils")
+include(":insets")
+include(":insets-ui")
+include(":appcompat-theme")
+include(":drawablepainter")
+include(":navigation-animation")
+include(":navigation-material")
+include(":pager")
+include(":pager-indicators")
+include(":permissions")
+include(":permissions-lint")
+include(":placeholder")
+include(":placeholder-material")
+include(":placeholder-material3")
+include(":flowlayout")
+include(":systemuicontroller")
+include(":swiperefresh")
+include(":sample")
+include(":testharness")
+include(":themeadapter-core")
+include(":themeadapter-appcompat")
+include(":themeadapter-material")
+include(":themeadapter-material3")
+include(":web")
 
-rootProject.name = 'accompanist'
+rootProject.name = "accompanist"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id("com.gradle.enterprise") version("3.10.3")
+    id("com.gradle.enterprise").version("3.10.3")
 }
 
 gradleEnterprise {


### PR DESCRIPTION
Following up https://github.com/google/accompanist/issues/1578 and relating to https://github.com/google/accompanist/pull/1579

Migrating the `settings.gradle` file  to Kotlin DSL.

I have split up the PR into two commits. The first one prepares the file to be migrated by using steps described in [these docs](https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#prepare_your_groovy_scripts). The second one is where I actually convert the file to .kts file and updates the rest of the file to be compatible with Kotlin DSL.

Used this (https://docs.gradle.com/enterprise/gradle-plugin/) to check the gradle enterprise configuration was correct 