### PR TITLE
[Placeholder documentation] Show deprecated message within the warning box

### DIFF
--- a/docs/placeholder.md
+++ b/docs/placeholder.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-placeholder)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-**This library is deprecated, and the API is no longer maintained. We recommend forking the implementation and customising it to your needs.** The original documentation is below.
+    **This library is deprecated, and the API is no longer maintained. We recommend forking the implementation and customising it to your needs.** The original documentation is below.
 
 A library which provides a [modifier][modifier] for display 'placeholder' UI while content is loading.
 


### PR DESCRIPTION
Small formatting change so the warning message in the docs shows within the warning box rather than under it.

How it shows currently on https://google.github.io/accompanist/placeholder/
<img width="930" alt="Screenshot 2023-10-20 at 9 59 21 AM" src="https://github.com/google/accompanist/assets/8265864/011baf76-bbe1-46dd-b198-dcc2582e0586">


How I'd expect it to show (as seen on other pages)
<img width="930" alt="Screenshot 2023-10-20 at 9 59 37 AM" src="https://github.com/google/accompanist/assets/8265864/8f46dc42-32c3-4dba-b61e-1ddabdd4909f">
