### PR TITLE
[Navigation-animation] Delegate navigation-animation impl to androidx navigation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ okhttp = "3.12.13"
 coil = "1.3.2"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.6.0-rc02"
+androidxnavigation = "2.7.0-alpha01"
 androidxWindow = "1.0.0"
 
 metalava = "0.3.2"

--- a/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/NavHostControllerTest.kt
+++ b/navigation-animation/src/androidTest/java/com/google/accompanist/navigation/animation/NavHostControllerTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.NavHostController
 import androidx.navigation.NoOpNavigator
+import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.get
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -53,7 +54,7 @@ class NavHostControllerTest {
         }
 
         val navigator = composeTestRule.runOnIdle {
-            navController.navigatorProvider[AnimatedComposeNavigator::class]
+            navController.navigatorProvider[ComposeNavigator::class]
         }
 
         // trigger recompose
@@ -62,7 +63,7 @@ class NavHostControllerTest {
         }
 
         composeTestRule.runOnIdle {
-            assertThat(navController.navigatorProvider[AnimatedComposeNavigator::class])
+            assertThat(navController.navigatorProvider[ComposeNavigator::class])
                 .isEqualTo(navigator)
         }
     }

--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/AnimatedNavHost.kt
@@ -16,40 +16,24 @@
 
 package com.google.accompanist.navigation.animation
 
-import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavDestination
-import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.Navigator
-import androidx.navigation.compose.DialogHost
-import androidx.navigation.compose.DialogNavigator
-import androidx.navigation.compose.LocalOwnersProvider
-import androidx.navigation.createGraph
+import androidx.navigation.compose.NavHost
 import androidx.navigation.get
-import kotlinx.coroutines.flow.map
 
 /**
  * Provides in place in the Compose hierarchy for self contained navigation to occur.
@@ -85,20 +69,18 @@ public fun AnimatedNavHost(
     popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) = enterTransition,
     popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) = exitTransition,
     builder: NavGraphBuilder.() -> Unit
-) {
-    AnimatedNavHost(
-        navController,
-        remember(route, startDestination, builder) {
-            navController.createGraph(startDestination, route, builder)
-        },
-        modifier,
-        contentAlignment,
-        enterTransition,
-        exitTransition,
-        popEnterTransition,
-        popExitTransition
-    )
-}
+) = NavHost(
+    navController,
+    startDestination,
+    modifier,
+    contentAlignment,
+    route,
+    enterTransition,
+    exitTransition,
+    popEnterTransition,
+    popExitTransition,
+    builder
+)
 
 /**
  * Provides in place in the Compose hierarchy for self contained navigation to occur.
@@ -127,132 +109,13 @@ public fun AnimatedNavHost(
         { fadeOut(animationSpec = tween(700)) },
     popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) = enterTransition,
     popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) = exitTransition,
-) {
-
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
-        "NavHost requires a ViewModelStoreOwner to be provided via LocalViewModelStoreOwner"
-    }
-    val onBackPressedDispatcherOwner = LocalOnBackPressedDispatcherOwner.current
-    val onBackPressedDispatcher = onBackPressedDispatcherOwner?.onBackPressedDispatcher
-
-    // on successful recompose we setup the navController with proper inputs
-    // after the first time, this will only happen again if one of the inputs changes
-    navController.setLifecycleOwner(lifecycleOwner)
-    navController.setViewModelStore(viewModelStoreOwner.viewModelStore)
-    if (onBackPressedDispatcher != null) {
-        navController.setOnBackPressedDispatcher(onBackPressedDispatcher)
-    }
-
-    navController.graph = graph
-
-    val saveableStateHolder = rememberSaveableStateHolder()
-
-    // Find the ComposeNavigator, returning early if it isn't found
-    // (such as is the case when using TestNavHostController)
-    val composeNavigator = navController.navigatorProvider.get<Navigator<out NavDestination>>(
-        AnimatedComposeNavigator.NAME
-    ) as? AnimatedComposeNavigator ?: return
-    val visibleEntries by remember(navController.visibleEntries) {
-        navController.visibleEntries.map {
-            it.filter { entry ->
-                entry.destination.navigatorName == AnimatedComposeNavigator.NAME
-            }
-        }
-    }.collectAsState(emptyList())
-
-    val backStackEntry = visibleEntries.lastOrNull()
-
-    if (backStackEntry != null) {
-        val finalEnter: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
-            val targetDestination = targetState.destination as AnimatedComposeNavigator.Destination
-
-            if (composeNavigator.isPop.value) {
-                targetDestination.hierarchy.firstNotNullOfOrNull { destination ->
-                    popEnterTransitions[destination.route]?.invoke(this)
-                } ?: popEnterTransition.invoke(this)
-            } else {
-                targetDestination.hierarchy.firstNotNullOfOrNull { destination ->
-                    enterTransitions[destination.route]?.invoke(this)
-                } ?: enterTransition.invoke(this)
-            }
-        }
-
-        val finalExit: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
-            val initialDestination = initialState.destination as AnimatedComposeNavigator.Destination
-
-            if (composeNavigator.isPop.value) {
-                initialDestination.hierarchy.firstNotNullOfOrNull { destination ->
-                    popExitTransitions[destination.route]?.invoke(this)
-                } ?: popExitTransition.invoke(this)
-            } else {
-                initialDestination.hierarchy.firstNotNullOfOrNull { destination ->
-                    exitTransitions[destination.route]?.invoke(this)
-                } ?: exitTransition.invoke(this)
-            }
-        }
-
-        val transition = updateTransition(backStackEntry, label = "entry")
-        transition.AnimatedContent(
-            modifier,
-            transitionSpec = {
-                val zIndex = composeNavigator.backStack.value.size.toFloat()
-                // If the initialState of the AnimatedContent is not in visibleEntries, we are in
-                // a case where visible has cleared the old state for some reason, so instead of
-                // attempting to animate away from the initialState, we skip the animation.
-                if (initialState in visibleEntries) {
-                    ContentTransform(finalEnter(this), finalExit(this), zIndex)
-                } else {
-                    EnterTransition.None togetherWith ExitTransition.None
-                }
-            },
-            contentAlignment,
-            contentKey = { it.id }
-        ) {
-            // In some specific cases, such as clearing your back stack by changing your
-            // start destination, AnimatedContent can contain an entry that is no longer
-            // part of visible entries since it was cleared from the back stack and is not
-            // animating. In these cases the currentEntry will be null, and in those cases,
-            // AnimatedContent will just skip attempting to transition the old entry.
-            // See https://issuetracker.google.com/238686802
-            val currentEntry = visibleEntries.lastOrNull { entry ->
-                it == entry
-            }
-            // while in the scope of the composable, we provide the navBackStackEntry as the
-            // ViewModelStoreOwner and LifecycleOwner
-            currentEntry?.LocalOwnersProvider(saveableStateHolder) {
-                (currentEntry.destination as AnimatedComposeNavigator.Destination)
-                    .content(this, currentEntry)
-            }
-        }
-        if (transition.currentState == transition.targetState) {
-            visibleEntries.forEach { entry ->
-                composeNavigator.markTransitionComplete(entry)
-            }
-        }
-    }
-
-    val dialogNavigator = navController.navigatorProvider.get<Navigator<out NavDestination>>(
-        "dialog"
-    ) as? DialogNavigator ?: return
-
-    // Show any dialog destinations
-    DialogHost(dialogNavigator)
-}
-
-@ExperimentalAnimationApi
-internal val enterTransitions =
-    mutableMapOf<String?,
-        (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?>()
-
-@ExperimentalAnimationApi
-internal val exitTransitions =
-    mutableMapOf<String?, (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?>()
-
-@ExperimentalAnimationApi
-internal val popEnterTransitions =
-    mutableMapOf<String?, (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?)?>()
-
-@ExperimentalAnimationApi
-internal val popExitTransitions =
-    mutableMapOf<String?, (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?)?>()
+) = NavHost(
+    navController,
+    graph,
+    modifier,
+    contentAlignment,
+    enterTransition,
+    exitTransition,
+    popEnterTransition,
+    popExitTransition
+)

--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavGraphBuilder.kt
@@ -28,8 +28,8 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraph
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
-import androidx.navigation.get
 
 /**
  * Add the [Composable] to the [NavGraphBuilder]
@@ -58,26 +58,16 @@ public fun NavGraphBuilder.composable(
         AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?
     )? = exitTransition,
     content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
-) {
-    addDestination(
-        AnimatedComposeNavigator.Destination(
-            provider[AnimatedComposeNavigator::class],
-            content
-        ).apply {
-            this.route = route
-            arguments.forEach { (argumentName, argument) ->
-                addArgument(argumentName, argument)
-            }
-            deepLinks.forEach { deepLink ->
-                addDeepLink(deepLink)
-            }
-            enterTransition?.let { enterTransitions[route] = enterTransition }
-            exitTransition?.let { exitTransitions[route] = exitTransition }
-            popEnterTransition?.let { popEnterTransitions[route] = popEnterTransition }
-            popExitTransition?.let { popExitTransitions[route] = popExitTransition }
-        }
-    )
-}
+) = composable(
+    route,
+    arguments,
+    deepLinks,
+    enterTransition,
+    exitTransition,
+    popEnterTransition,
+    popExitTransition,
+    content
+)
 
 /**
  * Construct a nested [NavGraph]
@@ -110,11 +100,14 @@ public fun NavGraphBuilder.navigation(
         AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?
     )? = exitTransition,
     builder: NavGraphBuilder.() -> Unit
-) {
-    navigation(startDestination, route, arguments, deepLinks, builder).apply {
-        enterTransition?.let { enterTransitions[route] = enterTransition }
-        exitTransition?.let { exitTransitions[route] = exitTransition }
-        popEnterTransition?.let { popEnterTransitions[route] = popEnterTransition }
-        popExitTransition?.let { popExitTransitions[route] = popExitTransition }
-    }
-}
+) = navigation(
+    startDestination,
+    route,
+    arguments,
+    deepLinks,
+    enterTransition,
+    exitTransition,
+    popEnterTransition,
+    popExitTransition,
+    builder
+)

--- a/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavHostController.kt
+++ b/navigation-animation/src/main/java/com/google/accompanist/navigation/animation/NavHostController.kt
@@ -18,7 +18,6 @@ package com.google.accompanist.navigation.animation
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.Navigator
@@ -35,7 +34,4 @@ import androidx.navigation.compose.rememberNavController
 @Composable
 fun rememberAnimatedNavController(
     vararg navigators: Navigator<out NavDestination>
-): NavHostController {
-    val animatedNavigator = remember { AnimatedComposeNavigator() }
-    return rememberNavController(animatedNavigator, *navigators)
-}
+): NavHostController = rememberNavController(*navigators)


### PR DESCRIPTION
With navigation-animation migrated back to androidx navigation, we are deprecating accompanist navigation-animation with first step as delegating its implementation to androidx navigation.

Source breaking change -- navigation-animation migrated all internal usages of AnimatedComposeNavigator to ComposeNavigator. This means by default, animated NavHostController will only contain `ComposeNavigator` and no longer contain any `AnimatedComposeNavigator`. Code references to `AnimatedComposeNavigators` such as its retrieval from navigatorProvider may be impacted if none were manually added.

Test: ./gradlew navigation-aninmation:cC
Issue: #1646