### PR TITLE
Add Qlty code coverage reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,17 @@ jobs:
               --run-affected \
               --affected-base-ref=$BASE_REF
 
+      - name: Generate JaCoCo Reports
+        if: always()
+        run: ./gradlew jacocoTestReport --continue --no-configuration-cache --stacktrace
+
+      - name: Upload coverage to Qlty
+        if: always()
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: "**/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -21,6 +21,9 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.kotlin
+import org.gradle.kotlin.dsl.register
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -28,6 +31,11 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.library")
                 apply("org.jetbrains.kotlin.android")
+                apply("jacoco")
+            }
+
+            extensions.configure<JacocoPluginExtension> {
+                toolVersion = "0.8.11"
             }
 
             extensions.configure<LibraryExtension> {
@@ -41,6 +49,25 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 // The resource prefix is derived from the module name,
                 // so resources inside ":core:module1" must be prefixed with "core_module1_"
                 resourcePrefix = path.split("""\W""".toRegex()).drop(1).distinct().joinToString(separator = "_").lowercase() + "_"
+            }
+
+            tasks.register<JacocoReport>("jacocoTestReport") {
+                reports {
+                    xml.required.set(true)
+                    html.required.set(false)
+                }
+                sourceDirectories.setFrom(
+                    files("${projectDir}/src/main/java", "${projectDir}/src/main/kotlin")
+                )
+                classDirectories.setFrom(
+                    fileTree("${buildDir}/tmp/kotlin-classes/debug")
+                )
+                executionData.setFrom(
+                    fileTree(buildDir).include("jacoco/testDebugUnitTest.exec")
+                )
+                onlyIf {
+                    executionData.files.any { it.exists() }
+                }
             }
 
             dependencies {


### PR DESCRIPTION
## Summary
- Added JaCoCo coverage plugin to the Android library convention plugin, enabling coverage data generation for all library modules during unit tests
- Added CI steps to generate JaCoCo XML reports and upload them to Qlty Cloud after unit tests
- Uses coverage token authentication (public repo)

## Manual steps required
- Add `QLTY_COVERAGE_TOKEN` secret to the repository settings (Settings > Secrets and variables > Actions). Get the token from Qlty Cloud workspace settings (Settings > Code Coverage).

## Test plan
- [ ] Verify the CI build workflow passes
- [ ] Verify JaCoCo reports are generated for library modules
- [ ] Verify Qlty coverage upload step shows successful publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)