### PR TITLE
Implemented DismissDispatcher to be able to intercept BottomSheet navigation dismissal

### DIFF
--- a/navigation-material/api/current.api
+++ b/navigation-material/api/current.api
@@ -44,3 +44,14 @@ package com.google.accompanist.navigation.material {
 
 }
 
+package com.google.accompanist.navigation.material.dismiss {
+
+  public final class DismissDispatcherKt {
+  }
+
+  public final class DismissHandlerKt {
+    method @androidx.compose.runtime.Composable public static void DismissHandler(optional boolean isEnabled, kotlin.jvm.functions.Function0<kotlin.Unit> onDismiss);
+  }
+
+}
+

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/dismiss/DismissDispatcher.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/dismiss/DismissDispatcher.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.material.dismiss
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavigatorState
+
+internal val LocalDismissDispatcher = compositionLocalOf<OnDismissDispatcher?> {
+    null
+}
+
+internal class OnDismissDispatcher {
+
+    private val callbacks: MutableList<DismissHandlerCallback> = mutableListOf()
+
+    fun tryToDismissSheet(
+        state: NavigatorState,
+        backStackEntry: NavBackStackEntry,
+        showSheet: () -> Unit,
+    ) {
+        if (callbacks.any { it.isEnabled }) {
+            callbacks.forEach { it.onDismiss() }
+            // the sheet has been dismissed by the user
+            // (for example by tapping on the scrim or through an accessibility action)
+            // we need to show the sheet again to handle dismissal manually
+            showSheet()
+        } else {
+            state.pop(popUpTo = backStackEntry, saveState = false)
+        }
+    }
+
+    fun addCallback(callback: DismissHandlerCallback) = callbacks.add(callback)
+
+    fun removeCallback(callback: DismissHandlerCallback) = callbacks.remove(callback)
+}
+
+internal interface DismissHandlerCallback {
+    val isEnabled: Boolean
+    fun onDismiss()
+}

--- a/navigation-material/src/main/java/com/google/accompanist/navigation/material/dismiss/DismissHandler.kt
+++ b/navigation-material/src/main/java/com/google/accompanist/navigation/material/dismiss/DismissHandler.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.navigation.material.dismiss
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalLifecycleOwner
+
+@Composable
+public fun DismissHandler(isEnabled: Boolean = true, onDismiss: () -> Unit) {
+    // Safely update the current `onDismiss` lambda when a new one is provided
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+    // Remember in Composition a dismiss callback that calls the `onDismiss` lambda
+    val backCallback = remember {
+        object : DismissHandlerCallback {
+            override val isEnabled: Boolean = isEnabled
+
+            override fun onDismiss() {
+                return currentOnDismiss()
+            }
+        }
+    }
+
+    val dismissDispatcher = checkNotNull(LocalDismissDispatcher.current) {
+        "No OnDismissDispatcher was provided via LocalDismissDispatcher"
+    }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, dismissDispatcher) {
+        // Add callback to the dismissDispatcher
+        dismissDispatcher.addCallback(backCallback)
+        // When the effect leaves the Composition, remove the callback
+        onDispose {
+            dismissDispatcher.removeCallback(backCallback)
+        }
+    }
+}

--- a/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
+++ b/sample/src/main/java/com/google/accompanist/sample/navigation/material/BottomSheetNavSample.kt
@@ -21,20 +21,32 @@ package com.google.accompanist.sample.navigation.material
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
 import com.google.accompanist.navigation.material.bottomSheet
+import com.google.accompanist.navigation.material.dismiss.DismissHandler
 import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
 import com.google.accompanist.sample.AccompanistSampleTheme
 import java.util.UUID
@@ -55,6 +67,7 @@ private object Destinations {
     const val Home = "HOME"
     const val Feed = "FEED"
     const val Sheet = "SHEET"
+    const val Sheet2 = "SHEET2"
 }
 
 @OptIn(ExperimentalMaterialNavigationApi::class)
@@ -79,7 +92,21 @@ fun BottomSheetNavDemo() {
                 BottomSheet(
                     showFeed = { navController.navigate(Destinations.Feed) },
                     showAnotherSheet = {
-                        navController.navigate(Destinations.Sheet + "?arg=${UUID.randomUUID()}")
+                        navController.navigate(Destinations.Sheet2 + "?arg=Confirmation Dialog to dismiss the sheet")
+                    },
+                    arg = arg
+                )
+            }
+
+            bottomSheet(Destinations.Sheet2 + "?arg={arg}") { backstackEntry ->
+                val arg = backstackEntry.arguments?.getString("arg") ?: "Missing argument :("
+                BottomSheet2(
+                    showFeed = { navController.navigate(Destinations.Feed) },
+                    showAnotherSheet = {
+                        navController.navigate(Destinations.Sheet2 + "?arg=${UUID.randomUUID()}")
+                    },
+                    navigateUp = {
+                        navController.popBackStack()
                     },
                     arg = arg
                 )
@@ -102,7 +129,11 @@ private fun HomeScreen(showSheet: () -> Unit, showFeed: () -> Unit) {
 }
 
 @Composable
-private fun BottomSheet(showFeed: () -> Unit, showAnotherSheet: () -> Unit, arg: String) {
+private fun BottomSheet(
+    showFeed: () -> Unit,
+    showAnotherSheet: () -> Unit,
+    arg: String
+) {
     Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         Text("Sheet with arg: $arg")
         Button(onClick = showFeed) {
@@ -113,3 +144,61 @@ private fun BottomSheet(showFeed: () -> Unit, showAnotherSheet: () -> Unit, arg:
         }
     }
 }
+
+@Composable
+private fun BottomSheet2(
+    showFeed: () -> Unit,
+    showAnotherSheet: () -> Unit,
+    navigateUp: () -> Unit,
+    arg: String
+) {
+    var showConfirmationDialog by remember {
+        mutableStateOf(false)
+    }
+
+    if (showConfirmationDialog) {
+        ConfirmationDialog(
+            onCancel = { showConfirmationDialog = false },
+            onApprove = { navigateUp() }
+        )
+    }
+    DismissHandler {
+        showConfirmationDialog = true
+    }
+
+    BottomSheet(
+        showFeed = showFeed,
+        showAnotherSheet = showAnotherSheet,
+        arg = arg
+    )
+}
+
+@Composable
+private fun ConfirmationDialog(
+    onApprove: () -> Unit,
+    onCancel: () -> Unit
+) = AlertDialog(
+    title = { Text(text = "Alert!") },
+    text = { Text("Do you really want do leave that screen?") },
+    onDismissRequest = onCancel,
+    buttons = {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            Button(
+                onClick = { onCancel() }
+            ) {
+                Text(text = "Cancel")
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(
+                onClick = { onApprove() }
+            ) {
+                Text(text = "Ok")
+            }
+        }
+    }
+)


### PR DESCRIPTION
### Implemented DismissDispatcher: Intercepting BottomSheet Dismissal

I've implemented DismissDispatcher to provide more control over user-initiated dismissal of BottomSheets. This functionality mirrors the behavior of BackHandler for handling back button presses.

### What can you intercept?

- Back press: Dismissal triggered by pressing the back button.
- BottomSheet interactions:
   - Clicking on the scrim (background dimming area) outside the sheet content.
   - Swiping down on the sheet itself.

### How to use DismissDispatcher:

1. Call DismissHandler in your sheet's content.
2. Override the callback function. The usage is similar to BackHandler.

Code Example:

```Kotlin
@Composable
private fun BottomSheet(
  navigateUp: () -> Unit,
) {
  var showConfirmationDialog by remember {
    mutableStateOf(false)
  }

  if (showConfirmationDialog) {
    ConfirmationDialog(
      onCancel = { showConfirmationDialog = false },
      onApprove = { navigateUp() }
    )
  }

  DismissHandler {
    showConfirmationDialog = true
  }

  BottomSheetContent()
}
```

### Important Note:

This approach does not intercept dismissal initiated by the NavController. This allows you to easily close the BottomSheet programmatically using the NavController if needed.

### Attachments

https://github.com/google/accompanist/assets/38030130/2f7bd0d6-39e7-44d7-8778-b77da91c2613


