### PR TITLE
Add manual baseline profiles for each project

### DIFF
--- a/adaptive/src/main/baseline-prof.txt
+++ b/adaptive/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/adaptive/**->**(**)**

--- a/appcompat-theme/src/main/baseline-prof.txt
+++ b/appcompat-theme/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/appcompattheme/**->**(**)**

--- a/drawablepainter/src/main/baseline-prof.txt
+++ b/drawablepainter/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/drawablepainter/**->**(**)**

--- a/flowlayout/src/main/baseline-prof.txt
+++ b/flowlayout/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/flowlayout/**->**(**)**

--- a/insets-ui/src/main/baseline-prof.txt
+++ b/insets-ui/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/insets/ui/**->**(**)**

--- a/insets/src/main/baseline-prof.txt
+++ b/insets/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/insets/**->**(**)**

--- a/navigation-animation/src/main/baseline-prof.txt
+++ b/navigation-animation/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/navigation/animation/**->**(**)**

--- a/navigation-material/src/main/baseline-prof.txt
+++ b/navigation-material/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/navigation/material/**->**(**)**

--- a/pager-indicators/src/main/baseline-prof.txt
+++ b/pager-indicators/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/pager/indicators/**->**(**)**

--- a/pager/src/main/baseline-prof.txt
+++ b/pager/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/pager/**->**(**)**

--- a/permissions/src/main/baseline-prof.txt
+++ b/permissions/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/permissions/**->**(**)**

--- a/placeholder-material/src/main/baseline-prof.txt
+++ b/placeholder-material/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/placeholder/material/**->**(**)**

--- a/placeholder-material3/src/main/baseline-prof.txt
+++ b/placeholder-material3/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/placeholder/material3/**->**(**)**

--- a/placeholder/src/main/baseline-prof.txt
+++ b/placeholder/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/placeholder/**->**(**)**

--- a/swiperefresh/src/main/baseline-prof.txt
+++ b/swiperefresh/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/swiperefresh/**->**(**)**

--- a/systemuicontroller/src/main/baseline-prof.txt
+++ b/systemuicontroller/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/systemuicontroller/**->**(**)**

--- a/themeadapter-appcompat/src/main/baseline-prof.txt
+++ b/themeadapter-appcompat/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/themeadapter/appcompat/**->**(**)**

--- a/themeadapter-core/src/main/baseline-prof.txt
+++ b/themeadapter-core/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/themeadapter/core**->**(**)**

--- a/themeadapter-material/src/main/baseline-prof.txt
+++ b/themeadapter-material/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/themeadapter/material**->**(**)**

--- a/themeadapter-material3/src/main/baseline-prof.txt
+++ b/themeadapter-material3/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/themeadapter/material3/**->**(**)**

--- a/web/src/main/baseline-prof.txt
+++ b/web/src/main/baseline-prof.txt
@@ -1,0 +1,2 @@
+# include everything
+HSPLcom/google/accompanist/web/**->**(**)**


### PR DESCRIPTION
By creating a manual baseline profile for each of these libraries, all code will be part of the resulting baseline profile.
This is the most lightweight catch all approach to add accompanist code to baseline profiles.

We could add an explicit dependency on profileinstaller, but that's being brought in from Compose either way.
So adding the new dependency here would only add to maintenance overhead.