### PR TITLE
[Navigation Material] Add null check for retainedEntry in BackHandler

### DIFF
--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -221,7 +221,7 @@ public class BottomSheetNavigator(
         }
 
         BackHandler(retainedEntry != null) {
-            state.popWithTransition(retainedEntry!!, false)
+            retainedEntry?.let { state.popWithTransition(it, false) }
         }
 
         SheetContentHost(


### PR DESCRIPTION
BackHandler sometimes crashes the application with the `NullPointerException`. 
Log from the FirebaseCrashlytics:

```
Fatal Exception: java.lang.NullPointerException:
       at com.google.accompanist.navigation.material.BottomSheetNavigator$sheetContent$1$2.invoke(BottomSheetNavigator.kt:224)
       at com.google.accompanist.navigation.material.BottomSheetNavigator$sheetContent$1$2.invoke(BottomSheetNavigator.kt:223)
```

This seems to be a random issue on low-end devices. 

This issue was noticed using `com.google.accompanist:accompanist-navigation-material:0.32.0` on a large-scale application.