### PR TITLE
[Pager] Remove false positive deprecation message from pagerTabIndicatorOffset

### DIFF
--- a/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
+++ b/pager-indicators/src/main/java/com/google/accompanist/pager/PagerTab.kt
@@ -60,13 +60,6 @@ public fun Modifier.pagerTabIndicatorOffset(
  * [androidx.compose.foundation.pager.VerticalPager].
  */
 @OptIn(ExperimentalFoundationApi::class)
-@Deprecated(
-    """
-   pagerTabIndicatorOffset for accompanist Pagers are deprecated, please use the version that takes 
-   androidx.compose.foundation.pager.PagerState instead
-For more migration information, please visit https://google.github.io/accompanist/pager/#migration
-"""
-)
 public fun Modifier.pagerTabIndicatorOffset(
     pagerState: androidx.compose.foundation.pager.PagerState,
     tabPositions: List<TabPosition>,


### PR DESCRIPTION
This method overload is using `androidx.compose.foundation.pager.PagerState` and shouldn't be marked as deprecated.

As doc [says](https://github.com/google/accompanist/blob/1645e59d53844e71fe7dbe9442309a6237f650a8/docs/pager.md?plain=1#L36):

> Implement it yourself, or still include and use `accompanist-pager-indicators`, it now supports `androidx.compose.foundation.pager.PagerState`

Closes #1739