### PR TITLE
[Permissions-Lint] Migrate gradle file to Kotlin DSL

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ coroutines = "1.6.4"
 okhttp = "3.12.13"
 coil = "1.3.2"
 
+androidlint = "25.3.0"
 androidxtest = "1.4.0"
 androidxnavigation = "2.7.0-alpha01"
 androidxWindow = "1.0.0"
@@ -107,6 +108,7 @@ squareup-mockwebserver = "com.squareup.okhttp3:mockwebserver:4.9.3"
 android-application = { id = "com.android.application", version.ref = "gradlePlugin" }
 android-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "gradlePlugin" }
+android-lint = { id = "com.android.lint", version.ref = "androidlint"}
 jetbrains-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 gradle-metalava = { id = "me.tylerbwong.gradle.metalava", version.ref = "metalava" }
 vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktechPublish" }

--- a/permissions-lint/build.gradle
+++ b/permissions-lint/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 
 plugins {
-    id 'java-library'
-    id 'kotlin'
-    id 'org.jetbrains.dokka'
-    id 'com.android.lint'
+    id("java-library")
+    id("kotlin")
+    id("org.jetbrains.dokka")
+    id("com.android.lint")
 }
 
 kotlin {
@@ -26,11 +26,11 @@ kotlin {
 }
 
 lintOptions {
-    htmlReport true
-    htmlOutput file("lint-report.html")
-    textReport true
-    absolutePaths false
-    ignoreTestSources true
+    htmlReport = true
+    htmlOutput = file("lint-report.html")
+    textReport = true
+    absolutePaths = false
+    ignoreTestSources = true
 }
 
 affectedTestConfiguration {
@@ -67,19 +67,19 @@ tasks.named("jar").configure { task ->
 
 dependencies {
     // Bundle metadataJvm inside the Jar
-    bundleInside libs.kotlin.metadataJvm
+    bundleInside(libs.kotlin.metadataJvm)
 
-    compileOnly libs.android.tools.lint.api
-    compileOnly libs.kotlin.reflect
-    compileOnly libs.kotlin.stdlib
-    compileOnly libs.kotlin.stdlibJdk8 // Override version from transitive dependencies
+    compileOnly(libs.android.tools.lint.api)
+    compileOnly(libs.kotlin.reflect)
+    compileOnly(libs.kotlin.stdlib)
+    compileOnly(libs.kotlin.stdlibJdk8) // Override version from transitive dependencies
 
-    testImplementation libs.junit
-    testImplementation libs.kotlin.reflect
-    testImplementation libs.kotlin.stdlib
-    testImplementation libs.kotlin.stdlibJdk8 // Override version from transitive dependencies
-    testImplementation libs.android.tools.lint.lint
-    testImplementation libs.android.tools.lint.tests
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.kotlin.stdlib)
+    testImplementation(libs.kotlin.stdlibJdk8) // Override version from transitive dependencies
+    testImplementation(libs.android.tools.lint.lint)
+    testImplementation(libs.android.tools.lint.tests)
 }
 
 java {

--- a/permissions-lint/build.gradle.kts
+++ b/permissions-lint/build.gradle.kts
@@ -15,17 +15,17 @@
  */
 
 plugins {
-    id("java-library")
+    `java-library`
     id("kotlin")
-    id("org.jetbrains.dokka")
-    id("com.android.lint")
+    id(libs.plugins.jetbrains.dokka.get().pluginId)
+    id(libs.plugins.android.lint.get().pluginId)
 }
 
 kotlin {
     explicitApi()
 }
 
-lintOptions {
+lint {
     htmlReport = true
     htmlOutput = file("lint-report.html")
     textReport = true
@@ -43,26 +43,26 @@ affectedTestConfiguration {
  * not currently support dependencies, so instead we need to bundle any dependencies with the
  * lint jar manually. (b/182319899)
  */
-def bundle = configurations.create("bundleInside")
+val bundleInside: Configuration = configurations.create("bundleInside")
 // bundleInside dependencies should be included as compileOnly and testImplementation as well
-configurations.getByName("compileOnly").setExtendsFrom([bundle])
-configurations.getByName("testImplementation").setExtendsFrom([bundle])
-tasks.named("jar").configure { task ->
-    def jarTask = task as Jar
-    jarTask.dependsOn(bundle)
-    jarTask.from({
-        bundle
-                // The stdlib is already bundled with lint, so no need to include it manually
-                // in the lint.jar if any dependencies here depend on it
-                .filter { !it.name.contains("kotlin-stdlib") }
-                .collect { file ->
-                    if (file.isDirectory()) {
-                        file
-                    } else {
-                        zipTree(file)
-                    }
-                }
-    })
+configurations.getByName("compileOnly").setExtendsFrom(setOf(bundleInside))
+configurations.getByName("testImplementation").setExtendsFrom(setOf(bundleInside))
+
+tasks.getByName<Jar>("jar") {
+    this.dependsOn(bundleInside)
+    this.from({
+       bundleInside
+               // The stdlib is already bundled with lint, so no need to include it manually
+               // in the lint.jar if any dependencies here depend on it
+               .filter { !it.name.contains("kotlin-stdlib") }
+               .map { file ->
+                   if (file.isDirectory) {
+                       file
+                   } else {
+                       zipTree(file)
+                   }
+               }
+   })
 }
 
 dependencies {


### PR DESCRIPTION
Following up https://github.com/google/accompanist/issues/1578 and relating to https://github.com/google/accompanist/pull/1579

Migrating the `:permissions-lint` module to Kotlin DSL.

I have split up the PR into two commits. The first one prepares the file to be migrated by using steps described in [these docs](https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html#prepare_your_groovy_scripts). The second one is where I actually convert the file to .kts file and updates the rest of the file to be compatible with Kotlin DSL.