### PR TITLE
[ThemeAdapter-Material3] Fix warning in docs

### DIFF
--- a/docs/themeadapter-material3.md
+++ b/docs/themeadapter-material3.md
@@ -3,7 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-themeadapter-material3)](https://search.maven.org/search?q=g:com.google.accompanist)
 
 !!! warning
-**This library is deprecated, and the API is no longer maintained. We recommend generating a theme with [Material Theme Builder](https://m3.material.io/theme-builder)** The original documentation is below.
+    **This library is deprecated, and the API is no longer maintained. We recommend generating a theme with [Material Theme Builder](https://m3.material.io/theme-builder)** The original documentation is below.
 
 ## Migration
 Recommendation: Use the [Material Theme Builder](https://m3.material.io/theme-builder) tool, or an alternative design tool, to generate a matching XML and Compose theme implementation for your app. See [Migrating XML themes to Compose](https://developer.android.com/jetpack/compose/designsystems/views-to-compose) to learn more.


### PR DESCRIPTION
The warning looks not how it supposed to be
<img width="710" alt="image" src="https://github.com/google/accompanist/assets/3684355/23257caa-c3fe-482e-9c02-8c48a7453210">
