### PR TITLE
[Drawable Painter] Fix AnimatedImageDrawable rendered in wrong size for systems below Android 12

### DIFF
--- a/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
+++ b/drawablepainter/src/main/java/com/google/accompanist/drawablepainter/DrawablePainter.kt
@@ -17,6 +17,7 @@
 package com.google.accompanist.drawablepainter
 
 import android.graphics.drawable.Animatable
+import android.graphics.drawable.AnimatedImageDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
@@ -127,10 +128,22 @@ public class DrawablePainter(
             // Reading this ensures that we invalidate when invalidateDrawable() is called
             drawInvalidateTick
 
-            // Update the Drawable's bounds
-            drawable.setBounds(0, 0, size.width.roundToInt(), size.height.roundToInt())
-
             canvas.withSave {
+                // AnimatedImageDrawable is not respecting the bounds below Android 12, so this is
+                // a workaround to make the render size correct in this specific case
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
+                    Build.VERSION.SDK_INT < Build.VERSION_CODES.S &&
+                    drawable is AnimatedImageDrawable
+                ) {
+                    canvas.scale(
+                        size.width / intrinsicSize.width,
+                        size.height / intrinsicSize.height
+                    )
+                } else {
+                    // Update the Drawable's bounds
+                    drawable.setBounds(0, 0, size.width.roundToInt(), size.height.roundToInt())
+                }
+
                 drawable.draw(canvas.nativeCanvas)
             }
         }


### PR DESCRIPTION
AnimatedImageDrawable doesn't respect bounds set to it when the Android version is below 12.

On Android version below 12, if we use the current way to render (setBounds), the size doesn't change with the container at all. It's always following intrinsic size which is wrong.

I've created a sample project for you to test it out.
[issue-demo-animated-image-drawable.zip](https://github.com/user-attachments/files/19833717/issue-demo-animated-image-drawable.zip)

Also, you can see from following videos to understand the issue.

Tested on Android 10
<video src="https://github.com/user-attachments/assets/6ece7847-34be-4b04-9d2d-10be02a77fec" />

Tested on Android 12
<video src="https://github.com/user-attachments/assets/b7757265-08ba-49ec-89ec-d75087e6f89e" />


Following is the commit in AOSP to add setBounds to AnimatedImageDrawable.
https://cs.android.com/android/_/android/platform/frameworks/base/+/be969efdb0234b7b39636ec0a586dbb708ec480d

This first appeared in android-12.0.0_r1, and this is the proof.
<img width="994" alt="image" src="https://github.com/user-attachments/assets/b7617358-e306-4ec8-95df-d27077be9387" />
