### PR TITLE
Removing tools:ignore="GradleOverride"

### DIFF
--- a/appcompat-theme/build.gradle.kts
+++ b/appcompat-theme/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packagingOptions {

--- a/appcompat-theme/src/androidTest/AndroidManifest.xml
+++ b/appcompat-theme/src/androidTest/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+    <uses-sdk android:minSdkVersion="21"  />
 
     <application>
         <activity

--- a/appcompat-theme/src/main/AndroidManifest.xml
+++ b/appcompat-theme/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/drawablepainter/build.gradle.kts
+++ b/drawablepainter/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     testOptions {

--- a/drawablepainter/src/main/AndroidManifest.xml
+++ b/drawablepainter/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/flowlayout/build.gradle.kts
+++ b/flowlayout/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/flowlayout/src/main/AndroidManifest.xml
+++ b/flowlayout/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/insets-ui/build.gradle.kts
+++ b/insets-ui/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/insets-ui/src/main/AndroidManifest.xml
+++ b/insets-ui/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/insets/build.gradle.kts
+++ b/insets/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/insets/src/main/AndroidManifest.xml
+++ b/insets/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/navigation-animation/build.gradle.kts
+++ b/navigation-animation/build.gradle.kts
@@ -59,6 +59,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     testOptions {

--- a/navigation-animation/src/main/AndroidManifest.xml
+++ b/navigation-animation/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/navigation-material/build.gradle.kts
+++ b/navigation-material/build.gradle.kts
@@ -59,6 +59,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     testOptions {

--- a/navigation-material/src/main/AndroidManifest.xml
+++ b/navigation-material/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/pager-indicators/build.gradle.kts
+++ b/pager-indicators/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/pager-indicators/src/main/AndroidManifest.xml
+++ b/pager-indicators/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/pager/build.gradle.kts
+++ b/pager/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/pager/src/main/AndroidManifest.xml
+++ b/pager/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/permissions/build.gradle.kts
+++ b/permissions/build.gradle.kts
@@ -64,6 +64,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     testOptions {

--- a/permissions/src/main/AndroidManifest.xml
+++ b/permissions/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/placeholder-material/build.gradle.kts
+++ b/placeholder-material/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/placeholder-material/src/main/AndroidManifest.xml
+++ b/placeholder-material/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/placeholder-material3/build.gradle.kts
+++ b/placeholder-material3/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/placeholder-material3/src/main/AndroidManifest.xml
+++ b/placeholder-material3/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+    <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/placeholder/build.gradle.kts
+++ b/placeholder/build.gradle.kts
@@ -56,6 +56,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/placeholder/src/main/AndroidManifest.xml
+++ b/placeholder/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/swiperefresh/build.gradle.kts
+++ b/swiperefresh/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/swiperefresh/src/main/AndroidManifest.xml
+++ b/swiperefresh/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/systemuicontroller/build.gradle.kts
+++ b/systemuicontroller/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/systemuicontroller/src/main/AndroidManifest.xml
+++ b/systemuicontroller/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/testharness/build.gradle.kts
+++ b/testharness/build.gradle.kts
@@ -64,6 +64,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/testharness/src/main/AndroidManifest.xml
+++ b/testharness/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/themeadapter-appcompat/build.gradle.kts
+++ b/themeadapter-appcompat/build.gradle.kts
@@ -59,6 +59,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/themeadapter-appcompat/src/main/AndroidManifest.xml
+++ b/themeadapter-appcompat/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/themeadapter-core/build.gradle.kts
+++ b/themeadapter-core/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/themeadapter-core/src/main/AndroidManifest.xml
+++ b/themeadapter-core/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/themeadapter-material/build.gradle.kts
+++ b/themeadapter-material/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/themeadapter-material/src/main/AndroidManifest.xml
+++ b/themeadapter-material/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/themeadapter-material3/build.gradle.kts
+++ b/themeadapter-material3/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/themeadapter-material3/src/main/AndroidManifest.xml
+++ b/themeadapter-material3/src/main/AndroidManifest.xml
@@ -16,5 +16,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-  <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+  <uses-sdk android:minSdkVersion="21"  />
 </manifest>

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         textOutput = File("stdout")
         // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks
         checkReleaseBuilds = false
+        disable += setOf("GradleOverrides")
     }
 
     packaging {

--- a/web/src/main/AndroidManifest.xml
+++ b/web/src/main/AndroidManifest.xml
@@ -17,5 +17,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <uses-sdk android:minSdkVersion="21" tools:ignore="GradleOverrides" />
+    <uses-sdk android:minSdkVersion="21"  />
 </manifest>


### PR DESCRIPTION
This issue is primarily due to Bazel.

When compiling a module, Bazel will bring in libraries and their transitive dependencies. When resolving manifest merger actions, Accompanist is brought in via the compose library.

Per this GH issue (https://github.com/mixpanel/mixpanel-android/issues/298):

"By ignoring the GradleOverrides, it ignores all overrides for the entire project"

Therefore, as long as an app brings in Accompanist, the app will be forced to use API 21 minimum. They cannot use the tools:overrideLibrary to override Accompanist because Accompanist will be brought in transitively.

It also seems wholly unnecessary to have this tag to begin with as well.