### PR TITLE
[Permissions] Alter use of READ_EXTERNAL_STORAGE permission from permissions samples.

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     <!-- Used for the permissions sample -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 

--- a/sample/src/main/java/com/google/accompanist/sample/permissions/RequestMultiplePermissionsSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/permissions/RequestMultiplePermissionsSample.kt
@@ -42,7 +42,7 @@ class RequestMultiplePermissionsSample : ComponentActivity() {
             AccompanistSampleTheme {
                 val multiplePermissionsState = rememberMultiplePermissionsState(
                     listOf(
-                        android.Manifest.permission.READ_EXTERNAL_STORAGE,
+                        android.Manifest.permission.RECORD_AUDIO,
                         android.Manifest.permission.CAMERA,
                     )
                 )


### PR DESCRIPTION
fixes #1679.

RequestMultiplePermissionsSample was using READ_EXTERNAL_STORAGE, but this permission was removed at API Level 33 for more detailed items. It leads to the state where rememberMultiplePermissionsState() never count it as approved whereas launchMultiplePermissionRequest() will never ask the user for it as a valid permission, and the entire sample never gets to the "both approved" state.

Use another permission entry which is still valid at any API level.