### PR TITLE
[Navigation-Animation] Fix NavController receiving back events even while AnimatedNavHost is not in composition

### DIFF
--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
@@ -29,6 +29,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.with
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -142,6 +143,14 @@ public fun AnimatedNavHost(
     navController.setViewModelStore(viewModelStoreOwner.viewModelStore)
     if (onBackPressedDispatcher != null) {
         navController.setOnBackPressedDispatcher(onBackPressedDispatcher)
+    }
+    // Ensure that the NavController only receives back events while
+    // the AnimatedNavHost is in composition
+    DisposableEffect(navController) {
+        navController.enableOnBackPressed(true)
+        onDispose {
+            navController.enableOnBackPressed(false)
+        }
     }
 
     navController.graph = graph


### PR DESCRIPTION
Hi folks, I think there's a bug in the library which casues navController to receive back events even if `AnimatedNavHost` is not in composition. Because of that each time `AnimatedNavHost` gets recomposed new navController will be registered for receiving back events which can lead to weird issues with back navigation. Please check the MRE  and detailed description in [this repo](https://github.com/Leedwon/AnimatedNavControllerBackPressIssues). 

Fix is based on `androidx.navigation.compose.NavHost` which has the same mechanism for disabling back events in `onDispose`.