### PR TITLE
[Documentation] Fix warning box/text in docs

### DIFF
--- a/docs/systemuicontroller.md
+++ b/docs/systemuicontroller.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-systemuicontroller)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-**This library is deprecated, and the API is no longer maintained. We recommend forking the implementation and customising it to your needs.** The original documentation is below.
+    **This library is deprecated, and the API is no longer maintained. We recommend forking the implementation and customising it to your needs.** The original documentation is below.
 
 ## Migration
 Recommendation: If you were using SystemUIController to go edge-to-edge in your activity and change the system bar colors and system bar icon colors, use the new [Activity.enableEdgeToEdge](https://developer.android.com/reference/androidx/activity/ComponentActivity#(androidx.activity.ComponentActivity).enableEdgeToEdge(androidx.activity.SystemBarStyle,androidx.activity.SystemBarStyle)) method available in androidx.activity 1.8.0-alpha03 and later. This method backports the scrims used on some versions of Android. [This](https://github.com/android/nowinandroid/pull/817) is a sample PR of the migration to the new method and removing the dependency on SystemUIController in Now in Android.

--- a/docs/themeadapter-appcompat.md
+++ b/docs/themeadapter-appcompat.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-themeadapter-appcompat)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-**This library is deprecated, and the API is no longer maintained.** The original documentation is below.
+    **This library is deprecated, and the API is no longer maintained.** The original documentation is below.
 
 ## Migration
 Recommendation: Use the [Material Theme Builder](https://m3.material.io/theme-builder) tool, or an alternative design tool, to generate a matching XML and Compose theme implementation for your app. See [Migrating XML themes to Compose](https://developer.android.com/jetpack/compose/designsystems/views-to-compose) to learn more.

--- a/docs/themeadapter-core.md
+++ b/docs/themeadapter-core.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-themeadapter-core)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-**This library is deprecated, and the API is no longer maintained.** The original documentation is below.
+    **This library is deprecated, and the API is no longer maintained.** The original documentation is below.
 
 ## Migration
 Recommendation: Use the [Material Theme Builder](https://m3.material.io/theme-builder) tool, or an alternative design tool, to generate a matching XML and Compose theme implementation for your app. See [Migrating XML themes to Compose](https://developer.android.com/jetpack/compose/designsystems/views-to-compose) to learn more.

--- a/docs/themeadapter-material.md
+++ b/docs/themeadapter-material.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-themeadapter-material)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-**This library is deprecated, and the API is no longer maintained.** The original documentation is below.
+    **This library is deprecated, and the API is no longer maintained.** The original documentation is below.
 
 ## Migration
 Recommendation: Use the [Material Theme Builder](https://m3.material.io/theme-builder) tool, or an alternative design tool, to generate a matching XML and Compose theme implementation for your app. See [Migrating XML themes to Compose](https://developer.android.com/jetpack/compose/designsystems/views-to-compose) to learn more.
@@ -58,9 +58,9 @@ MdcTheme {
 This is especially handy when you're migrating an existing app, a `Fragment` (or other UI container) at a time.
 
 !!! caution
-If you are using an AppCompat (i.e. non-MDC) theme in your app, you should use
-[AppCompat Theme Adapter](https://github.com/google/accompanist/tree/main/themeadapter-appcompat)
-instead, as it attempts to bridge the gap between [AppCompat][appcompat] XML themes, and M2 themes in [Jetpack Compose][compose].
+    If you are using an AppCompat (i.e. non-MDC) theme in your app, you should use
+    [AppCompat Theme Adapter](https://github.com/google/accompanist/tree/main/themeadapter-appcompat)
+    instead, as it attempts to bridge the gap between [AppCompat][appcompat] XML themes, and M2 themes in [Jetpack Compose][compose].
 
 ### Customizing the M2 theme
 

--- a/docs/web.md
+++ b/docs/web.md
@@ -5,7 +5,7 @@
 A library which provides a Jetpack Compose wrapper around Android's WebView.
 
 !!! warning
-**This library is deprecated, and the API is no longer maintained. We recommend forking the implementation and customising it to your needs.** The original documentation is below.
+    **This library is deprecated, and the API is no longer maintained. We recommend forking the implementation and customising it to your needs.** The original documentation is below.
 
 ## Usage
 


### PR DESCRIPTION
Some pages are currently incorrectly formatted so the warning boxes don't have text in them
<img width="871" alt="Screenshot 2023-11-29 at 2 28 57 PM" src="https://github.com/google/accompanist/assets/8265864/6677a4f9-1b89-4e0b-85da-a65134be7038">

This PR just changes the formatting so they show correctly.
The warning boxes (and caution boxes) should show with text inside it as you see on docs pages like [insets](https://google.github.io/accompanist/insets/)
<img width="869" alt="Screenshot 2023-11-29 at 2 28 06 PM" src="https://github.com/google/accompanist/assets/8265864/86b271b6-46b3-4490-ac72-cc4c1c612011">

I [previously made this fix](https://github.com/google/accompanist/pull/1724) for the placeholder page but didn't realise there is the same problem in other places. This PR address all the places I found