### PR TITLE
[Web]Remove the wrapper of webview to solve nestedscroll issue

### DIFF
--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.view.children
 import com.google.accompanist.web.LoadingState.Finished
 import com.google.accompanist.web.LoadingState.Loading
 import kotlinx.coroutines.CoroutineScope
@@ -225,7 +224,8 @@ fun WebView(
         },
         modifier = modifier,
         onRelease = { parentFrame ->
-            val wv = parentFrame.children.first() as WebView
+            // Since FrameLayout is removed,parentFrame is just the WebView
+            val wv = parentFrame
             onDispose(wv)
         }
     )

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -222,7 +222,6 @@ fun WebView(
                 webChromeClient = chromeClient
                 webViewClient = client
             }.also { state.webView = it }
-
         },
         modifier = modifier,
         onRelease = { parentFrame ->

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -210,7 +210,7 @@ fun WebView(
 
     AndroidView(
         factory = { context ->
-            val childView = (factory?.invoke(context) ?: WebView(context)).apply {
+            (factory?.invoke(context) ?: WebView(context)).apply {
                 onCreated(this)
 
                 this.layoutParams = layoutParams
@@ -223,14 +223,6 @@ fun WebView(
                 webViewClient = client
             }.also { state.webView = it }
 
-            // Workaround a crash on certain devices that expect WebView to be
-            // wrapped in a ViewGroup.
-            // b/243567497
-            val parentLayout = FrameLayout(context)
-            parentLayout.layoutParams = layoutParams
-            parentLayout.addView(childView)
-
-            parentLayout
         },
         modifier = modifier,
         onRelease = { parentFrame ->

--- a/web/src/main/java/com/google/accompanist/web/WebView.kt
+++ b/web/src/main/java/com/google/accompanist/web/WebView.kt
@@ -223,10 +223,8 @@ fun WebView(
             }.also { state.webView = it }
         },
         modifier = modifier,
-        onRelease = { parentFrame ->
-            // Since FrameLayout is removed,parentFrame is just the WebView
-            val wv = parentFrame
-            onDispose(wv)
+        onRelease = {
+            onDispose(it)
         }
     )
 }


### PR DESCRIPTION
In this [PR](https://github.com/google/accompanist/pull/1483), Ben wrapped the Webview with a Framelayout to workaround rare crash. However, this led to the problem that the nested scroll does not work now. Since the AndroidViewHolder use view?.isNestedScrollingEnabled to determine whether the child view support nested scroll. It works well before this change because Webview supports nested scroll but failed now since FrameLayout does not. I opened an [issue](https://github.com/google/accompanist/issues/1652) about this problem and Ben approved me to remove the Framelayout first to workaround this issue. Thus I finished it and submit this PR

Fixes #1652 