### PR TITLE
[Navigation Animation] Update to Navigation 2.6.0-rc02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ okhttp = "3.12.13"
 coil = "1.3.2"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.6.0-alpha08"
+androidxnavigation = "2.6.0-rc02"
 androidxWindow = "1.0.0"
 
 metalava = "0.3.2"
@@ -66,12 +66,12 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 androidx-appcompat = "androidx.appcompat:appcompat:1.4.2"
 androidx-core = "androidx.core:core-ktx:1.8.0"
-androidx-activity-compose = "androidx.activity:activity-compose:1.5.1"
+androidx-activity-compose = "androidx.activity:activity-compose:1.7.2"
 androidx-fragment = "androidx.fragment:fragment-ktx:1.5.1"
 androidx-dynamicanimation = "androidx.dynamicanimation:dynamicanimation-ktx:1.0.0-alpha03"
 androidx-lifecycle-runtime = "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
 androidx-lifecycle-viewmodel-compose = "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1"
-androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common-java8:2.6.0"
+androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common-java8:2.6.1"
 androidx-window = { module = "androidx.window:window", version.ref = "androidxWindow" }
 androidx-window-testing = { module = "androidx.window:window-testing", version.ref = "androidxWindow" }
 


### PR DESCRIPTION
Update to Navigation 2.6.0-rc02 to automatically make all fixes since alpha08 available to Accompanist users.

Also update
- Activity Compose to 1.7.2
- Lifecycle Common Java8 to 2.6.1

Since those are also transitive dependencies of Navigation 2.6.0-rc02.

Fixes #1635 
Fixes #1638
