### PR TITLE
[TestHarness] Deprecate testharness

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ A library which provides a way to use Android Drawables as Jetpack Compose Paint
 ### 📜 [Adaptive](./adaptive/)
 A library providing a collection of utilities for adaptive layouts.
 
-### 🗜 [Test Harness](./testharness/)
-Utilities for testing Compose layouts.
-
 ### ⬇️ [Swipe to Refresh](./swiperefresh/) (Deprecated)
 See our [Migration Guide](https://google.github.io/accompanist/swiperefresh/) for migrating to PullRefresh in Compose Material.
 
@@ -87,6 +84,9 @@ A library that enables the reuse of [MDC-Android][mdc] Material 3 XML themes, fo
 
 ### 🌏 [Web](./web/) (Deprecated)
 A wrapper around WebView for basic WebView support in Jetpack Compose.
+
+### 🗜 [Test Harness](./testharness/) (Deprecated)
+Utilities for testing Compose layouts.
 
 ### 📐 [Insets](./insets/) (Deprecated & Removed)
 See our [Migration Guide](https://google.github.io/accompanist/insets/) for migrating to Insets in Compose.

--- a/adaptive/build.gradle.kts
+++ b/adaptive/build.gradle.kts
@@ -108,9 +108,6 @@ dependencies {
     androidTestImplementation(project(":internal-testutils"))
     testImplementation(project(":internal-testutils"))
 
-    androidTestImplementation(project(":testharness"))
-    testImplementation(project(":testharness"))
-
     androidTestImplementation(libs.junit)
     testImplementation(libs.junit)
 

--- a/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/TwoPaneTest.kt
+++ b/adaptive/src/sharedTest/kotlin/com/google/accompanist/adaptive/TwoPaneTest.kt
@@ -19,6 +19,7 @@ package com.google.accompanist.adaptive
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -26,7 +27,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.ForcedSize
+import androidx.compose.ui.test.LayoutDirection
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.then
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -42,7 +47,6 @@ import androidx.window.core.ExperimentalWindowApi
 import androidx.window.layout.DisplayFeature
 import androidx.window.layout.FoldingFeature
 import androidx.window.testing.layout.FoldingFeature
-import com.google.accompanist.testharness.TestHarness
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -62,9 +66,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Ltr
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Ltr)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -88,6 +92,9 @@ class TwoPaneTest {
                         splitFraction = 1f / 3f
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -124,9 +131,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Rtl
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Rtl)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -150,6 +157,9 @@ class TwoPaneTest {
                         splitFraction = 1f / 3f
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -186,9 +196,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Ltr
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Ltr)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -213,6 +223,9 @@ class TwoPaneTest {
                         gapWidth = 64.dp
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -249,9 +262,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Rtl
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Rtl)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -276,6 +289,9 @@ class TwoPaneTest {
                         gapWidth = 64.dp
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -312,8 +328,8 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -337,6 +353,9 @@ class TwoPaneTest {
                         splitFraction = 1f / 3f
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -373,8 +392,8 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -399,6 +418,9 @@ class TwoPaneTest {
                         gapHeight = 64.dp
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -435,9 +457,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Ltr
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Ltr)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -462,6 +484,9 @@ class TwoPaneTest {
                         offsetFromStart = true,
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -498,9 +523,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Rtl
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Rtl)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -525,6 +550,9 @@ class TwoPaneTest {
                         offsetFromStart = true,
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -561,9 +589,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Ltr
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Ltr)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -589,6 +617,9 @@ class TwoPaneTest {
                         gapWidth = 64.dp
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -625,9 +656,9 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp),
-                layoutDirection = LayoutDirection.Rtl
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp)) then
+                    DeviceConfigurationOverride.LayoutDirection(LayoutDirection.Rtl)
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -653,6 +684,9 @@ class TwoPaneTest {
                         gapWidth = 64.dp
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -689,8 +723,8 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -715,6 +749,9 @@ class TwoPaneTest {
                         offsetFromTop = true
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -751,8 +788,8 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -778,6 +815,9 @@ class TwoPaneTest {
                         gapHeight = 64.dp
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -814,8 +854,8 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -840,6 +880,9 @@ class TwoPaneTest {
                         offsetFromTop = false
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -876,8 +919,8 @@ class TwoPaneTest {
         lateinit var secondCoordinates: LayoutCoordinates
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -903,6 +946,9 @@ class TwoPaneTest {
                         gapHeight = 64.dp
                     ),
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -946,8 +992,8 @@ class TwoPaneTest {
         }
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -972,6 +1018,9 @@ class TwoPaneTest {
                     ),
                     displayFeatures = displayFeatures,
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -1022,8 +1071,8 @@ class TwoPaneTest {
         }
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -1048,6 +1097,9 @@ class TwoPaneTest {
                     ),
                     displayFeatures = displayFeatures,
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -1098,8 +1150,8 @@ class TwoPaneTest {
         }
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -1124,6 +1176,9 @@ class TwoPaneTest {
                     ),
                     displayFeatures = displayFeatures,
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -1174,8 +1229,8 @@ class TwoPaneTest {
         }
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -1200,6 +1255,9 @@ class TwoPaneTest {
                     ),
                     displayFeatures = displayFeatures,
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -1250,8 +1308,8 @@ class TwoPaneTest {
         }
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -1276,6 +1334,9 @@ class TwoPaneTest {
                     ),
                     displayFeatures = displayFeatures,
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -1326,8 +1387,8 @@ class TwoPaneTest {
         }
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
                 TwoPane(
@@ -1352,6 +1413,9 @@ class TwoPaneTest {
                     ),
                     displayFeatures = displayFeatures,
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }
@@ -1402,8 +1466,8 @@ class TwoPaneTest {
         }
 
         composeTestRule.setContent {
-            TestHarness(
-                size = DpSize(900.dp, 1200.dp)
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 1200.dp))
             ) {
                 density = LocalDensity.current
 
@@ -1429,6 +1493,9 @@ class TwoPaneTest {
                     ),
                     displayFeatures = displayFeatures,
                     modifier = Modifier
+                        // TODO: This should not be necessary, remove once
+                        //       https://issuetracker.google.com/issues/322354080 is fixed
+                        .requiredSize(900.dp, 1200.dp)
                         .onPlaced { twoPaneCoordinates = it }
                 )
             }

--- a/docs/testharness.md
+++ b/docs/testharness.md
@@ -2,6 +2,40 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.google.accompanist/accompanist-testharness)](https://search.maven.org/search?q=g:com.google.accompanist)
 
+!!! warning
+**This library is deprecated, with a superseding version in androidx.compose.ui.test. The migration guide and original documentation is below.
+
+## Migration
+
+`DeviceConfigurationOverride` from `ui-test` is the replacement for `TestHarness`.
+
+The top-level [`@Composable DeviceConfigurationOverride`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/package-summary#DeviceConfigurationOverride(androidx.compose.ui.test.DeviceConfigurationOverride,kotlin.Function0))
+provides the same structure as `TestHarness`, applying overrides to a piece of `content` under test.
+
+Instead of all of the overrides appearing as parameters to `TestHarness`, the
+`DeviceConfigurationOverride` top-level function takes a particular implementation of the
+[`fun interface DeviceConfigurationOverride`](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride).
+
+The [built-in `DeviceConfigurationOverride`s](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/DeviceConfigurationOverride.Companion)
+are available as extension methods on the companion object of `DeviceConfigurationOverride`, and
+the built-in overrides cover all of the parameters of `TestHarness`.
+
+Multiple `DeviceConfigurationOverride`s can be combined with [then](https://developer.android.com/reference/kotlin/androidx/compose/ui/test/package-summary#(androidx.compose.ui.test.DeviceConfigurationOverride).then(androidx.compose.ui.test.DeviceConfigurationOverride))
+
+## Migration steps:
+
+1. Replace `TestHarness()` with `DeviceConfigurationOverride()` (a deprecation replacement is
+   available)
+1. Remove the override for any argument that was previously using a default value.
+   Because the overrides have been split into independent overrides, the "default" behavior can
+   be achieved by not specifying that override.
+
+   Example: If you want to keep the current dark mode setting and not override it, instead of
+   querying for and specifying the current dark mode theme to apply in an override, don't apply the
+   `DeviceConfigurationOverride.DarkMode` override.
+
+## Original docs
+
 A library providing a test harness for UI components.
 
 ## Background

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-compose = "1.6.0"
+compose = "1.7.0-alpha01"
 composeCompiler = "1.5.8"
 composeMaterial3 = "1.0.1"
 composesnapshot = "-" # a single character = no snapshot
@@ -30,6 +30,7 @@ compose-ui-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref = "compose" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 compose-foundation-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }

--- a/pager/build.gradle.kts
+++ b/pager/build.gradle.kts
@@ -107,9 +107,6 @@ dependencies {
     androidTestImplementation(project(":internal-testutils"))
     testImplementation(project(":internal-testutils"))
 
-    androidTestImplementation(project(":testharness"))
-    testImplementation(project(":testharness"))
-
     androidTestImplementation(libs.junit)
     testImplementation(libs.junit)
 

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseHorizontalPagerTest.kt
@@ -29,6 +29,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.LayoutDirection
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
@@ -41,7 +43,6 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.width
-import com.google.accompanist.testharness.TestHarness
 
 /**
  * Contains [HorizontalPager] tests. This class is extended
@@ -125,7 +126,9 @@ abstract class BaseHorizontalPagerTest(
         userScrollEnabled: Boolean,
         onPageComposed: (Int) -> Unit
     ) {
-        TestHarness(layoutDirection = layoutDirection) {
+        DeviceConfigurationOverride(
+            DeviceConfigurationOverride.LayoutDirection(layoutDirection = layoutDirection)
+        ) {
             applierScope = rememberCoroutineScope()
 
             Box {

--- a/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
+++ b/pager/src/sharedTest/kotlin/com/google/accompanist/pager/BaseVerticalPagerTest.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.LayoutDirection
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
@@ -39,7 +41,6 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.width
-import com.google.accompanist.testharness.TestHarness
 
 /**
  * Contains the [VerticalPager] tests. This class is extended
@@ -105,7 +106,9 @@ abstract class BaseVerticalPagerTest(
         userScrollEnabled: Boolean,
         onPageComposed: (Int) -> Unit
     ) {
-        TestHarness(layoutDirection = LayoutDirection.Ltr) {
+        DeviceConfigurationOverride(
+            DeviceConfigurationOverride.LayoutDirection(layoutDirection = LayoutDirection.Ltr)
+        ) {
             applierScope = rememberCoroutineScope()
 
             Box {

--- a/sample/src/main/java/com/google/accompanist/sample/testharness/TestHarnessSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/testharness/TestHarnessSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.testharness
 
 import android.os.Bundle

--- a/testharness/api/current.api
+++ b/testharness/api/current.api
@@ -2,7 +2,7 @@
 package com.google.accompanist.testharness {
 
   public final class TestHarnessKt {
-    method @androidx.compose.runtime.Composable public static void TestHarness(optional long size, optional boolean darkMode, optional androidx.core.os.LocaleListCompat locales, optional androidx.compose.ui.unit.LayoutDirection? layoutDirection, optional float fontScale, optional Integer? fontWeightAdjustment, optional Boolean? isScreenRound, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @Deprecated @androidx.compose.runtime.Composable public static void TestHarness(optional long size, optional boolean darkMode, optional androidx.core.os.LocaleListCompat locales, optional androidx.compose.ui.unit.LayoutDirection? layoutDirection, optional float fontScale, optional Integer? fontWeightAdjustment, optional Boolean? isScreenRound, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
 }

--- a/testharness/build.gradle.kts
+++ b/testharness/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
     implementation(libs.androidx.core)
     testImplementation(libs.androidx.core)
     implementation(libs.kotlin.coroutines.android)
+    implementation(libs.compose.ui.test)
 
     // ======================
     // Test dependencies

--- a/testharness/src/main/java/com/google/accompanist/testharness/TestHarness.kt
+++ b/testharness/src/main/java/com/google/accompanist/testharness/TestHarness.kt
@@ -70,6 +70,32 @@ import kotlin.math.floor
  * the [isScreenRound] will be left unchanged.
  */
 @Composable
+@Deprecated(
+    replaceWith = ReplaceWith(
+        "DeviceConfigurationOverride(DeviceConfigurationOverride.ForcedSize(size) " +
+            "then DeviceConfigurationOverride.DarkMode(darkMode) " +
+            "then DeviceConfigurationOverride.Locales(LocaleList(locales.toLanguageTags()))" +
+            "then DeviceConfigurationOverride.LayoutDirection(layoutDirection)" +
+            "then DeviceConfigurationOverride.FontScale(fontScale)" +
+            "then DeviceConfigurationOverride.FontWeightAdjustment(fontWeightAdjustment)" +
+            "then DeviceConfigurationOverride.RoundScreen(isScreenRound), " +
+            "content)",
+        "androidx.compose.ui.test.DeviceConfigurationOverride",
+        "androidx.compose.ui.test.ForcedSize",
+        "androidx.compose.ui.test.DarkMode",
+        "androidx.compose.ui.test.Locales",
+        "androidx.compose.ui.test.LayoutDirection",
+        "androidx.compose.ui.test.FontScale",
+        "androidx.compose.ui.test.FontWeightAdjustment",
+        "androidx.compose.ui.test.RoundScreen",
+        "androidx.compose.ui.test.then",
+        "androidx.compose.ui.text.intl.LocaleList",
+    ),
+    message = "TestHarness has been superceded by DeviceConfigurationOverride in ui-test. " +
+        "Each argument in TestHarness have been replaced with an individual " +
+        "DeviceConfigurationOverride, so the suggested replacement is likely unnecessarily " +
+        "adding overrides for anything that was previously using the default arguments."
+)
 public fun TestHarness(
     size: DpSize = DpSize.Unspecified,
     darkMode: Boolean = isSystemInDarkTheme(),

--- a/testharness/src/sharedTest/kotlin/com/google/accompanist/testharness/TestHarnessTest.kt
+++ b/testharness/src/sharedTest/kotlin/com/google/accompanist/testharness/TestHarnessTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.testharness
 
 import android.content.res.Configuration

--- a/testharness/src/sharedTest/kotlin/com/google/accompanist/testharness/TestHarnessTestApi23.kt
+++ b/testharness/src/sharedTest/kotlin/com/google/accompanist/testharness/TestHarnessTestApi23.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.testharness
 
 import androidx.compose.ui.platform.LocalConfiguration


### PR DESCRIPTION
Deprecates testharness with the replacement of `DeviceConfigurationOverride`.

This PR also replaces the internal usage in some other module's tests, and provides a migration guide to the new methods.