### PR TITLE
[Navigation Material] Ensure Navigation Material properly handles back for nested nav

### DIFF
--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -17,6 +17,7 @@
 package com.google.accompanist.navigation.material
 
 import android.annotation.SuppressLint
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material.ExperimentalMaterialApi
@@ -211,6 +212,10 @@ class BottomSheetNavigator(
         if (retainedEntry != null) {
             LaunchedEffect(retainedEntry) {
                 sheetState.show()
+            }
+
+            BackHandler {
+                state.popWithTransition(popUpTo = retainedEntry!!, saveState = false)
             }
         }
 


### PR DESCRIPTION
If there is a nested NavGraph under the current bottomSheet destination and you do a back press, instead of the bottomSheet which is the topmost destination being popped, the nested NavHost underneath will be popped instead. This is caused by bottomSheet not properly intercepting back presses.

This change added a BackHandler to ensure that bottomSheets correctly respect the system back hierarchy for back events.

Fixes: #1726
