### PR TITLE
[Docs] Move flow layouts to deprecated section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ A library that provides [Android runtime permissions][runtimepermissions] suppor
 ### ⏳ [Placeholder](./placeholder/)
 A library that provides easy-to-use modifiers for displaying a placeholder UI while content is loading.
 
-### 🌊 [Flow Layouts](./flowlayout/) (Deprecated)
-See our [Migration Guide](https://google.github.io/accompanist/flowlayout/) for migrating to FlowLayout in Compose.
-
 ### 🧭✨[Navigation-Animation](./navigation-animation/)
 A library which provides [Compose Animation](https://developer.android.com/jetpack/compose/animation) support for Jetpack Navigation Compose.
 
@@ -87,6 +84,9 @@ See our [Migration Guide](https://google.github.io/accompanist/appcompat-theme/)
 
 ### 📖 [Pager](./pager/) (Deprecated)
 See our [Migration Guide](https://google.github.io/accompanist/pager/) for migrating to Pager in Compose.
+
+### 🌊 [Flow Layouts](./flowlayout/) (Deprecated)
+See our [Migration Guide](https://google.github.io/accompanist/flowlayout/) for migrating to FlowLayout in Compose.
 
 ---
 


### PR DESCRIPTION
Adjusts the main README links by moving `Flow Layouts` to the other deprecated libraries.