### PR TITLE
[DrawablePainter] Fix drawable scaling (#1766)

### DIFF
--- a/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
+++ b/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
@@ -130,6 +130,10 @@ public class DrawablePainter(
             // Update the Drawable's bounds
             drawable.setBounds(0, 0, size.width.roundToInt(), size.height.roundToInt())
 
+            val scaleX = size.width / drawableIntrinsicSize.width
+            val scaleY = size.height / drawableIntrinsicSize.height
+            canvas.scale(scaleX, scaleY)
+
             canvas.withSave {
                 drawable.draw(canvas.nativeCanvas)
             }


### PR DESCRIPTION
Properly scales the canvas to match the composables size or uses the drawable size if none is set.