### PR TITLE
[navigation-material] Fixes crash in BottomSheetNavigator when user goes back

### DIFF
--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -182,13 +182,13 @@ public class BottomSheetNavigator(
                 }
         }
 
-        if (retainedEntry != null) {
-            LaunchedEffect(retainedEntry) {
+        retainedEntry?.let {
+            LaunchedEffect(it) {
                 sheetState.show()
             }
 
             BackHandler {
-                state.popWithTransition(popUpTo = retainedEntry!!, saveState = false)
+                state.popWithTransition(popUpTo = it, saveState = false)
             }
         }
 


### PR DESCRIPTION
Attempting to address https://github.com/google/accompanist/issues/1750 and https://github.com/google/accompanist/issues/1733.

Although I couldn't reproduce the `NullPointerException` on `BottomSheetNavigator.kt:191`, by looking at the code I suggest avoiding the not-null assertion operator on `retainedEntry` with a `let` scope function.