### PR TITLE
Fix issue bundling kotlin metadataJvm in permissions lint

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -35,6 +35,10 @@ kotlin {
 }
 
 dependencies {
+    // used by BundleInsideHelper.kt
+    implementation(libs.apacheAnt)
+    implementation(libs.shadow)
+
     compileOnly(libs.android.gradlePlugin)
     compileOnly(libs.android.tools.common)
     compileOnly(libs.compose.gradlePlugin)

--- a/build-logic/convention/src/main/kotlin/com/google/accompanist/BundleInsideHelper.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/accompanist/BundleInsideHelper.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist
+
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Usage
+import org.gradle.api.file.FileTreeElement
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+
+/** Allow java and Android libraries to bundle other projects inside the project jar/aar. */
+object BundleInsideHelper {
+    val CONFIGURATION_NAME = "bundleInside"
+    val REPACKAGE_TASK_NAME = "repackageBundledJars"
+
+    /**
+     * Creates a configuration for the users to use that will be used to bundle these dependency
+     * jars inside of libs/ directory inside of the aar.
+     *
+     * ```
+     * dependencies {
+     *   bundleInside(project(":foo"))
+     * }
+     * ```
+     *
+     * Used project are expected
+     *
+     * @param relocations a list of package relocations to apply
+     * @param dropResourcesWithSuffix used to drop Java resources if they match this suffix, null
+     *   means no filtering
+     * @receiver the project that should bundle jars specified by this configuration
+     * @see forInsideAar(String, String)
+     */
+    @JvmStatic
+    fun Project.forInsideAar(relocations: List<Relocation>?, dropResourcesWithSuffix: String?) {
+        val bundle = createBundleConfiguration()
+        val repackage = configureRepackageTaskForType(relocations, bundle, dropResourcesWithSuffix)
+        // Add to AGP's configuration so this jar get packaged inside of the aar.
+        dependencies.add("implementation", files(repackage.flatMap { it.archiveFile }))
+    }
+
+    /**
+     * Creates 3 configurations for the users to use that will be used bundle these dependency jars
+     * inside of libs/ directory inside of the aar.
+     *
+     * ```
+     * dependencies {
+     *   bundleInside(project(":foo"))
+     * }
+     * ```
+     *
+     * Used project are expected
+     *
+     * @param from specifies from which package the rename should happen
+     * @param to specifies to which package to put the renamed classes
+     * @param dropResourcesWithSuffix used to drop Java resources if they match this suffix, null
+     *   means no filtering
+     * @receiver the project that should bundle jars specified by these configurations
+     */
+    @JvmStatic
+    fun Project.forInsideAar(from: String, to: String, dropResourcesWithSuffix: String?) {
+        forInsideAar(listOf(Relocation(from, to)), dropResourcesWithSuffix)
+    }
+
+    /**
+     * Creates a configuration for users to use that will bundle the dependency jars inside of this
+     * lint check's jar. This is required because lintPublish does not currently support
+     * dependencies, so instead we need to bundle any dependencies with the lint jar manually.
+     * (b/182319899)
+     *
+     * ```
+     * dependencies {
+     *     if (rootProject.hasProperty("android.injected.invoked.from.ide")) {
+     *         compileOnly(LINT_API_LATEST)
+     *     } else {
+     *         compileOnly(LINT_API_MIN)
+     *     }
+     *     compileOnly(KOTLIN_STDLIB)
+     *     // Include this library inside the resulting lint jar
+     *     bundleInside(project(":foo-lint-utils"))
+     * }
+     * ```
+     *
+     * @receiver the project that should bundle jars specified by these configurations
+     */
+    @JvmStatic
+    fun Project.forInsideLintJar(): Configuration {
+        val bundle = createBundleConfiguration()
+        val compileOnly = configurations.getByName("compileOnly")
+        val testImplementation = configurations.getByName("testImplementation")
+
+        compileOnly.extendsFrom(bundle)
+        testImplementation.extendsFrom(bundle)
+
+        // Relocation needed to avoid classpath conflicts with Android Studio (b/337980250)
+        // Can be removed if we migrate from using kotlin-metadata-jvm inside of lint checks
+        val relocations = listOf(Relocation("kotlin.metadata", "androidx.lint.kotlin.metadata"))
+        val repackage = configureRepackageTaskForType(relocations, bundle, null)
+        val sourceSets = extensions.getByType(SourceSetContainer::class.java)
+        repackage.configure {
+            this.from(sourceSets.findByName("main")?.output)
+            // kotlin-metadata-jvm has a service descriptor that needs transformation
+            this.mergeServiceFiles()
+            // Exclude Kotlin metadata files from kotlin-metadata-jvm
+            this.exclude(
+                "META-INF/kotlin-metadata-jvm.kotlin_module",
+                "META-INF/kotlin-metadata.kotlin_module",
+                "META-INF/metadata.jvm.kotlin_module",
+                "META-INF/metadata.kotlin_module"
+            )
+        }
+
+        listOf("apiElements", "runtimeElements").forEach { config ->
+            configurations.getByName(config).apply {
+                outgoing.artifacts.clear()
+                outgoing.artifact(repackage)
+            }
+        }
+
+        return bundle
+    }
+
+    data class Relocation(val from: String, val to: String)
+
+    private fun Project.configureRepackageTaskForType(
+        relocations: List<Relocation>?,
+        configuration: Configuration,
+        dropResourcesWithSuffix: String?
+    ): TaskProvider<ShadowJar> {
+        val action = Action<ShadowJar> {
+            configurations = listOf(configuration)
+            if (relocations != null) {
+                for (relocation in relocations) {
+                    println("Relocating ${relocation.from} to ${relocation.to}")
+                    relocate(relocation.from, relocation.to)
+                }
+            }
+            val dontIncludeResourceTransformer = DontIncludeResourceTransformer()
+            dontIncludeResourceTransformer.dropResourcesWithSuffix = dropResourcesWithSuffix
+            transformers.add(dontIncludeResourceTransformer)
+            archiveBaseName.set("repackaged")
+            archiveVersion.set("")
+            destinationDirectory.set(layout.buildDirectory.dir("repackaged"))
+        }
+        return tasks.register(REPACKAGE_TASK_NAME, ShadowJar::class.java, action)
+    }
+
+    private fun Project.createBundleConfiguration(): Configuration {
+        val bundle =
+            configurations.create(CONFIGURATION_NAME) {
+                attributes {
+                    attribute(Usage.USAGE_ATTRIBUTE, objects.named<Usage>(Usage.JAVA_RUNTIME))
+                }
+                isCanBeConsumed = false
+            }
+        return bundle
+    }
+
+    class DontIncludeResourceTransformer : Transformer {
+        @Optional @Input var dropResourcesWithSuffix: String? = null
+
+        override fun getName(): String {
+            return "DontIncludeResourceTransformer"
+        }
+
+        override fun canTransformResource(element: FileTreeElement?): Boolean {
+            val path = element?.relativePath?.pathString
+            return dropResourcesWithSuffix != null &&
+                (path?.endsWith(dropResourcesWithSuffix!!) == true)
+        }
+
+        override fun transform(context: TransformerContext?) {
+            // no op
+        }
+
+        override fun hasTransformedResource(): Boolean {
+            return true
+        }
+
+        override fun modifyOutputStream(zipOutputStream: ZipOutputStream?, b: Boolean) {
+            // no op
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/google/accompanist/BundleInsideHelper.kt
+++ b/build-logic/convention/src/main/kotlin/com/google/accompanist/BundleInsideHelper.kt
@@ -32,6 +32,11 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 
+/**
+ * Originally from https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:buildSrc/public/src/main/kotlin/androidx/build/BundleInsideHelper.kt
+ * Small modifications based on gradle version
+ */
+
 /** Allow java and Android libraries to bundle other projects inside the project jar/aar. */
 object BundleInsideHelper {
     val CONFIGURATION_NAME = "bundleInside"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,10 +41,12 @@ compose-material3-material3 = { module = "androidx.compose.material3:material3",
 compose-animation-animation = { module = "androidx.compose.animation:animation", version.ref = "compose" }
 compose-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 
+apacheAnt = { module = "org.apache.ant:ant", version = "1.10.11" }
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "gradlePlugin" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 gradleMavenPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "vanniktechPublish" }
 metalavaGradle = { module = "me.tylerbwong.gradle.metalava:plugin", version.ref = "metalava" }
+shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version = "8.3.3" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
-kotlin-metadataJvm = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.3.0"
+kotlin-metadataJvm = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 

--- a/permissions-lint/build.gradle.kts
+++ b/permissions-lint/build.gradle.kts
@@ -23,10 +23,6 @@ plugins {
     id(libs.plugins.android.lint.get().pluginId)
 }
 
-kotlin {
-    explicitApi()
-}
-
 lint {
     htmlReport = true
     htmlOutput = file("lint-report.html")

--- a/permissions-lint/build.gradle.kts
+++ b/permissions-lint/build.gradle.kts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.google.accompanist.BundleInsideHelper
+import com.google.accompanist.BundleInsideHelper.forInsideLintJar
 
 plugins {
     `java-library`
@@ -43,27 +45,7 @@ affectedTestConfiguration {
  * not currently support dependencies, so instead we need to bundle any dependencies with the
  * lint jar manually. (b/182319899)
  */
-val bundleInside: Configuration = configurations.create("bundleInside")
-// bundleInside dependencies should be included as compileOnly and testImplementation as well
-configurations.getByName("compileOnly").setExtendsFrom(setOf(bundleInside))
-configurations.getByName("testImplementation").setExtendsFrom(setOf(bundleInside))
-
-tasks.getByName<Jar>("jar") {
-    this.dependsOn(bundleInside)
-    this.from({
-       bundleInside
-               // The stdlib is already bundled with lint, so no need to include it manually
-               // in the lint.jar if any dependencies here depend on it
-               .filter { !it.name.contains("kotlin-stdlib") }
-               .map { file ->
-                   if (file.isDirectory) {
-                       file
-                   } else {
-                       zipTree(file)
-                   }
-               }
-   })
-}
+val bundleInside = forInsideLintJar()
 
 dependencies {
     // Bundle metadataJvm inside the Jar

--- a/permissions-lint/src/main/java/com/google/accompanist/permissions/lint/util/ComposableUtils.kt
+++ b/permissions-lint/src/main/java/com/google/accompanist/permissions/lint/util/ComposableUtils.kt
@@ -18,12 +18,14 @@
 
 package com.google.accompanist.permissions.lint.util
 
+// FILE COPIED FROM:
+// https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/lint/common/src/main/java/androidx/compose/lint/ComposableUtils.kt
+
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.impl.compiled.ClsParameterImpl
 import com.intellij.psi.impl.light.LightParameter
-import kotlinx.metadata.jvm.annotations
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtProperty
@@ -34,6 +36,7 @@ import org.jetbrains.uast.UAnonymousClass
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UDeclaration
 import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.ULambdaExpression
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UParameter
@@ -44,141 +47,167 @@ import org.jetbrains.uast.getContainingUClass
 import org.jetbrains.uast.getParameterForArgument
 import org.jetbrains.uast.toUElement
 import org.jetbrains.uast.withContainingElements
-
-// FILE COPIED FROM:
-// https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/lint/common/src/main/java/androidx/compose/lint/ComposableUtils.kt
+import kotlin.metadata.jvm.annotations
 
 /**
- * Returns whether this [UCallExpression] is invoked within the body of a Composable function or
- * lambda.
- *
- * This searches parent declarations until we find a lambda expression or a function, and looks
- * to see if these are Composable.
+ * Returns whether this [UCallExpression] is directly invoked within the body of a Composable
+ * function or lambda without being `remember`ed.
  */
-public fun UCallExpression.isInvokedWithinComposable(): Boolean {
+public fun UCallExpression.isNotRemembered(): Boolean = isNotRememberedWithKeys()
+
+/**
+ * Returns whether this [UCallExpression] is directly invoked within the body of a Composable
+ * function or lambda without being `remember`ed, or whether it is invoked inside a `remember call
+ * without the provided [keys][keyClassNames].
+ * - Returns true if this [UCallExpression] is directly invoked inside a Composable function or
+ *   lambda without being `remember`ed
+ * - Returns true if this [UCallExpression] is invoked inside a call to `remember`, but without all
+ *   of the provided [keys][keyClassNames] being used as key parameters to `remember`
+ * - Returns false if this [UCallExpression] is correctly `remember`ed with the provided
+ *   [keys][keyClassNames], or is not called inside a `remember` block, and is not called inside a
+ *   Composable function or lambda
+ *
+ * @param keyClassNames [Name]s representing the expected classes that should be used as a key
+ *   parameter to the `remember` call
+ */
+public fun UCallExpression.isNotRememberedWithKeys(vararg keyClassNames: Name): Boolean {
+    val visitor = ComposableBodyVisitor(this)
+    // The nearest method or lambda expression that contains this call expression
+    val boundaryElement = visitor.parentUElements().last()
+    // Check if the nearest lambda expression is actually a call to remember
+    val rememberCall: UCallExpression? =
+        (boundaryElement.uastParent as? UCallExpression)?.takeIf {
+            it.methodName == Names.Runtime.Remember.shortName &&
+                it.resolve()?.isInPackageName(Names.Runtime.PackageName) == true
+        }
+    return if (rememberCall == null) {
+        visitor.isComposable()
+    } else {
+        val parameterTypes =
+            rememberCall.valueArguments.mapNotNull { it.getExpressionType()?.canonicalText }
+        !keyClassNames.all { parameterTypes.contains(it.javaFqn) }
+    }
+}
+
+/**
+ * Returns whether this [UExpression] is invoked within the body of a Composable function or lambda.
+ *
+ * This searches parent declarations until we find a lambda expression or a function, and looks to
+ * see if these are Composable.
+ */
+fun UExpression.isInvokedWithinComposable(): Boolean {
     return ComposableBodyVisitor(this).isComposable()
 }
 
 // TODO: https://youtrack.jetbrains.com/issue/KT-45406
 // KotlinUMethodWithFakeLightDelegate.hasAnnotation() (for reified functions for example)
 // doesn't find annotations, so just look at the annotations directly.
-/**
- * Returns whether this method is @Composable or not
- */
-public val PsiMethod.isComposable: Boolean
-    get() = annotations.any { it.qualifiedName == Composable.javaFqn }
+/** Returns whether this method is @Composable or not */
+val PsiMethod.isComposable
+    get() = annotations.any { it.qualifiedName == Names.Runtime.Composable.javaFqn }
 
-/**
- * Returns whether this variable's type is @Composable or not
- */
-public val UVariable.isComposable: Boolean
+/** Returns whether this variable's type is @Composable or not */
+val UVariable.isComposable: Boolean
     get() {
         // Annotation on the lambda
-        val annotationOnLambda = when (val initializer = uastInitializer) {
-            is ULambdaExpression -> {
-                val source = initializer.sourcePsi
-                if (source is KtFunction) {
-                    // Anonymous function, val foo = @Composable fun() {}
-                    source.hasComposableAnnotation
-                } else {
-                    // Lambda, val foo = @Composable {}
-                    initializer.findAnnotation(Composable.javaFqn) != null
+        val annotationOnLambda =
+            when (val initializer = uastInitializer) {
+                is ULambdaExpression -> {
+                    val source = initializer.sourcePsi
+                    if (source is KtFunction) {
+                        // Anonymous function, val foo = @Composable fun() {}
+                        source.hasComposableAnnotation
+                    } else {
+                        // Lambda, val foo = @Composable {}
+                        initializer.findAnnotation(Names.Runtime.Composable.javaFqn) != null
+                    }
                 }
+                else -> false
             }
-            else -> false
-        }
         // Annotation on the type, foo: @Composable () -> Unit = { }
         val annotationOnType = typeReference?.isComposable == true
         return annotationOnLambda || annotationOnType
     }
 
-/**
- * Returns whether this parameter's type is @Composable or not
- */
+/** Returns whether this parameter's type is @Composable or not */
 private val PsiParameter.isComposable: Boolean
-    get() = when {
-        // The parameter is in a class file. Currently type annotations aren't currently added to
-        // the underlying type (https://youtrack.jetbrains.com/issue/KT-45307), so instead we use
-        // the metadata annotation.
-        this is ClsParameterImpl ||
-            // In some cases when a method is defined in bytecode and the call fails to resolve
-            // to the ClsMethodImpl, we will instead get a LightParameter. Note that some Kotlin
-            // declarations too will also appear as a LightParameter, so we can check to see if
-            // the source language is Java, which means that this is a LightParameter for
-            // bytecode, as opposed to for a Kotlin declaration.
-            // https://youtrack.jetbrains.com/issue/KT-46883
-            (this is LightParameter && this.language is JavaLanguage) -> {
-            // Find the containing method, so we can get metadata from the containing class
-            val containingMethod = getParentOfType<PsiMethod>(true)
-            val kmFunction = containingMethod!!.toKmFunction()
+    get() =
+        when {
+            // The parameter is in a class file. Currently type annotations aren't currently added
+            // to
+            // the underlying type (https://youtrack.jetbrains.com/issue/KT-45307), so instead we
+            // use
+            // the metadata annotation.
+            this is ClsParameterImpl ||
+                // In some cases when a method is defined in bytecode and the call fails to resolve
+                // to the ClsMethodImpl, we will instead get a LightParameter. Note that some Kotlin
+                // declarations too will also appear as a LightParameter, so we can check to see if
+                // the source language is Java, which means that this is a LightParameter for
+                // bytecode, as opposed to for a Kotlin declaration.
+                // https://youtrack.jetbrains.com/issue/KT-46883
+                (this is LightParameter && this.language is JavaLanguage) -> {
+                // Find the containing method, so we can get metadata from the containing class
+                val containingMethod = getParentOfType<PsiMethod>(true)
+                val kmFunction = containingMethod!!.toKmFunction()
 
-            val kmValueParameter = kmFunction?.valueParameters?.find {
-                it.name == name
+                val kmValueParameter = kmFunction?.valueParameters?.find { it.name == name }
+
+                kmValueParameter?.type?.annotations?.find {
+                    it.className == Names.Runtime.Composable.kmClassName
+                } != null
             }
+            // The parameter is in a source declaration
+            else -> (toUElement() as? UParameter)?.typeReference?.isComposable == true
+        }
 
-            kmValueParameter?.type?.annotations?.find {
-                it.className == Composable.kmClassName
-            } != null
+/** Returns whether this lambda expression is @Composable or not */
+val ULambdaExpression.isComposable: Boolean
+    get() =
+        when (val lambdaParent = uastParent) {
+            // Function call with a lambda parameter
+            is UCallExpression -> {
+                val parameter = lambdaParent.getParameterForArgument(this)
+                parameter?.isComposable == true
+            }
+            // A local / non-local lambda variable
+            is UVariable -> {
+                lambdaParent.isComposable
+            }
+            // Either a new UAST type we haven't handled, or non-Kotlin declarations
+            else -> false
         }
-        // The parameter is in a source declaration
-        else -> (toUElement() as UParameter).typeReference!!.isComposable
-    }
-
-/**
- * Returns whether this lambda expression is @Composable or not
- */
-public val ULambdaExpression.isComposable: Boolean
-    get() = when (val lambdaParent = uastParent) {
-        // Function call with a lambda parameter
-        is UCallExpression -> {
-            val parameter = lambdaParent.getParameterForArgument(this)
-            parameter?.isComposable == true
-        }
-        // A local / non-local lambda variable
-        is UVariable -> {
-            lambdaParent.isComposable
-        }
-        // Either a new UAST type we haven't handled, or non-Kotlin declarations
-        else -> false
-    }
 
 /**
- * Helper class that visits parent declarations above the provided [callExpression], until it
- * finds a lambda or method. This 'boundary' is used as the indicator for whether this
- * [callExpression] can be considered to be inside a Composable body or not.
+ * Helper class that visits parent declarations above the provided [expression], until it finds a
+ * lambda or method. This 'boundary' is used as the indicator for whether this [expression] can be
+ * considered to be inside a Composable body or not.
  *
  * @see isComposable
  * @see parentUElements
  */
-private class ComposableBodyVisitor(
-    private val callExpression: UCallExpression
-) {
-    /**
-     * @return whether the body can be considered Composable or not
-     */
-    fun isComposable(): Boolean = when (val element = parentUElements.last()) {
-        is UMethod -> element.isComposable
-        is ULambdaExpression -> element.isComposable
-        else -> false
-    }
+private class ComposableBodyVisitor(private val expression: UExpression) {
+    /** @return whether the body can be considered Composable or not */
+    fun isComposable(): Boolean =
+        when (val element = parentUElements.last()) {
+            is UMethod -> element.isComposable
+            is ULambdaExpression -> element.isComposable
+            else -> false
+        }
 
-    /**
-     * Returns all parent [UElement]s until and including the boundary lambda / method.
-     */
+    /** Returns all parent [UElement]s until and including the boundary lambda / method. */
     fun parentUElements() = parentUElements
 
     /**
      * The outermost UElement that corresponds to the surrounding UDeclaration that contains
-     * [callExpression], with the following special cases:
-     *
-     * - if the containing UDeclaration is a local property, we ignore it and search above as
-     * it still could be created in the context of a Composable body
-     * - if the containing UDeclaration is an anonymous class (object { }), we ignore it and
-     * search above as it still could be created in the context of a Composable body
+     * [expression], with the following special cases:
+     * - if the containing UDeclaration is a local property, we ignore it and search above as it
+     *   still could be created in the context of a Composable body
+     * - if the containing UDeclaration is an anonymous class (object { }), we ignore it and search
+     *   above as it still could be created in the context of a Composable body
      */
     private val boundaryUElement by lazy {
         // The nearest property / function / etc declaration that contains this call expression
-        var containingDeclaration = callExpression.getContainingDeclaration()
+        var containingDeclaration = expression.getContainingDeclaration()
 
         fun UDeclaration.isLocalProperty() = (sourcePsi as? KtProperty)?.isLocal == true
         fun UDeclaration.isAnonymousClass() = this is UAnonymousClass
@@ -203,7 +232,7 @@ private class ComposableBodyVisitor(
         val elements = mutableListOf<UElement>()
 
         // Look through containing elements until we find a lambda or a method
-        for (element in callExpression.withContainingElements) {
+        for (element in expression.withContainingElements) {
             elements += element
             when (element) {
                 // TODO: consider handling the case of a lambda inside an inline function call,
@@ -222,12 +251,10 @@ private class ComposableBodyVisitor(
     }
 }
 
-/**
- * Returns whether this type reference is @Composable or not
- */
-private val UTypeReferenceExpression.isComposable: Boolean
+/** Returns whether this type reference is @Composable or not */
+val UTypeReferenceExpression.isComposable: Boolean
     get() {
-        if (type.hasAnnotation(Composable.javaFqn)) return true
+        if (type.hasAnnotation(Names.Runtime.Composable.javaFqn)) return true
 
         // Annotations on the types of local properties (val foo: @Composable () -> Unit = {})
         // are currently not present on the PsiType, we so need to manually check the underlying
@@ -235,74 +262,9 @@ private val UTypeReferenceExpression.isComposable: Boolean
         return (sourcePsi as? KtTypeReference)?.hasComposableAnnotation == true
     }
 
-/**
- * Returns whether this annotated declaration has a Composable annotation
- */
+/** Returns whether this annotated declaration has a Composable annotation */
 private val KtAnnotated.hasComposableAnnotation: Boolean
-    get() = annotationEntries.any {
-        (it.toUElement() as UAnnotation).qualifiedName == Composable.javaFqn
-    }
-
-private val RuntimePackageName = Package("androidx.compose.runtime")
-private val Composable = Name(RuntimePackageName, "Composable")
-
-/**
- * @return a [PackageName] with a Java-style (separated with `.`) [packageName].
- */
-internal fun Package(packageName: String): PackageName =
-    PackageName(packageName.split("."))
-
-/**
- * @return a [Name] with the provided [pkg] and Java-style (separated with `.`) [shortName].
- */
-internal fun Name(pkg: PackageName, shortName: String): Name =
-    Name(pkg, shortName.split("."))
-
-/**
- * Represents a qualified package
- *
- * @property segments the segments representing the package
- */
-internal class PackageName internal constructor(internal val segments: List<String>) {
-    /**
-     * The Java-style package name for this [Name], separated with `.`
-     */
-    val javaPackageName: String
-        get() = segments.joinToString(".")
-}
-
-/**
- * Represents the qualified name for an element
- *
- * @property pkg the package for this element
- * @property nameSegments the segments representing the element - there can be multiple in the
- * case of nested classes.
- */
-internal class Name internal constructor(
-    private val pkg: PackageName,
-    private val nameSegments: List<String>
-) {
-    /**
-     * The short name for this [Name]
-     */
-    val shortName: String
-        get() = nameSegments.last()
-
-    /**
-     * The Java-style fully qualified name for this [Name], separated with `.`
-     */
-    val javaFqn: String
-        get() = pkg.segments.joinToString(".", postfix = ".") +
-            nameSegments.joinToString(".")
-
-    /**
-     * The [ClassName] for use with kotlinx.metadata. Note that in kotlinx.metadata the actual
-     * type might be different from the underlying JVM type, for example:
-     * kotlin/Int -> java/lang/Integer
-     */
-    val kmClassName: ClassName
-        get() = pkg.segments.joinToString("/", postfix = "/") +
-            nameSegments.joinToString(".")
-}
-
-private typealias ClassName = String
+    get() =
+        annotationEntries.any {
+            (it.toUElement() as UAnnotation).qualifiedName == Names.Runtime.Composable.javaFqn
+        }

--- a/permissions-lint/src/main/java/com/google/accompanist/permissions/lint/util/Names.kt
+++ b/permissions-lint/src/main/java/com/google/accompanist/permissions/lint/util/Names.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.permissions.lint.util
+
+/**
+ * File copied from
+ * https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/lint/common/src/main/java/androidx/compose/lint/Names.kt
+ */
+
+import kotlin.metadata.ClassName
+
+/** Contains common names used for lint checks. */
+object Names {
+    object Animation {
+        val PackageName = Package("androidx.compose.animation")
+
+        object Core {
+            val PackageName = Package("androidx.compose.animation.core")
+            val Animatable = Name(PackageName, "Animatable")
+        }
+    }
+
+    object AnimationCore {
+        val PackageName = Package("androidx.compose.animation.core")
+    }
+
+    object Runtime {
+        val PackageName = Package("androidx.compose.runtime")
+
+        val Composable = Name(PackageName, "Composable")
+        val CompositionLocal = Name(PackageName, "CompositionLocal")
+        val DerivedStateOf = Name(PackageName, "derivedStateOf")
+        val State = Name(PackageName, "State")
+        val MutableState = Name(PackageName, "MutableState")
+        val MutableStateOf = Name(PackageName, "mutableStateOf")
+        val MutableIntStateOf = Name(PackageName, "mutableIntStateOf")
+        val MutableLongStateOf = Name(PackageName, "mutableLongStateOf")
+        val MutableFloatStateOf = Name(PackageName, "mutableFloatStateOf")
+        val MutableDoubleStateOf = Name(PackageName, "mutableDoubleStateOf")
+        val MutableStateListOf = Name(PackageName, "mutableStateListOf")
+        val MutableStateMapOf = Name(PackageName, "mutableStateMapOf")
+        val ProduceState = Name(PackageName, "produceState")
+        val Remember = Name(PackageName, "remember")
+        val DisposableEffect = Name(PackageName, "DisposableEffect")
+        val RememberSaveable = Name(PackageName, "rememberSaveable")
+        val LaunchedEffect = Name(PackageName, "LaunchedEffect")
+        val ReusableContent = Name(PackageName, "ReusableContent")
+        val Key = Name(PackageName, "key")
+        val StructuralEqualityPolicy = Name(PackageName, "structuralEqualityPolicy")
+    }
+
+    object Ui {
+        val PackageName = Package("androidx.compose.ui")
+        val Composed = Name(PackageName, "composed")
+        val Modifier = Name(PackageName, "Modifier")
+
+        object Layout {
+            val PackageName = Package("androidx.compose.ui.layout")
+            val ParentDataModifier = Name(PackageName, "ParentDataModifier")
+        }
+
+        object Pointer {
+            val PackageName = Package(Ui.PackageName, "input.pointer")
+            val PointerInputScope = Name(PackageName, "PointerInputScope")
+            val PointerInputScopeModifier = Name(PackageName, "pointerInput")
+            val AwaitPointerEventScope = Name(PackageName, "awaitPointerEventScope")
+        }
+
+        object Unit {
+            val PackageName = Package("androidx.compose.ui.unit")
+            val Dp = Name(PackageName, "Dp")
+        }
+
+        object Node {
+            val PackageName = Package(Ui.PackageName, "node")
+            val CurrentValueOf = Name(PackageName, "currentValueOf")
+        }
+    }
+
+    object UiGraphics {
+        val PackageName = Package("androidx.compose.ui.graphics")
+        val Color = Name(PackageName, "Color")
+    }
+}
+
+/**
+ * Represents a qualified package
+ *
+ * @property segments the segments representing the package
+ */
+class PackageName internal constructor(internal val segments: List<String>) {
+    /** The Java-style package name for this [Name], separated with `.` */
+    val javaPackageName: String
+        get() = segments.joinToString(".")
+}
+
+/**
+ * Represents the qualified name for an element
+ *
+ * @property pkg the package for this element
+ * @property nameSegments the segments representing the element - there can be multiple in the case
+ *   of nested classes.
+ */
+class Name
+internal constructor(private val pkg: PackageName, private val nameSegments: List<String>) {
+    /** The short name for this [Name] */
+    val shortName: String
+        get() = nameSegments.last()
+
+    /** The Java-style fully qualified name for this [Name], separated with `.` */
+    val javaFqn: String
+        get() = pkg.segments.joinToString(".", postfix = ".") + nameSegments.joinToString(".")
+
+    /**
+     * The [ClassName] for use with kotlin.metadata. Note that in kotlin.metadata the actual type
+     * might be different from the underlying JVM type, for example: kotlin/Int -> java/lang/Integer
+     */
+    val kmClassName: ClassName
+        get() = pkg.segments.joinToString("/", postfix = "/") + nameSegments.joinToString(".")
+
+    /** The [PackageName] of this element. */
+    val packageName: PackageName
+        get() = pkg
+}
+
+/** @return a [PackageName] with a Java-style (separated with `.`) [packageName]. */
+fun Package(packageName: String): PackageName = PackageName(packageName.split("."))
+
+/** @return a [PackageName] with a Java-style (separated with `.`) [packageName]. */
+fun Package(packageName: PackageName, shortName: String): PackageName =
+    PackageName(packageName.segments + shortName.split("."))
+
+/** @return a [Name] with the provided [pkg] and Java-style (separated with `.`) [shortName]. */
+fun Name(pkg: PackageName, shortName: String): Name = Name(pkg, shortName.split("."))

--- a/permissions-lint/src/main/java/com/google/accompanist/permissions/lint/util/PsiUtils.kt
+++ b/permissions-lint/src/main/java/com/google/accompanist/permissions/lint/util/PsiUtils.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.accompanist.permissions.lint.util
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassOwner
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiType
+import com.intellij.psi.util.InheritanceUtil
+
+/**
+ * File copied from
+ * https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/lint/common/src/main/java/androidx/compose/lint/PsiUtils.kt
+ */
+
+/** Returns whether [this] has [packageName] as its package name. */
+fun PsiMethod.isInPackageName(packageName: PackageName): Boolean {
+    val actual = (containingFile as? PsiClassOwner)?.packageName
+    return packageName.javaPackageName == actual
+}
+
+/** Whether this [PsiMethod] returns Unit */
+val PsiMethod.returnsUnit
+    get() = returnType.isVoidOrUnit
+
+/**
+ * Whether this [PsiType] is `void` or [Unit]
+ *
+ * In Kotlin 1.6 some expressions now explicitly return [Unit] instead of just being [PsiType.VOID],
+ * so this returns whether this type is either.
+ */
+val PsiType?.isVoidOrUnit
+    get() = this == PsiType.VOID || this?.canonicalText == "kotlin.Unit"
+
+/** @return whether [this] inherits from [name]. Returns `true` if [this] _is_ directly [name]. */
+fun PsiType.inheritsFrom(name: Name) = InheritanceUtil.isInheritor(this, name.javaFqn)
+
+/** @return whether [this] inherits from [name]. Returns `true` if [this] _is_ directly [name]. */
+fun PsiClass.inheritsFrom(name: Name) = InheritanceUtil.isInheritor(this, name.javaFqn)


### PR DESCRIPTION
b/379173583

Updated lint set up to match AndroidX

Tested by unzipping `permissionsRelease.aar`, then unzipping the bundled lint.jar and manually verifying that `kotlin/metadata` has been moved to `androidx/lint/kotlin/metadata`