### PR TITLE
Chore: Enable TYPESAFE_PROJECT_ACCESSORS from gradle

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>

--- a/adaptive/build.gradle.kts
+++ b/adaptive/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
     // Test dependencies
     // ======================
 
-    androidTestImplementation(project(":internal-testutils"))
-    testImplementation(project(":internal-testutils"))
+    androidTestImplementation(projects.internalTestutils)
+    testImplementation(projects.internalTestutils)
 
     androidTestImplementation(libs.junit)
     testImplementation(libs.junit)

--- a/permissions/build.gradle.kts
+++ b/permissions/build.gradle.kts
@@ -41,8 +41,8 @@ dependencies {
     implementation(libs.compose.foundation.foundation)
     implementation(libs.kotlin.coroutines.android)
 
-    lintChecks(project(":permissions-lint"))
-    lintPublish(project(":permissions-lint"))
+    lintChecks(projects.permissionsLint)
+    lintPublish(projects.permissionsLint)
 
     // ======================
     // Test dependencies
@@ -50,7 +50,7 @@ dependencies {
 
     androidTestUtil(libs.androidx.test.orchestrator)
 
-    androidTestImplementation(project(":internal-testutils"))
+    androidTestImplementation(projects.internalTestutils)
     androidTestImplementation(libs.androidx.activity.compose)
     androidTestImplementation(libs.compose.material.material)
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -62,9 +62,9 @@ android {
 dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
-    implementation(project(":adaptive"))
-    implementation(project(":drawablepainter"))
-    implementation(project(":permissions"))
+    implementation(projects.adaptive)
+    implementation(projects.drawablepainter)
+    implementation(projects.permissions)
 
     implementation(libs.compose.material.iconsext)
     implementation(libs.compose.material3.material3)
@@ -79,5 +79,5 @@ dependencies {
 
     implementation(libs.kotlin.stdlib)
 
-    lintChecks(project(":permissions-lint"))
+    lintChecks(projects.permissionsLint)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,3 +46,5 @@ check(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     https://developer.android.com/build/jdks#jdk-config-in-studio
     """.trimIndent()
 }
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Type-safe project accessors in Gradle are a feature that helps you manage dependencies between modules in a multi-module project in a more robust and developer-friendly way.

Here's a breakdown of what they are and why they're useful:

The Problem with String-Based Project Dependencies

Traditionally, when declaring a dependency on another module within the same Gradle build, you would use a string path like this:

```groovy 
dependencies {
    implementation project(":core")
    implementation project(":features:feature_login")
}
```

While this works, it has a few drawbacks:•

**No Compile-Time Safety**: If you misspell the module path (e.g., :coree instead of :core), you won't get an error until Gradle tries to configure the project during a build. This can lead to wasted time.

**Refactoring Challenges**: If you rename or move a module, you need to manually find and update all the string-based paths in your build.gradle files. This is error-prone, especially in large projects.

**Limited IDE Support**: IDEs have a harder time understanding these string-based relationships, which can limit features like code completion or "find usages" for module dependencies.

**Enter Type-Safe Project Accessors**

Type-safe project accessors address these issues by generating code that represents your project modules. Instead of strings, you use generated accessor methods.

**How They Work**

When you enable type-safe project accessors, Gradle generates accessors for each of your subprojects. These accessors are then available in your build scripts.

For example, instead of project(":core"), you might write:

```groovy
dependencies {
    implementation projects.core
    implementation projects.features.featureLogin // Or similar, depending on naming convention
}
```

Benefits of Type-Safe Project Accessors

- Compile-Time Safety: If you try to reference a module that doesn't exist or misspell its name, you'll get a compilation error in your build script before you even run a build. This catches errors much earlier.
- Improved Refactoring: If you rename or move a module, your IDE can help you refactor the generated accessors, just like any other code. This makes refactoring module structures much safer and easier.
- Better IDE Integration: IDEs can understand these generated accessors better, leading to improved code completion, navigation, and other smart features when working with module dependencies.
- Increased Readability (Potentially): For deeply nested modules, the accessor chain (e.g., projects.features.authentication.api) can be more readable than a long string path.


https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors