### PR TITLE
[pager-indicators] Drop false-positive deprecation of pagerTabIndicatorOffset()

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
@@ -60,13 +60,6 @@ public fun Modifier.pagerTabIndicatorOffset(
  * [androidx.compose.foundation.pager.VerticalPager].
  */
 @OptIn(ExperimentalFoundationApi::class)
-@Deprecated(
-    """
-   pagerTabIndicatorOffset for accompanist Pagers are deprecated, please use the version that takes 
-   androidx.compose.foundation.pager.PagerState instead
-For more migration information, please visit https://google.github.io/accompanist/pager/#migration
-"""
-)
 public fun Modifier.pagerTabIndicatorOffset(
     pagerState: androidx.compose.foundation.pager.PagerState,
     tabPositions: List<TabPosition>,


### PR DESCRIPTION
Fixes #1744.

The deprecation was intended to apply only to the old overload above, but was presumably copy-pasted by accident.
