### PR TITLE
[Navigation Material] Deprecate navigation-material APIs

### DIFF
--- a/docs/navigation-material.md
+++ b/docs/navigation-material.md
@@ -6,8 +6,26 @@ A library which provides [Compose Material](https://developer.android.com/jetpac
 This features composable bottom sheet destinations.
 
 !!! warning
-    The navigation APIs are currently experimental and they could change at any time.
-    All of the APIs are marked with the `@ExperimentalMaterialNavigationApi` annotation.
+    **This library is deprecated, with official material-navigation support in
+[androidx.compose.material.navigation](https://developer.android.com/jetpack/androidx/releases/compose-material#1.7.0-alpha04).**
+The original documentation is below the migration guide.
+
+## Migration
+
+The official `androidx.compose.material.navigation` version 1.7.0-alpha04+ offers all of the same functionality as Accompanist Navigation Material.
+
+All class names are the same, the only needed changes are import related.
+
+1. Replace dependency `com.google.accompanist:accompanist-navigation-material:<version>` with `androidx.compose.material:material-navigation:<version>`
+2. Change import for ModalBottomSheetLayout from `com.google.accompanist.navigation.material.ModalBottomSheetLayout` to `androidx.compose.material.navigation.ModalBottomSheetLayout`
+3. Change import for bottomSheet from `com.google.accompanist.navigation.material.bottomSheet` to `androidx.compose.material.navigation.bottomSheet`
+4. Change import for rememberBottomSheetNavigator from `com.google.accompanist.navigation.material.rememberBottomSheetNavigator` to `androidx.compose.material.navigation.rememberBottomSheetNavigator`
+5. Change import for BottomSheetNavigator from `com.google.accompanist.navigation.material.BottomSheetNavigator` to `androidx.compose.material.navigation.BottomSheetNavigator`
+6. Change import for BottomSheetNavigatorSheetState from `com.google.accompanist.navigation.material.BottomSheetNavigatorSheetState` to `androidx.compose.material.navigation.BottomSheetNavigatorSheetState`
+
+# Deprecated Guidance for Accompanist Navigation Material
+
+The following is the deprecated guide for using Navigation Material in Accompanist. Please see above migration section for how to use the `androidx.compose.material.navigation` Material Navigation.
 
 ## Usage
 

--- a/navigation-material/api/current.api
+++ b/navigation-material/api/current.api
@@ -2,31 +2,31 @@
 package com.google.accompanist.navigation.material {
 
   public final class BottomSheetKt {
-    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static void ModalBottomSheetLayout(com.google.accompanist.navigation.material.BottomSheetNavigator bottomSheetNavigator, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.Shape sheetShape, optional float sheetElevation, optional long sheetBackgroundColor, optional long sheetContentColor, optional long scrimColor, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static void ModalBottomSheetLayout(com.google.accompanist.navigation.material.BottomSheetNavigator bottomSheetNavigator, optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.graphics.Shape sheetShape, optional float sheetElevation, optional long sheetBackgroundColor, optional long sheetContentColor, optional long scrimColor, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
-  @androidx.navigation.Navigator.Name("BottomSheetNavigator") @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public final class BottomSheetNavigator extends androidx.navigation.Navigator<com.google.accompanist.navigation.material.BottomSheetNavigator.Destination> {
-    ctor public BottomSheetNavigator(androidx.compose.material.ModalBottomSheetState sheetState);
-    method public com.google.accompanist.navigation.material.BottomSheetNavigator.Destination createDestination();
-    method public com.google.accompanist.navigation.material.BottomSheetNavigatorSheetState getNavigatorSheetState();
-    method public kotlin.jvm.functions.Function1<androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> getSheetContent();
+  @Deprecated @androidx.navigation.Navigator.Name("BottomSheetNavigator") @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public final class BottomSheetNavigator extends androidx.navigation.Navigator<com.google.accompanist.navigation.material.BottomSheetNavigator.Destination> {
+    ctor @Deprecated public BottomSheetNavigator(androidx.compose.material.ModalBottomSheetState sheetState);
+    method @Deprecated public com.google.accompanist.navigation.material.BottomSheetNavigator.Destination createDestination();
+    method @Deprecated public com.google.accompanist.navigation.material.BottomSheetNavigatorSheetState getNavigatorSheetState();
+    method @Deprecated public kotlin.jvm.functions.Function1<androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> getSheetContent();
     property public final com.google.accompanist.navigation.material.BottomSheetNavigatorSheetState navigatorSheetState;
     property public final kotlin.jvm.functions.Function1<androidx.compose.foundation.layout.ColumnScope,kotlin.Unit> sheetContent;
   }
 
-  @androidx.navigation.NavDestination.ClassType(Composable::class) public static final class BottomSheetNavigator.Destination extends androidx.navigation.NavDestination implements androidx.navigation.FloatingWindow {
-    ctor public BottomSheetNavigator.Destination(com.google.accompanist.navigation.material.BottomSheetNavigator navigator, kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
+  @Deprecated @androidx.navigation.NavDestination.ClassType(Composable::class) public static final class BottomSheetNavigator.Destination extends androidx.navigation.NavDestination implements androidx.navigation.FloatingWindow {
+    ctor @Deprecated public BottomSheetNavigator.Destination(com.google.accompanist.navigation.material.BottomSheetNavigator navigator, kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
   }
 
   public final class BottomSheetNavigatorKt {
-    method @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec);
+    method @Deprecated @androidx.compose.runtime.Composable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static com.google.accompanist.navigation.material.BottomSheetNavigator rememberBottomSheetNavigator(optional androidx.compose.animation.core.AnimationSpec<java.lang.Float> animationSpec);
   }
 
-  @androidx.compose.runtime.Stable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public final class BottomSheetNavigatorSheetState {
-    ctor public BottomSheetNavigatorSheetState(androidx.compose.material.ModalBottomSheetState sheetState);
-    method public androidx.compose.material.ModalBottomSheetValue getCurrentValue();
-    method public androidx.compose.material.ModalBottomSheetValue getTargetValue();
-    method public boolean isVisible();
+  @Deprecated @androidx.compose.runtime.Stable @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public final class BottomSheetNavigatorSheetState {
+    ctor @Deprecated public BottomSheetNavigatorSheetState(androidx.compose.material.ModalBottomSheetState sheetState);
+    method @Deprecated public androidx.compose.material.ModalBottomSheetValue getCurrentValue();
+    method @Deprecated public androidx.compose.material.ModalBottomSheetValue getTargetValue();
+    method @Deprecated public boolean isVisible();
     property public final androidx.compose.material.ModalBottomSheetValue currentValue;
     property public final boolean isVisible;
     property public final androidx.compose.material.ModalBottomSheetValue targetValue;
@@ -36,7 +36,7 @@ package com.google.accompanist.navigation.material {
   }
 
   public final class NavGraphBuilderKt {
-    method @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static void bottomSheet(androidx.navigation.NavGraphBuilder, String route, optional java.util.List<androidx.navigation.NamedNavArgument> arguments, optional java.util.List<androidx.navigation.NavDeepLink> deepLinks, kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
+    method @Deprecated @com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi public static void bottomSheet(androidx.navigation.NavGraphBuilder, String route, optional java.util.List<androidx.navigation.NamedNavArgument> arguments, optional java.util.List<androidx.navigation.NavDeepLink> deepLinks, kotlin.jvm.functions.Function2<? super androidx.compose.foundation.layout.ColumnScope,? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
   }
 
   public final class SheetContentHostKt {

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/BottomSheetNavigatorTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/BottomSheetNavigatorTest.kt
@@ -68,6 +68,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.math.roundToLong
 
+@Suppress("DEPRECATION")
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterialNavigationApi::class)

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/NavGraphBuilderTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/NavGraphBuilderTest.kt
@@ -36,6 +36,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterialNavigationApi::class)
 @LargeTest
 @RunWith(AndroidJUnit4::class)

--- a/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
+++ b/navigation-material/src/androidTest/java/com/google/accompanist/navigation.material/SheetContentHostTest.kt
@@ -49,6 +49,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@Suppress("DEPRECATION")
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 @OptIn(

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheet.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheet.kt
@@ -32,8 +32,15 @@ import androidx.compose.ui.unit.Dp
  *
  * @see [ModalBottomSheetLayout]
  */
+@Deprecated(
+    "Migrate to Androidx compose.material.navigation ModalBottomSheetLayout with the same " +
+        "parameters. To migrate, change import from " +
+        "com.google.accompanist.navigation.material.ModalBottomSheetLayout to " +
+        "androidx.compose.material.navigation.ModalBottomSheetLayout."
+)
 @ExperimentalMaterialNavigationApi
 @OptIn(ExperimentalMaterialApi::class)
+@Suppress("DEPRECATION")
 @Composable
 public fun ModalBottomSheetLayout(
     bottomSheetNavigator: BottomSheetNavigator,

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/BottomSheetNavigator.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.navigation.material
 
 import android.annotation.SuppressLint
@@ -52,6 +54,12 @@ import kotlinx.coroutines.flow.transform
  *
  * @param sheetState The sheet state that is driven by the [BottomSheetNavigator]
  */
+@Deprecated(
+    "Migrate to Androidx compose.material.navigation BottomSheetNavigatorSheetState " +
+        "with the same parameters. To migrate, change import from " +
+        "com.google.accompanist.navigation.material.BottomSheetNavigatorSheetState to " +
+        "androidx.compose.material.navigation.BottomSheetNavigatorSheetState."
+)
 @ExperimentalMaterialNavigationApi
 @OptIn(ExperimentalMaterialApi::class)
 @Stable
@@ -78,6 +86,12 @@ public class BottomSheetNavigatorSheetState(internal val sheetState: ModalBottom
 /**
  * Create and remember a [BottomSheetNavigator]
  */
+@Deprecated(
+    "Migrate to Androidx compose.material.navigation rememberBottomSheetNavigator " +
+        "with the same parameters. To migrate, change import from " +
+        "com.google.accompanist.navigation.material.rememberBottomSheetNavigator to " +
+        "androidx.compose.material.navigation.rememberBottomSheetNavigator."
+)
 @ExperimentalMaterialNavigationApi
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -110,6 +124,12 @@ public fun rememberBottomSheetNavigator(
  * @param sheetState The [ModalBottomSheetState] that the [BottomSheetNavigator] will use to
  * drive the sheet state
  */
+@Deprecated(
+    "Migrate to Androidx compose.material.navigation BottomSheetNavigator " +
+        "with the same parameters. To migrate, change import from " +
+        "com.google.accompanist.navigation.material.BottomSheetNavigator to " +
+        "androidx.compose.material.navigation.BottomSheetNavigator."
+)
 @ExperimentalMaterialNavigationApi
 @OptIn(ExperimentalMaterialApi::class)
 @Navigator.Name("BottomSheetNavigator")

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/NavGraphBuilder.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/NavGraphBuilder.kt
@@ -33,6 +33,13 @@ import androidx.navigation.get
  * @param deepLinks list of deep links to associate with the destinations
  * @param content the sheet content at the given destination
  */
+@Deprecated(
+    "Migrate to Androidx compose.material.navigation NavGraphBuilder.bottomSheet with the " +
+        "same parameters. To migrate, change import from " +
+        "com.google.accompanist.navigation.material.bottomSheet to " +
+        "androidx.compose.material.navigation.bottomSheet."
+)
+@Suppress("DEPRECATION")
 @SuppressLint("NewApi") // b/187418647
 @ExperimentalMaterialNavigationApi
 public fun NavGraphBuilder.bottomSheet(

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/SheetContentHost.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/SheetContentHost.kt
@@ -70,8 +70,8 @@ internal fun ColumnScope.SheetContentHost(
                 }
         }
         backStackEntry.LocalOwnersProvider(saveableStateHolder) {
-            val content =
-                (backStackEntry.destination as BottomSheetNavigator.Destination).content
+            @Suppress("DEPRECATION")
+            val content = (backStackEntry.destination as BottomSheetNavigator.Destination).content
             content(backStackEntry)
         }
     }

--- a/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.google.accompanist.sample.navigation.material
 
 import android.os.Bundle


### PR DESCRIPTION
Now that Compose Material 1.7.0-alpha04 is out it offers the same functionality as Accompanist Navigation Material.

This deprecates all of the classes and functions

Test: ./gradlew navigation-material:cc
