### PR TITLE
[FlowLayout Documentation] Update flowlayout.md

### DIFF
--- a/docs/flowlayout.md
+++ b/docs/flowlayout.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-flowlayout)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-    **This library is deprecated, with official insets support in androidx.compose.foundation.** The migration guide and original documentation is below.
+    **This library is deprecated, with official FlowLayout support in androidx.compose.foundation.** The migration guide and original documentation is below.
 
 ## Migration Guide to the official FlowLayouts
 

--- a/docs/flowlayout.md
+++ b/docs/flowlayout.md
@@ -2,28 +2,12 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-flowlayout)](https://search.maven.org/search?q=g:com.google.accompanist)
 
-Flow Layouts in Accompanist is now deprecated. Please see the migration guide below to begin using 
-Flow Layouts in Androidx.
-
-The official `androidx.compose.foundation` FlowLayouts support is very similar to accompanist/flowlayouts, with a few changes.
-
-It is most similar to `Row` and `Column` and shares similar modifiers and the scopes. 
-Unlike the standard `Row` and `Column` composables, if it runs out of space on the current row, 
-the children are placed in the next line, and this repeats until the children are fully placed.
-
-## Usage
-  
-``` kotlin
-FlowRow {
-    // row contents
-}
-
-FlowColumn {
-    // column contents
-}
-```
+!!! warning
+    **This library is deprecated, with official insets support in androidx.compose.foundation.** The migration guide and original documentation is below.
 
 ## Migration Guide to the official FlowLayouts
+
+The official `androidx.compose.foundation` FlowLayouts support is very similar to accompanist/flowlayouts, with a few changes.
 
 1. Replace import packages to point to Androidx.Compose
 ``` kotlin
@@ -126,6 +110,24 @@ FlowRow(maxItemsInEachRow = 3) {
 For examples, refer to the [Flow Row samples](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/compose/foundation/foundation-layout/samples/src/main/java/androidx/compose/foundation/layout/samples/FlowRowSample.kt) 
 and the [Flow Column samples](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/compose/foundation/foundation-layout/samples/src/main/java/androidx/compose/foundation/layout/samples/FlowColumnSample.kt).
 
+## Original Docs
+
+It is most similar to `Row` and `Column` and shares similar modifiers and the scopes. 
+Unlike the standard `Row` and `Column` composables, if it runs out of space on the current row, 
+the children are placed in the next line, and this repeats until the children are fully placed.
+
+## Usage
+  
+``` kotlin
+FlowRow {
+    // row contents
+}
+
+FlowColumn {
+    // column contents
+}
+```
+
 ## Download
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-flowlayout)](https://search.maven.org/search?q=g:com.google.accompanist)
@@ -136,7 +138,7 @@ repositories {
 }
 
 dependencies {
-    implementation "androidx.compose.foundation:foundation:<compose-version>"
+    implementation "com.google.accompanist:accompanist-flowlayout:<version>"
 }
 ```
 


### PR DESCRIPTION
Update the style of the deprecated message for FlowLayout so it shows nicely in the docs
I.e. with the warning box similar to insets and other pages

<img width="884" alt="Screenshot 2023-11-29 at 1 53 30 PM" src="https://github.com/google/accompanist/assets/8265864/d7631d65-41a4-48b5-9ab5-0fcf1a5ba7c7">

Also rearrange the content so it's easy to understand new vs old with the seperate "migration" and "original docs" sections like on other docs pages, e.g. [insets](https://google.github.io/accompanist/insets/)